### PR TITLE
Remove never used OpflexPool::getMasterForRole

### DIFF
--- a/libopflex/engine/include/opflex/engine/internal/OpflexPool.h
+++ b/libopflex/engine/include/opflex/engine/internal/OpflexPool.h
@@ -236,16 +236,6 @@ public:
     void setRoles(OpflexClientConnection* conn, uint8_t roles);
 
     /**
-     * Get the primary connection for the given role.  This will be
-     * the first connection in the set of ready connections with that
-     * role.
-     *
-     * @return the master for the role, or NULL if there is no ready
-     * connection with that role
-     */
-    OpflexClientConnection* getMasterForRole(ofcore::OFConstants::OpflexRole role);
-
-    /**
      * Send a given message to all the connected and ready peers with
      * the given role.  This message can be called from any thread.
      *
@@ -392,7 +382,6 @@ private:
     class RoleData {
     public:
         conn_set_t conns;
-        OpflexClientConnection* curMaster;
     };
 
     typedef std::map<uint8_t, RoleData> role_map_t;

--- a/libopflex/engine/test/OpflexPool_test.cpp
+++ b/libopflex/engine/test/OpflexPool_test.cpp
@@ -92,9 +92,6 @@ BOOST_FIXTURE_TEST_CASE( manage_roles , PoolFixture ) {
                   OFConstants::OBSERVER |
                   OFConstants::ENDPOINT_REGISTRY);
 
-    BOOST_CHECK_EQUAL(c1, pool.getMasterForRole(OFConstants::POLICY_REPOSITORY));
-    BOOST_CHECK_EQUAL(c1, pool.getMasterForRole(OFConstants::OBSERVER));
-    BOOST_CHECK_EQUAL(c1, pool.getMasterForRole(OFConstants::ENDPOINT_REGISTRY));
     BOOST_CHECK_EQUAL(1, pool.getRoleCount(OFConstants::POLICY_REPOSITORY));
     BOOST_CHECK_EQUAL(1, pool.getRoleCount(OFConstants::OBSERVER));
     BOOST_CHECK_EQUAL(1, pool.getRoleCount(OFConstants::ENDPOINT_REGISTRY));
@@ -102,23 +99,11 @@ BOOST_FIXTURE_TEST_CASE( manage_roles , PoolFixture ) {
     pool.setRoles(c2,
                   OFConstants::POLICY_REPOSITORY |
                   OFConstants::ENDPOINT_REGISTRY);
-    BOOST_CHECK_EQUAL(c1, pool.getMasterForRole(OFConstants::OBSERVER));
     pool.setRoles(c3, OFConstants::OBSERVER);
 
     BOOST_CHECK_EQUAL(2, pool.getRoleCount(OFConstants::POLICY_REPOSITORY));
     BOOST_CHECK_EQUAL(2, pool.getRoleCount(OFConstants::OBSERVER));
     BOOST_CHECK_EQUAL(2, pool.getRoleCount(OFConstants::ENDPOINT_REGISTRY));
-
-    // fail to next master
-    OpflexClientConnection* m1 =
-        pool.getMasterForRole(OFConstants::POLICY_REPOSITORY);
-    BOOST_CHECK_EQUAL(m1, pool.getMasterForRole(OFConstants::ENDPOINT_REGISTRY));
-    ((MockClientConn*)m1)->ready = false;
-    BOOST_CHECK(m1 != pool.getMasterForRole(OFConstants::ENDPOINT_REGISTRY));
-
-    // check stickiness
-    ((MockClientConn*)m1)->ready = true;
-    BOOST_CHECK(m1 != pool.getMasterForRole(OFConstants::ENDPOINT_REGISTRY));
 
     c1->disconnect();
     BOOST_CHECK_EQUAL(1, pool.getRoleCount(OFConstants::POLICY_REPOSITORY));


### PR DESCRIPTION
Signed-off-by: Tom Flynn <tom.flynn@gmail.com>