### PR TITLE
Rule priority incorrect for opflex trunk ports.

### DIFF
--- a/agent-ovs/ovs/AccessFlowManager.cpp
+++ b/agent-ovs/ovs/AccessFlowManager.cpp
@@ -136,7 +136,12 @@ static void flowBypassDhcpRequest(FlowEntryList& el, bool v4, uint32_t inport,
                                   uint32_t outport,
                                   std::shared_ptr<const Endpoint>& ep ) {
     FlowBuilder fb;
-    fb.priority(200).inPort(inport);
+    if (ep->getAccessIfaceVlan()) {
+        fb.priority(201).inPort(inport);
+    } else {
+        fb.priority(200).inPort(inport);
+    }
+
     flowutils::match_dhcp_req(fb, v4);
     fb.action().reg(MFF_REG7, outport);
 

--- a/agent-ovs/ovs/test/AccessFlowManager_test.cpp
+++ b/agent-ovs/ovs/test/AccessFlowManager_test.cpp
@@ -338,7 +338,7 @@ void AccessFlowManagerFixture::initExpDhcpEp(shared_ptr<Endpoint>& ep) {
     initExpEp(ep);
     if (ep->getDHCPv4Config()) {
         ADDF(Bldr()
-             .table(GRP).priority(200).udp().in(access)
+             .table(GRP).priority(ep->getAccessIfaceVlan() ? 201 : 200).udp().in(access)
              .isVlan(ep->getAccessIfaceVlan().get())
              .isTpSrc(68).isTpDst(67)
              .actions()
@@ -348,7 +348,7 @@ void AccessFlowManagerFixture::initExpDhcpEp(shared_ptr<Endpoint>& ep) {
     }
     if (ep->getDHCPv6Config()) {
         ADDF(Bldr()
-             .table(GRP).priority(200).udp6().in(access)
+             .table(GRP).priority(ep->getAccessIfaceVlan() ? 201 : 200).udp6().in(access)
              .isVlan(ep->getAccessIfaceVlan().get())
              .isTpSrc(546).isTpDst(547)
              .actions()


### PR DESCRIPTION
We currently create 2 dhcp rules with same priority 200 for untagged and
tagged traffic on the same port. The result is that we end up hitting
the first rule even for the vlan traffic preventing the sub-interface
from acquiring the dhcp ip address.

Without the fix the rules look like this.
 cookie=0x0, duration=3.957s, table=0, n_packets=0, n_bytes=0, priority=200,udp,in_port=1,tp_src=68,tp_dst=67 actions=load:0x6->NXM_NX_REG7[],goto_table:3
 cookie=0x0, duration=4.299s, table=0, n_packets=0, n_bytes=0, priority=200,udp,in_port=1,dl_vlan=4094,tp_src=68,tp_dst=67 actions=load:0x6->NXM_NX_REG7[],write_metadata:0x1/0xff,goto_table:3

With the fix the second rule would look like this.
 cookie=0x0, duration=4.299s, table=0, n_packets=0, n_bytes=0, priority=201,udp,in_port=1,dl_vlan=4094,tp_src=68,tp_dst=67 actions=load:0x6->NXM_NX_REG7[],write_metadata:0x1/0xff,goto_table:3

Verified the fix creating flows using the attribute access-interface-vlan": 4094 in the ep file and made sure with the attribute the rule is created with priority 201 and without it with priority 200.

Updated unit test files.

Change-Id: I90f27d6940b58b075a36156e6a60497a0688cb6f
Signed-off-by: Madhu Challa <challa@gmail.com>
(cherry picked from commit bca92d44b0a0d24d07d30d373eb218a539b5b6c6)