### PR TITLE
Agent replying to arp with dhcp ip on native vlan.

### DIFF
--- a/agent-ovs/ovs/IntFlowManager.cpp
+++ b/agent-ovs/ovs/IntFlowManager.cpp
@@ -602,7 +602,8 @@ static void flowsProxyDiscovery(FlowEntryList& el,
                                 const uint8_t* matchSourceMac,
                                 uint32_t tunPort,
                                 IntFlowManager::EncapType encapType,
-                                bool directDelivery = false) {
+                                bool directDelivery = false,
+                                uint32_t dropInPort = OFPP_NONE) {
     if (ipAddr.is_v4()) {
         if (tunPort != OFPP_NONE &&
             encapType != IntFlowManager::ENCAP_NONE) {
@@ -617,11 +618,22 @@ static void flowsProxyDiscovery(FlowEntryList& el,
         }
         {
             FlowBuilder proxyArp;
+            // Match on inPort to ignore this arp (prio + 1)
+            if (dropInPort != OFPP_NONE)
+                proxyArp.priority(priority+1).inPort(dropInPort);
+            else
+                proxyArp.priority(priority);
+
             if (matchSourceMac)
                 proxyArp.ethSrc(matchSourceMac);
-            matchDestArp(proxyArp.priority(priority), ipAddr, bdId, rdId);
-            actionArpReply(proxyArp, macAddr, ipAddr)
-                .build(el);
+            matchDestArp(proxyArp, ipAddr, bdId, rdId);
+
+            // Drop the arp request on this inPort
+            if (dropInPort != OFPP_NONE)
+                proxyArp.build(el);
+            else
+                actionArpReply(proxyArp, macAddr, ipAddr)
+                    .build(el);
         }
     } else {
         // pass MAC address in flow metadata
@@ -929,6 +941,13 @@ static void flowsEndpointDHCPSource(IntFlowManager& flowMgr,
                            sizeof(serverMac));
                 }
 
+                // Ignore arp requests on uplink interface.
+                flowsProxyDiscovery(elBridgeDst, 51,
+                                    serverIp, serverMac,
+                                    epgVnid, rdId, bdId, false,
+                                    NULL, OFPP_NONE,
+                                    IntFlowManager::ENCAP_NONE,
+                                    false, flowMgr.getTunnelPort());
                 flowsProxyDiscovery(elBridgeDst, 51,
                                     serverIp, serverMac,
                                     epgVnid, rdId, bdId, false,

--- a/agent-ovs/ovs/test/IntFlowManager_test.cpp
+++ b/agent-ovs/ovs/test/IntFlowManager_test.cpp
@@ -2895,6 +2895,7 @@ void BaseIntFlowManagerFixture::initExpVirtualDhcp(bool virtIp,
                                                    bool serverOverride) {
     string mmac("01:00:00:00:00:00/01:00:00:00:00:00");
     string bmac("ff:ff:ff:ff:ff:ff");
+    uint32_t tunPort = intFlowManager.getTunnelPort();
 
     uint32_t port = portmapper.FindPort(ep0->getInterfaceName().get());
     ADDF(Bldr().cookie(ovs_ntohll(flow::cookie::DHCP_V4))
@@ -2910,6 +2911,13 @@ void BaseIntFlowManagerFixture::initExpVirtualDhcp(bool virtIp,
         hexServerIp = "0x1020304";
         serverMac = "0xffbbffddeeff";
     }
+    ADDF(Bldr().table(BR).priority(52).arp()
+         .reg(BD, 1)
+         .reg(RD, 1)
+         .in(tunPort)
+         .isEthDst(bmac).isTpa(serverIp)
+         .isArpOp(1)
+         .actions().drop().done());
     ADDF(Bldr().table(BR).priority(51).arp()
          .reg(BD, 1)
          .reg(RD, 1)


### PR DESCRIPTION
This happen due to the following rule.

 cookie=0x0, duration=6892.708s, table=3, n_packets=0, n_bytes=0, priority=51,arp,reg4=0x1,reg6=0x1,dl_dst=ff:ff:ff:ff:ff:ff,arp_tpa=192.168.0.2,arp_op=1 actions=move:NXM_OF_ETH_SRC[]->NXM_OF_ETH_DST[],load:0xfa163e5239f4->NXM_OF_ETH_SRC[],load:0x2->NXM_OF_ARP_OP[],move:NXM_NX_ARP_SHA[]->NXM_NX_ARP_THA[],load:0xfa163e5239f4->NXM_NX_ARP_SHA[],move:NXM_OF_ARP_SPA[]->NXM_OF_ARP_TPA[],load:0xc0a80002->NXM_OF_ARP_SPA[],IN_PORT

The goal is to not respond to similar arp request on the fabric uplink.

We solve this by adding a higher priority rule that looks like this, note the match on in_port=<tunnel_port> and action=drop.
 cookie=0x0, duration=6892.708s, table=3, n_packets=0, n_bytes=0, priority=52,arp,reg4=0x1,reg6=0x1,in_port=3,dl_dst=ff:ff:ff:ff:ff:ff,arp_tpa=192.168.0.2,arp_op=1 actions=drop

Change-Id: I79857106ba5b45d35618554629e2d07bf09fe6a9
Signed-off-by: Madhu Challa <challa@gmail.com>
(cherry picked from commit f796286a09f029a7bbd13218c59fbb1dfa92a043)