### PR TITLE
Restore OVS connection behavior from before OVS 2.12 upgrade

### DIFF
--- a/agent-ovs/ovs/SwitchConnection.cpp
+++ b/agent-ovs/ovs/SwitchConnection.cpp
@@ -138,7 +138,7 @@ SwitchConnection::doConnectOF() {
     vconn *newConn;
     int error;
     error = vconn_open_block(swPath.c_str(), versionBitmap, DSCP_DEFAULT,
-            0, &newConn);
+            -1, &newConn);
     if (error) {
         return error;
     }


### PR DESCRIPTION
Original behavior before timeout param was added to
vconn_open_block was to retry OF connection indefinitely

Setting the timeout behavior to 0 meant no retries at all.
Changing the setting to -1 restores the original behavior

Signed-off-by: Tom Flynn <tom.flynn@gmail.com>