### PR TITLE
fix for a flaky test

### DIFF
--- a/agent-ovs/ovs/test/IntFlowManager_test.cpp
+++ b/agent-ovs/ovs/test/IntFlowManager_test.cpp
@@ -1021,8 +1021,11 @@ BOOST_FIXTURE_TEST_CASE(mcast, VxlanIntFlowManagerFixture) {
     string mcast3 = "224.5.1.1";
     string mcast4 = "224.5.1.2";
 
+    // Both mcast1 and mcast3 will get programmed as part of
+    // IntFlowManager.configUpdated()
     unordered_set<string> expected;
     expected.insert(mcast1);
+    expected.insert(mcast3);
 
     intFlowManager.configUpdated(config->getURI());
     setConnected();


### PR DESCRIPTION
As part of intflowmanager.configUpdated(), first platform config's mcast ip will get added to mcast path; then epg2 egDomUpdated will result in the next mcast ip to get added. Waiting for both of them to get added for the test to be reliable.

Signed-off-by: Gautam Venkataramanan <gautam.chennai@gmail.com>