### PR TITLE
Adding prometheus UT for EpCounter and cleanup

### DIFF
--- a/agent-ovs/cmd/test/policy_repo_stress.cpp
+++ b/agent-ovs/cmd/test/policy_repo_stress.cpp
@@ -96,7 +96,7 @@ public:
         std::unordered_set<std::string> eps;
         epMgr.getEndpointsByIface("interface-name", eps);
         for (auto& uuid : eps) {
-            opflexagent::EndpointManager::EpCounters counters;
+            opflexagent::EpCounters counters;
             memset(&counters, 0, sizeof(counters));
             uint64_t c = ++intCounter;
             counters.txPackets = c;

--- a/agent-ovs/lib/EndpointManager.cpp
+++ b/agent-ovs/lib/EndpointManager.cpp
@@ -1439,7 +1439,8 @@ void EndpointManager::updateEndpointCounters(const std::string& uuid,
         if (ep_name)
             prometheusManager.addNUpdateEpCounter(uuid, ep_name.get(),
                                                   es.endpoint->getAttributeHash(),
-                                                  es.endpoint->getAttributes());
+                                                  es.endpoint->getAttributes(),
+                                                  newVals);
         else
             LOG(ERROR) << "ep name not found for uuid:" << uuid;
     }

--- a/agent-ovs/lib/SimStats.cpp
+++ b/agent-ovs/lib/SimStats.cpp
@@ -31,7 +31,7 @@ void SimStats::updateInterfaceCounters() {
     std::unordered_set<std::string> eps;
     epMgr.getEndpointUUIDs(eps);
     for (auto& uuid : eps) {
-        opflexagent::EndpointManager::EpCounters counters{};
+        opflexagent::EpCounters counters{};
         uint64_t c = ++intCounter;
         counters.txPackets = c;
         counters.rxPackets = c;

--- a/agent-ovs/lib/include/opflexagent/EndpointManager.h
+++ b/agent-ovs/lib/include/opflexagent/EndpointManager.h
@@ -43,6 +43,71 @@ typedef std::unordered_map<std::string,
                         std::shared_ptr<const Endpoint>> ip_ep_map_t;
 
 /**
+ * Counter values for endpoint stats
+ */
+struct EpCounters {
+    /**
+     * Number of packets sent
+     */
+    uint64_t txPackets;
+
+    /**
+     * Number of packets received
+     */
+    uint64_t rxPackets;
+
+    /**
+     * the number of dropped packets sent
+     */
+    uint64_t txDrop;
+
+    /**
+     * the number of dropped packets received
+     */
+    uint64_t rxDrop;
+
+    /**
+     * the number of multicast packets sent
+     */
+    uint64_t txMulticast;
+
+    /**
+     * the number of multicast packets received
+     */
+    uint64_t rxMulticast;
+
+    /**
+     * the number of broadcast packets sent
+     */
+    uint64_t txBroadcast;
+
+    /**
+     * the number of broadcast packets received
+     */
+    uint64_t rxBroadcast;
+
+    /**
+     * the number of unicast packets sent
+     */
+    uint64_t txUnicast;
+
+    /**
+     * the number of unicast packets received
+     */
+    uint64_t rxUnicast;
+
+    /**
+     * the number of bytes sent
+     */
+    uint64_t txBytes;
+
+    /**
+     * the number of bytes received
+     */
+    uint64_t rxBytes;
+};
+
+/**
  * The endpoint manager is responsible for maintaining the state
  * related to endpoints.  It discovers new endpoints on the system and
  * write the appropriate objects and references into the endpoint
@@ -237,71 +302,6 @@ public:
     * @param uri string uri reference to the platform/config object that changed.
     */
     void configUpdated(const opflex::modb::URI& uri);
-
-    /**
-     * Counter values for endpoint stats
-     */
-    struct EpCounters {
-        /**
-         * Number of packets sent
-         */
-        uint64_t txPackets;
-
-        /**
-         * Number of packets received
-         */
-        uint64_t rxPackets;
-
-        /**
-         * the number of dropped packets sent
-         */
-        uint64_t txDrop;
-
-        /**
-         * the number of dropped packets received
-         */
-        uint64_t rxDrop;
-
-        /**
-         * the number of multicast packets sent
-         */
-        uint64_t txMulticast;
-
-        /**
-         * the number of multicast packets received
-         */
-        uint64_t rxMulticast;
-
-        /**
-         * the number of broadcast packets sent
-         */
-        uint64_t txBroadcast;
-
-        /**
-         * the number of broadcast packets received
-         */
-        uint64_t rxBroadcast;
-
-        /**
-         * the number of unicast packets sent
-         */
-        uint64_t txUnicast;
-
-        /**
-         * the number of unicast packets received
-         */
-        uint64_t rxUnicast;
-
-        /**
-         * the number of bytes sent
-         */
-        uint64_t txBytes;
-
-        /**
-         * the number of bytes received
-         */
-        uint64_t rxBytes;
-    };
 
     /**
      * Update the counters for an endpoint to the specified values

--- a/agent-ovs/lib/include/opflexagent/PrometheusManager.h
+++ b/agent-ovs/lib/include/opflexagent/PrometheusManager.h
@@ -38,6 +38,7 @@ using boost::optional;
 using namespace prometheus;
 
 class Agent;
+struct EpCounters;
 
 // Optional pair of label attr hash and Gauge ptr
 typedef optional<pair<size_t, Gauge *> >  hgauge_pair_t;
@@ -96,11 +97,13 @@ public:
      * @param ep_name     the name of the ep
      * @param attr_hash   hash of prometheus compatible ep attr
      * @param attr_map    map of all ep attributes
+     * @param counters    struct holding all the counters of an EP
      */
     void addNUpdateEpCounter(const string& uuid,
                              const string& ep_name,
                              const size_t& attr_hash,
-        const unordered_map<string, string>&    attr_map);
+        const unordered_map<string, string>& attr_map,
+                             const EpCounters& counters);
     /**
      * Remove EpCounter metric given the ep name
      */

--- a/agent-ovs/ovs/InterfaceStatsManager.cpp
+++ b/agent-ovs/ovs/InterfaceStatsManager.cpp
@@ -137,7 +137,7 @@ void InterfaceStatsManager::on_timer(const error_code& ec) {
 void InterfaceStatsManager::
 updateEndpointCounters(const std::string& uuid,
                        SwitchConnection * connection,
-                       EndpointManager::EpCounters& counters) {
+                       EpCounters& counters) {
     EndpointManager& epMgr = agent->getEndpointManager();
     if (!accessConnection) {
         epMgr.updateEndpointCounters(uuid, counters);
@@ -152,7 +152,7 @@ updateEndpointCounters(const std::string& uuid,
     }
 
     if (epIntfCounters.accessCounters && epIntfCounters.intCounters) {
-        EndpointManager::EpCounters epCount =
+        EpCounters epCount =
                       epIntfCounters.accessCounters.get();
         epCount.txDrop += epIntfCounters.intCounters.get().txDrop;
         epCount.rxDrop += epIntfCounters.intCounters.get().rxDrop;
@@ -181,7 +181,7 @@ void InterfaceStatsManager::Handle(SwitchConnection* connection,
         int error_flg = ofputil_decode_port_stats(&ps, &b);
         if (error_flg)
             break;
-        EndpointManager::EpCounters counters;
+        EpCounters counters;
         memset(&counters, 0, sizeof(counters));
 
         counters.txPackets = ps.stats.tx_packets;

--- a/agent-ovs/ovs/include/InterfaceStatsManager.h
+++ b/agent-ovs/ovs/include/InterfaceStatsManager.h
@@ -113,8 +113,8 @@ private:
      * Counters for endpoints.
      */
     struct IntfCounters {
-        boost::optional<EndpointManager::EpCounters> intCounters;
-        boost::optional<EndpointManager::EpCounters> accessCounters;
+        boost::optional<EpCounters> intCounters;
+        boost::optional<EpCounters> accessCounters;
     };
     typedef std::unordered_map<std::string, IntfCounters> intf_counter_map_t;
 
@@ -124,7 +124,7 @@ private:
     void on_timer(const boost::system::error_code& ec);
     void updateEndpointCounters(const std::string& uuid,
                                 SwitchConnection *swConn,
-                                EndpointManager::EpCounters& counters);
+                                EpCounters& counters);
 
     std::atomic<bool> stopping;
 };


### PR DESCRIPTION
- stopped relying on observer mo to update EpCounter metrics
- create/del checks along with stats updates
- label hash change checks during mod
- removed unused function
- since forward declaration of nested class/struct/type isnt allowed in c++, had to un-nest EpCounters

Signed-off-by: Gautam Venkataramanan <gautam.chennai@gmail.com>