### PR TITLE
Fix infinite loop in getVlanRangesByIface

### DIFF
--- a/agent-ovs/lib/LearningBridgeManager.cpp
+++ b/agent-ovs/lib/LearningBridgeManager.cpp
@@ -343,6 +343,7 @@ getVlanRangesByIface(const std::string& uuid,
     auto it = lbi_map.find(uuid);
     if (it == lbi_map.end()) return;
 
+    LOG(DEBUG) << "getVlanRangesByIface for " << uuid;
     for (auto r : it->second.iface->getTrunkVlans()) {
         auto it = range_lbi_map.find(r);
 
@@ -351,6 +352,7 @@ getVlanRangesByIface(const std::string& uuid,
                 break;
 
             ranges.insert(it->first);
+            it++;
         }
     }
 }


### PR DESCRIPTION
This code gets triggered on handlePortStatusUpdate and would result in the
opflex agent getting stuck in an infinite loop because the iterator is
not being incremented in the while loop.

---------------------------------------------------------------------------
Simple way to repro the issue is to add or del the patch ports on br-fabric
example:
ovs-vsctl del-port br-fabric qpi2b4b79dd-6e
ovs-vsctl add-port br-fabric qpi2b4b79dd-6e -- set interface qpi2b4b79dd-6e type=patch options:peer=qpf2b4b79dd-6e
Or
ovs-vsctl del-port br-fabric patch-fabric-ex
ovs-vsctl add-port br-fabric patch-fabric-ex -- set interface patch-fabric-ex type=patch options:peer=patch-ex-fabric
---------------------------------------------------------------------------
Verified we come out of the loop with the fix.

Change-Id: Ia330e40942083e9d289e256b951cc803a35e4864
Signed-off-by: Madhu Challa <challa@gmail.com>
(cherry picked from commit f03095eb35259694b779d9b8298316920bb41d4c)