### PR TITLE
More LGTM fixes

### DIFF
--- a/agent-ovs/ovs/IntFlowManager.cpp
+++ b/agent-ovs/ovs/IntFlowManager.cpp
@@ -85,9 +85,9 @@ namespace pt = boost::property_tree;
 using namespace modelgbp::gbp;
 using namespace modelgbp::gbpe;
 
-std::random_device rng;
-std::mt19937 urng(rng());
-basic_random_generator<std::mt19937> uuidGen(urng);
+std::random_device randomDevice;
+std::mt19937 randomSeed(randomDevice());
+basic_random_generator<std::mt19937> uuidGen(randomSeed);
 
 namespace opflexagent {
 

--- a/agent-ovs/ovs/TableState.cpp
+++ b/agent-ovs/ovs/TableState.cpp
@@ -243,6 +243,12 @@ TableState::~TableState() {
     delete pimpl;
 }
 
+const TableState& TableState::operator=(const TableState& ts) {
+    delete pimpl;
+    pimpl = new TableStateImpl(*ts.pimpl);
+    return ts;
+}
+
 void TableState::diffSnapshot(const FlowEntryList& oldEntries,
                               FlowEdit& diffs) const {
     typedef std::pair<bool, FlowEntryPtr> visited_fe_t;

--- a/agent-ovs/ovs/include/TableState.h
+++ b/agent-ovs/ovs/include/TableState.h
@@ -286,6 +286,13 @@ public:
     ~TableState();
 
     /**
+     * Assignment operator
+     * @param ts the object to copy from
+     * @return return argument for chaining
+     */
+    const TableState& operator=(const TableState& ts);
+
+    /**
      * Update cached entry-list corresponding to given object-id
      */
     void apply(const std::string& objId,

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,5 +1,39 @@
 path_classifiers:
   docs: "docs"
+queries:
+  - include: cpp/offset-use-before-range-check
+  - include: cpp/incomplete-parity-check
+  - include: cpp/mistyped-function-arguments
+  - include: cpp/leap-year/adding-365-days-per-year
+  - include: cpp/user-controlled-bypass
+  - include: cpp/cleartext-storage-database
+  - include: cpp/cleartext-storage-buffer
+  - include: cpp/cleartext-storage-file
+  - include: cpp/inconsistent-call-on-result
+  - include: cpp/incorrect-not-operator-usage
+  - include: cpp/stack-address-escape
+  - include: cpp/lossy-function-result-cast
+  - include: cpp/missing-case-in-switch
+  - include: cpp/nested-loops-with-same-variable
+  - include: cpp/suspicious-allocation-size
+  - include: cpp/allocation-too-small
+  - include: cpp/bad-strncpy-size
+  - include: cpp/uninitialized-local
+  - include: cpp/unsafe-strncat
+  - include: cpp/unsafe-strcat
+  - include: cpp/static-buffer-overflow
+  - include: cpp/suspicious-sizeof
+  - include: cpp/suspicious-pointer-scaling
+  - include: cpp/suspicious-pointer-scaling-void
+  - include: cpp/toctou-race-condition
+  - include: cpp/uncontrolled-arithmetic
+  - include: cpp/path-injection
+  - include: cpp/tainted-format-string
+  - include: cpp/tainted-format-string-through-global
+  - include: cpp/uncontrolled-process-operation
+  - include: cpp/unterminated-variadic-call
+  - include: cpp/tainted-permissions-check
+  - include: cpp/integer-used-for-enum
 extraction:
   cpp:
     prepare:

--- a/libopflex/comms/transport/ZeroCopyOpenSSL.cpp
+++ b/libopflex/comms/transport/ZeroCopyOpenSSL.cpp
@@ -544,21 +544,13 @@ ZeroCopyOpenSSL::ZeroCopyOpenSSL(ZeroCopyOpenSSL::Ctx * ctx, bool passive)
         ready_(false)
     {
 
-                           bioInternal_                       &&
-    BIO_set_write_buf_size(bioInternal_, 24576)               &&
-
-                           bioExternal_                       &&
-    BIO_set_write_buf_size(bioExternal_, 24576)               &&
-
-    BIO_make_bio_pair     (bioInternal_, bioExternal_)        &&
-
-                           bioSSL_                            &&
-
-    (ssl_               = SSL_new(ctx->getSslCtx()))          &&
-
-    BIO_set_ssl           (bioSSL_, ssl_, BIO_CLOSE)          &&
-
-    (ready_             = true);
+    if(bioInternal_ && BIO_set_write_buf_size(bioInternal_, 24576) &&
+       bioExternal_ && BIO_set_write_buf_size(bioExternal_, 24576) &&
+       BIO_make_bio_pair(bioInternal_, bioExternal_) && bioSSL_ &&
+       (ssl_ = SSL_new(ctx->getSslCtx())) &&
+       BIO_set_ssl(bioSSL_, ssl_, BIO_CLOSE)) {
+        ready_ = true;
+    }
 
     if (!ready_) {
         LOG(ERROR) << "Fatal failure: " << ZeroCopyOpenSSL::dumpOpenSslErrorStackAsString();


### PR DESCRIPTION
Enable more checks.
Virtual method issues reported are fine because they happen in destructors and the behavior is intended.
Assignment operator requirements are about readability.

Signed-off-by: Kiran Shastri <shastrinator@gmail.com>