### PR TITLE
Fix for agent crash reported in CSCvu46192/SR689109894

### DIFF
--- a/libopflex/engine/OpflexPool.cpp
+++ b/libopflex/engine/OpflexPool.cpp
@@ -459,7 +459,8 @@ void OpflexPool::validatePeerSet(OpflexClientConnection * conn, const peer_name_
     peer_name_set_t to_remove;
     util::RecursiveLockGuard guard(&conn_mutex, &conn_mutex_key);
 
-    BOOST_FOREACH(const conn_map_t::value_type& cv, connections) {
+    conn_map_t conns(connections);
+    BOOST_FOREACH(const conn_map_t::value_type& cv, conns) {
         OpflexClientConnection* c = cv.second.conn;
         OpflexClientConnection* srcPeer = getPeer(conn->getHostname(), conn->getPort());
         peer_name_t peer_name = make_pair(c->getHostname(), c->getPort());


### PR DESCRIPTION
Root cause:
During leaf replacement of VPC member, the tep ip of replaced leaf changes. Due to this we remove the stale opflex peer connection and add new tep ip of replaced leaf. During this process we seem to be hitting crash due to hoisting issue in BOOST_FOREACH.
More details on this here: https://www.boost.org/doc/libs/1_73_0/doc/html/foreach/pitfalls.html

Tests performed:
./opflex_server --policy=/home/noiro/work/opflex/agent-ovs/policy.json --peer "127.0.0.1:8010" <-- this is agent's configured peer that listens on 8009
./opflex_server --policy=/home/noiro/work/opflex/agent-ovs/policy.json --peer "127.0.0.1:8011" --peer "127.0.0.1:8012" --server_port 8010
./opflex_server --policy=/home/noiro/work/opflex/agent-ovs/policy.json --peer "127.0.0.1:8012" --peer "127.0.0.1:8013" --server_port 8011
./opflex_server --policy=/home/noiro/work/opflex/agent-ovs/policy.json --peer "127.0.0.1:8013" --peer "127.0.0.1:8011" --server_port 8012
sudo ./opflex_agent -c ~/agent.conf 2>&1 | tee agent.log

TODO: this will be followed up with UT in libopflex to hit the exact case which led to crash

Signed-off-by: Gautam Venkataramanan <gautam.chennai@gmail.com>