### PR TITLE
Optimizing travis build time for opflex

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,11 @@ env:
   - TEST_SUITE=tsan-build.sh
   - TEST_SUITE=asan-build.sh
 
-script: bash ./.travis/$TEST_SUITE
+#script: bash ./.travis/$TEST_SUITE
 
-after_success:
-  - bash ./.travis/coveralls-deploy.sh
+#after_success:
+#  - bash ./.travis/coveralls-deploy.sh
+
+
+script: echo $TEST_SUITE
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,11 +36,8 @@ env:
   - TEST_SUITE=tsan-build.sh
   - TEST_SUITE=asan-build.sh
 
-#script: bash ./.travis/$TEST_SUITE
+script: bash ./.travis/$TEST_SUITE
 
-#after_success:
-#  - bash ./.travis/coveralls-deploy.sh
-
-
-script: echo $TEST_SUITE
+after_success:
+  - bash ./.travis/coveralls-deploy.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,13 @@ compiler:
   - gcc
 os: linux
 dist: bionic
+
+#default cache timeout is 3 minutes, if need be we can increase timeout
+cache:
+  directories:
+    - ../ovs
+    - ../prometheus-cpp
+
 addons:
   apt:
     packages:
@@ -19,6 +26,8 @@ addons:
 
 before_install:
   - pip install --user cpp-coveralls
+
+install: bash ./.travis/install-dependencies.sh
 
 before_script: sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6';
 

--- a/.travis/asan-build.sh
+++ b/.travis/asan-build.sh
@@ -22,33 +22,6 @@ sudo make install &> /dev/null
 popd
 popd
 
-git clone https://github.com/openvswitch/ovs.git --branch v2.12.0 --depth 1
-pushd ovs
-./boot.sh &> /dev/null
-./configure  --enable-shared &> /dev/null
-make -j2 &> /dev/null
-sudo make install &> /dev/null
-sudo mkdir -p /usr/local/include/openvswitch/openvswitch
-sudo mv /usr/local/include/openvswitch/*.h /usr/local/include/openvswitch/openvswitch
-sudo mv /usr/local/include/openflow /usr/local/include/openvswitch
-sudo cp -t "/usr/local/include/openvswitch/" include/*.h
-sudo find lib -name "*.h" -exec cp --parents -t "/usr/local/include/openvswitch/" {} \;
-popd
-
-git clone https://github.com/noironetworks/3rdparty-debian.git
-cp 3rdparty-debian/prometheus/prometheus-cpp.patch ~
-git clone https://github.com/jupp0r/prometheus-cpp.git
-pushd prometheus-cpp
-git checkout 9effb90b0c266316358680cbf862a8564eb2c2d4
-git submodule init
-git submodule update
-git apply ~/prometheus-cpp.patch
-mkdir _build && cd _build
-cmake .. -DBUILD_SHARED_LIBS=ON &> /dev/null
-make $make_args
-sudo make install
-popd
-
 pushd agent-ovs
 ./autogen.sh &> /dev/null
 ./configure --enable-prometheus --enable-asan

--- a/.travis/install-dependencies.sh
+++ b/.travis/install-dependencies.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -o errtrace
+set -x
+
+mkdir -p ../ovs
+pushd ../ovs
+git clone https://github.com/openvswitch/ovs.git --branch v2.12.0 --depth 1
+pushd ovs
+./boot.sh &> /dev/null
+./configure  --enable-shared &> /dev/null
+make -j2 &> /dev/null
+sudo make install &> /dev/null
+sudo mkdir -p /usr/local/include/openvswitch/openvswitch
+sudo mv /usr/local/include/openvswitch/*.h /usr/local/include/openvswitch/openvswitch
+sudo mv /usr/local/include/openflow /usr/local/include/openvswitch
+sudo cp -t "/usr/local/include/openvswitch/" include/*.h
+sudo find lib -name "*.h" -exec cp --parents -t "/usr/local/include/openvswitch/" {} \;
+popd
+popd
+
+mkdir -p ../prometheus-cpp
+pushd ../prometheus-cpp
+git clone https://github.com/noironetworks/3rdparty-debian.git
+cp 3rdparty-debian/prometheus/prometheus-cpp.patch ~
+git clone https://github.com/jupp0r/prometheus-cpp.git
+pushd prometheus-cpp
+git checkout 9effb90b0c266316358680cbf862a8564eb2c2d4
+git submodule init
+git submodule update
+git apply ~/prometheus-cpp.patch
+mkdir _build && cd _build
+cmake .. -DBUILD_SHARED_LIBS=ON &> /dev/null
+make $make_args
+sudo make install
+popd
+popd

--- a/.travis/install-dependencies.sh
+++ b/.travis/install-dependencies.sh
@@ -5,11 +5,17 @@ set -x
 
 mkdir -p ../ovs
 pushd ../ovs
-git clone https://github.com/openvswitch/ovs.git --branch v2.12.0 --depth 1
+if ! [ "$(ls -A .)" ]; then
+    git clone https://github.com/openvswitch/ovs.git --branch v2.12.0 --depth 1
+    pushd ovs
+    ./boot.sh &> /dev/null
+    ./configure  --enable-shared &> /dev/null
+    make -j2 &> /dev/null
+    popd
+else
+    echo "using cached ovs"
+fi
 pushd ovs
-./boot.sh &> /dev/null
-./configure  --enable-shared &> /dev/null
-make -j2 &> /dev/null
 sudo make install &> /dev/null
 sudo mkdir -p /usr/local/include/openvswitch/openvswitch
 sudo mv /usr/local/include/openvswitch/*.h /usr/local/include/openvswitch/openvswitch
@@ -21,17 +27,23 @@ popd
 
 mkdir -p ../prometheus-cpp
 pushd ../prometheus-cpp
-git clone https://github.com/noironetworks/3rdparty-debian.git
-cp 3rdparty-debian/prometheus/prometheus-cpp.patch ~
-git clone https://github.com/jupp0r/prometheus-cpp.git
+if ! [ "$(ls -A .)" ]; then
+    git clone https://github.com/noironetworks/3rdparty-debian.git
+    cp 3rdparty-debian/prometheus/prometheus-cpp.patch ~
+    git clone https://github.com/jupp0r/prometheus-cpp.git
+    pushd prometheus-cpp
+    git checkout 9effb90b0c266316358680cbf862a8564eb2c2d4
+    git submodule init
+    git submodule update
+    git apply ~/prometheus-cpp.patch
+    mkdir _build && cd _build
+    cmake .. -DBUILD_SHARED_LIBS=ON &> /dev/null
+    make $make_args
+    popd
+else
+    echo "using cached prometheus-cpp"
+fi
 pushd prometheus-cpp
-git checkout 9effb90b0c266316358680cbf862a8564eb2c2d4
-git submodule init
-git submodule update
-git apply ~/prometheus-cpp.patch
-mkdir _build && cd _build
-cmake .. -DBUILD_SHARED_LIBS=ON &> /dev/null
-make $make_args
 sudo make install
 popd
 popd

--- a/.travis/install-dependencies.sh
+++ b/.travis/install-dependencies.sh
@@ -43,7 +43,7 @@ if ! [ "$(ls -A .)" ]; then
 else
     echo "using cached prometheus-cpp"
 fi
-pushd prometheus-cpp
-sudo make install
+pushd prometheus-cpp/_build
+sudo make install &> /dev/null
 popd
 popd

--- a/.travis/travis-build.sh
+++ b/.travis/travis-build.sh
@@ -22,33 +22,6 @@ sudo make install &> /dev/null
 popd
 popd
 
-git clone https://github.com/openvswitch/ovs.git --branch v2.12.0 --depth 1
-pushd ovs
-./boot.sh &> /dev/null
-./configure  --enable-shared &> /dev/null
-make -j2 &> /dev/null
-sudo make install &> /dev/null
-sudo mkdir -p /usr/local/include/openvswitch/openvswitch
-sudo mv /usr/local/include/openvswitch/*.h /usr/local/include/openvswitch/openvswitch
-sudo mv /usr/local/include/openflow /usr/local/include/openvswitch
-sudo cp -t "/usr/local/include/openvswitch/" include/*.h
-sudo find lib -name "*.h" -exec cp --parents -t "/usr/local/include/openvswitch/" {} \;
-popd
-
-git clone https://github.com/noironetworks/3rdparty-debian.git
-cp 3rdparty-debian/prometheus/prometheus-cpp.patch ~
-git clone https://github.com/jupp0r/prometheus-cpp.git
-pushd prometheus-cpp
-git checkout 9effb90b0c266316358680cbf862a8564eb2c2d4
-git submodule init
-git submodule update
-git apply ~/prometheus-cpp.patch
-mkdir _build && cd _build
-cmake .. -DBUILD_SHARED_LIBS=ON &> /dev/null
-make $make_args
-sudo make install
-popd
-
 pushd agent-ovs
 ./autogen.sh &> /dev/null
 ./configure --enable-coverage --enable-prometheus

--- a/.travis/tsan-build.sh
+++ b/.travis/tsan-build.sh
@@ -22,33 +22,6 @@ sudo make install &> /dev/null
 popd
 popd
 
-git clone https://github.com/openvswitch/ovs.git --branch v2.12.0 --depth 1
-pushd ovs
-./boot.sh &> /dev/null
-./configure  --enable-shared &> /dev/null
-make -j2 &> /dev/null
-sudo make install &> /dev/null
-sudo mkdir -p /usr/local/include/openvswitch/openvswitch
-sudo mv /usr/local/include/openvswitch/*.h /usr/local/include/openvswitch/openvswitch
-sudo mv /usr/local/include/openflow /usr/local/include/openvswitch
-sudo cp -t "/usr/local/include/openvswitch/" include/*.h
-sudo find lib -name "*.h" -exec cp --parents -t "/usr/local/include/openvswitch/" {} \;
-popd
-
-git clone https://github.com/noironetworks/3rdparty-debian.git
-cp 3rdparty-debian/prometheus/prometheus-cpp.patch ~
-git clone https://github.com/jupp0r/prometheus-cpp.git
-pushd prometheus-cpp
-git checkout 9effb90b0c266316358680cbf862a8564eb2c2d4
-git submodule init
-git submodule update
-git apply ~/prometheus-cpp.patch
-mkdir _build && cd _build
-cmake .. -DBUILD_SHARED_LIBS=ON &> /dev/null
-make $make_args
-sudo make install
-popd
-
 pushd agent-ovs
 ./autogen.sh &> /dev/null
 ./configure --enable-prometheus --enable-tsan


### PR DESCRIPTION
Prometheus and ovs are put in travis cache. Speed up of 5 mins.

https://travis-ci.org/github/noironetworks/opflex/builds/687654456

I see that the cache is used. We should now time the total build time.