### PR TITLE
address few more lgtm and coverty issues

### DIFF
--- a/agent-ovs/ovs/PacketInHandler.cpp
+++ b/agent-ovs/ovs/PacketInHandler.cpp
@@ -275,11 +275,6 @@ static void handleNDPktIn(Agent& agent,
                                             &flow.ipv6_src);
     } else if (icmp->icmp6_type == ND_ROUTER_SOLICIT && egUri) {
         /* Router solicitation */
-        struct nd_router_solicit* router_sol =
-            (struct nd_router_solicit*) dpp_l4(pkt);
-        if (l4_size < sizeof(*router_sol))
-            return;
-
         LOG(DEBUG) << "Handling ICMPv6 router solicitation";
 
         b = packets::compose_icmp6_router_ad(mac,

--- a/agent-ovs/ovs/test/include/PolicyStatsManagerFixture.h
+++ b/agent-ovs/ovs/test/include/PolicyStatsManagerFixture.h
@@ -251,9 +251,8 @@ public:
 
         // generate flow removed message for the first flow
         // found in the flow entry list
-        const FlowEntryPtr& fe = entryList.front();
-        if (fe) {
-
+        if (!entryList.empty()) {
+            const FlowEntryPtr& fe = entryList.front();
             fs = &fstat;
             bzero(fs, sizeof(struct ofputil_flow_removed));
             fs->table_id = table_id;

--- a/agent-ovs/ovs/test/include/PolicyStatsManagerFixture.h
+++ b/agent-ovs/ovs/test/include/PolicyStatsManagerFixture.h
@@ -251,7 +251,8 @@ public:
 
         // generate flow removed message for the first flow
         // found in the flow entry list
-        for (const FlowEntryPtr& fe : entryList) {
+        const FlowEntryPtr& fe = entryList.front();
+        if (fe) {
 
             fs = &fstat;
             bzero(fs, sizeof(struct ofputil_flow_removed));
@@ -336,6 +337,7 @@ public:
         BOOST_REQUIRE(res_msg!=0);
         ofp_header *msgHdr = (ofp_header *)res_msg->data;
         cStatsManager* pSM = dynamic_cast<cStatsManager*>(statsManager);
+        BOOST_CHECK(pSM);
         pSM->testInjectTxnId(msgHdr->xid);
 
         // send first flow stats reply message
@@ -422,6 +424,7 @@ public:
         BOOST_REQUIRE(res_msg!=0);
         ofp_header *msgHdr = (ofp_header *)res_msg->data;
         cStatsManager* pSM = dynamic_cast<cStatsManager*>(statsManager);
+        BOOST_CHECK(pSM);
         pSM->testInjectTxnId(msgHdr->xid);
 
         // send first flow stats reply message


### PR DESCRIPTION
- lgtm: Comparison result is always the same:
We seem to be checking if l4_size is < sizeof(icmp6_hdr) above already. Hence removing "if (l4_size < sizeof(*router_sol))" which is reduntant.
struct nd_router_solicit {  /* router solicitation */
  struct icmp6_hdr  nd_rs_hdr;
  /* could be followed by options */
};

- coverty: fix null ptr dereference and unreachable code

Signed-off-by: Gautam Venkataramanan <gautam.chennai@gmail.com>