### PR TITLE
Revert "Add flow-rules to support ICMP type/code in L24Classifier"

### DIFF
--- a/agent-ovs/lib/include/opflexagent/test/ModbFixture.h
+++ b/agent-ovs/lib/include/opflexagent/test/ModbFixture.h
@@ -99,7 +99,6 @@ public:
     std::shared_ptr<modelgbp::gbpe::L24Classifier> classifier7;
     std::shared_ptr<modelgbp::gbpe::L24Classifier> classifier8;
     std::shared_ptr<modelgbp::gbpe::L24Classifier> classifier9;
-    std::shared_ptr<modelgbp::gbpe::L24Classifier> classifier10;
 
     std::shared_ptr<modelgbp::gbp::AllowDenyAction> action1;
 
@@ -338,10 +337,6 @@ protected:
             .setEtherT(l2::EtherTypeEnumT::CONST_IPV4).setProt(6 /* TCP */)
             .setSFromPort(66).setSToPort(69)
             .setDFromPort(94).setDToPort(95);
-        classifier10 = space->addGbpeL24Classifier("classifier10");
-        classifier10->setOrder(30)
-            .setEtherT(l2::EtherTypeEnumT::CONST_IPV4).setProt(1 /* ICMP */)
-            .setIcmpType(10).setIcmpCode(5);
         con3 = space->addGbpContract("contract3");
         con3->addGbpSubject("3_subject1")->addGbpRule("3_1_rule1")
             ->setOrder(1)
@@ -356,11 +351,6 @@ protected:
             .setDirection(DirectionEnumT::CONST_IN)
             .addGbpRuleToClassifierRSrc(classifier4->getURI().toString())
             ->setTargetL24Classifier(classifier4->getURI());
-        con3->addGbpSubject("3_subject1")->addGbpRule("3_1_rule3")
-            ->setOrder(3)
-            .setDirection(DirectionEnumT::CONST_IN)
-            .addGbpRuleToClassifierRSrc(classifier10->getURI().toString())
-            ->setTargetL24Classifier(classifier10->getURI());
         epg0->addGbpEpGroupToProvContractRSrc(con3->getURI().toString());
         epg1->addGbpEpGroupToConsContractRSrc(con3->getURI().toString());
 

--- a/agent-ovs/ovs/FlowUtils.cpp
+++ b/agent-ovs/ovs/FlowUtils.cpp
@@ -130,18 +130,8 @@ void add_classifier_entries(L24Classifier& clsfr, ClassAction act,
     ovs_be64 ckbe = ovs_htonll(cookie);
     MaskList srcPorts;
     MaskList dstPorts;
-    if (clsfr.getProt(0) == 1 &&
-        (clsfr.isIcmpTypeSet() || clsfr.isIcmpCodeSet())) {
-        if (clsfr.isIcmpTypeSet()) {
-            srcPorts.push_back(Mask(clsfr.getIcmpType(0), ~0));
-        }
-        if (clsfr.isIcmpCodeSet()) {
-            dstPorts.push_back(Mask(clsfr.getIcmpCode(0), ~0));
-        }
-    } else {
-        RangeMask::getMasks(clsfr.getSFromPort(), clsfr.getSToPort(), srcPorts);
-        RangeMask::getMasks(clsfr.getDFromPort(), clsfr.getDToPort(), dstPorts);
-    }
+    RangeMask::getMasks(clsfr.getSFromPort(), clsfr.getSToPort(), srcPorts);
+    RangeMask::getMasks(clsfr.getDFromPort(), clsfr.getDToPort(), dstPorts);
 
     /* Add a "ignore" mask to empty ranges - makes the loop later easy */
     if (srcPorts.empty()) {

--- a/agent-ovs/ovs/test/IntFlowManager_test.cpp
+++ b/agent-ovs/ovs/test/IntFlowManager_test.cpp
@@ -815,7 +815,7 @@ BOOST_FIXTURE_TEST_CASE(policy_portrange, VxlanIntFlowManagerFixture) {
     WAIT_FOR_DO(egs.size() == 1, 500, egs.clear();
                 policyMgr.getContractConsumers(con3->getURI(), egs));
     PolicyManager::rule_list_t rules;
-    WAIT_FOR_DO(rules.size() == 3, 500, rules.clear();
+    WAIT_FOR_DO(rules.size() == 2, 500, rules.clear();
                 policyMgr.getContractRules(con3->getURI(), rules));
 
     /* add con3 */
@@ -2188,9 +2188,6 @@ void BaseIntFlowManagerFixture::initExpCon3() {
     const opflex::modb::URI& ruleURI_4 = classifier4.get()->getURI();
     uint32_t con4_cookie = intFlowManager.getId(
                          classifier4->getClassId(), ruleURI_4);
-    const opflex::modb::URI& ruleURI_10 = classifier10.get()->getURI();
-    uint32_t con10_cookie = intFlowManager.getId(
-        classifier10->getClassId(), ruleURI_10);
     MaskList ml_80_85 = list_of<Mask>(0x0050, 0xfffc)(0x0054, 0xfffe);
     MaskList ml_66_69 = list_of<Mask>(0x0042, 0xfffe)(0x0044, 0xfffe);
     MaskList ml_94_95 = list_of<Mask>(0x005e, 0xfffe);
@@ -2209,9 +2206,6 @@ void BaseIntFlowManagerFixture::initExpCon3() {
                  .actions().go(OUT).done());
         }
     }
-    ADDF(Bldr(SEND_FLOW_REM).table(POL).priority(prio-256)
-        .cookie(con10_cookie).icmp().reg(SEPG, epg1_vnid).reg(DEPG, epg0_vnid)
-        .icmp_type(10).icmp_code(5).actions().go(OUT).done());
 }
 
 // Initialize flows related to IP address mapping/NAT


### PR DESCRIPTION
This reverts commit 38bc9a134322cd0c5ce1c63338b17ed91442caaa.
This patch was reverted in order to support AIM, which currently
doesn't explicitly configure the ICMP type/code values as
"unspecified". If not specified, their default values of 0 are
used, which renders the classifiers into flow-mods that cause
the ICMP packets to be (erroneously) dropped.