### PR TITLE
Printing sorted runtimes of all unit tests run under libopflex and ag…

### DIFF
--- a/.travis/travis-build.sh
+++ b/.travis/travis-build.sh
@@ -3,6 +3,9 @@
 set -o errtrace
 set -x
 
+export BOOST_TEST_COLOR_OUTPUT=yes
+export BOOST_TEST_LOG_LEVEL=test_suite
+
 pushd libopflex
 ./autogen.sh
 ./configure --enable-coverage &> /dev/null
@@ -30,3 +33,8 @@ sudo make install
 make check
 find . -name test-suite.log|xargs cat
 popd
+
+find . -name *_test.log | xargs grep "Leaving test case" | \
+    awk '{gsub(/\"|\;/,"")}1' | sed 's/..$//; s/\// /g; s/\:/ /g' | \
+    awk '{print $NF , $6 , $10}' | sort -nrk1 | \
+    awk '{print "time:"$1"us", "test:"$2":"$3}'


### PR DESCRIPTION
…ent-ovs

- This will give a high-level summary of how much time every test takes
- the time taken is obtained using boost log level=test_suite
- only added for the vanilla build (not for tsan, asan or ubsan where the times are expected to be longer)

Signed-off-by: Gautam Venkataramanan <gautam.chennai@gmail.com>