### PR TITLE
Fix a coverity issue.

### DIFF
--- a/agent-ovs/ovs/AdvertManager.cpp
+++ b/agent-ovs/ovs/AdvertManager.cpp
@@ -91,14 +91,18 @@ void AdvertManager::stop() {
     stopping = true;
 
     lock_guard<recursive_mutex> guard(timer_mutex);
-    if (routerAdvTimer)
-        routerAdvTimer->cancel();
-    if (endpointAdvTimer)
-        endpointAdvTimer->cancel();
-    if (allEndpointAdvTimer)
-        allEndpointAdvTimer->cancel();
-    if(tunnelEpAdvTimer)
-        tunnelEpAdvTimer->cancel();
+    try {
+        if (routerAdvTimer)
+            routerAdvTimer->cancel();
+        if (endpointAdvTimer)
+            endpointAdvTimer->cancel();
+        if (allEndpointAdvTimer)
+            allEndpointAdvTimer->cancel();
+        if(tunnelEpAdvTimer)
+            tunnelEpAdvTimer->cancel();
+    } catch(const std::exception &e) {
+        LOG(WARNING) << "Failed to cancel advertisement timer: " << e.what();
+    }
 }
 
 void AdvertManager::scheduleInitialRouterAdv() {


### PR DESCRIPTION
Any of the timer cancels can fail, but the timer handlers check the return value
and return doing nothing, so this should be safe to do.

Signed-off-by: Kiran Shastri <shastrinator@gmail.com>