### PR TITLE
Fix related flows like icmp port unreachable

### DIFF
--- a/agent-ovs/ovs/FlowUtils.cpp
+++ b/agent-ovs/ovs/FlowUtils.cpp
@@ -151,6 +151,7 @@ void add_classifier_entries(L24Classifier& clsfr, ClassAction act,
                             uint32_t flags, uint64_t cookie,
                             uint32_t svnid, uint32_t dvnid,
                             /* out */ FlowEntryList& entries) {
+    using modelgbp::l2::EtherTypeEnumT;
     using modelgbp::l4::TcpFlagsEnumT;
 
     ovs_be64 ckbe = ovs_htonll(cookie);
@@ -195,6 +196,38 @@ void add_classifier_entries(L24Classifier& clsfr, ClassAction act,
         for (const network::subnet_t& ds : effDestSub) {
             flow_func dst_func(make_flow_functor(ds, &FlowBuilder::ipDst));
 
+            /*
+             * For EtherType IPV4 and IPV6 add related flows based on
+             * EtherType and skip matching on L4 Proto and ports
+             */
+            if (act == flowutils::CA_REFLEX_REV_RELATED) {
+                FlowBuilder f;
+                uint16_t ethT = clsfr.getEtherT(EtherTypeEnumT::CONST_UNSPECIFIED);
+
+                if (ethT == EtherTypeEnumT::CONST_IPV4 ||
+                    ethT == EtherTypeEnumT::CONST_IPV6) {
+                    f.ethType(ethT);
+                } else {
+                    continue;
+                }
+
+                f.cookie(ckbe);
+                f.flags(flags);
+                f.conntrackState(FlowBuilder::CT_TRACKED |
+                                 FlowBuilder::CT_RELATED |
+                                 FlowBuilder::CT_REPLY,
+                                 FlowBuilder::CT_TRACKED |
+                                 FlowBuilder::CT_RELATED |
+                                 FlowBuilder::CT_REPLY |
+                                 FlowBuilder::CT_ESTABLISHED |
+                                 FlowBuilder::CT_INVALID |
+                                 FlowBuilder::CT_NEW);
+                 flowutils::match_group(f, priority, svnid, dvnid);
+                 f.action().go(nextTable);
+                 entries.push_back(f.build());
+                 continue;
+           }
+
             for (const Mask& sm : srcPorts) {
                 for (const Mask& dm : dstPorts) {
                     for (uint32_t flagMask : tcpFlagsVec) {
@@ -217,15 +250,6 @@ void add_classifier_entries(L24Classifier& clsfr, ClassAction act,
                                              FlowBuilder::CT_INVALID |
                                              FlowBuilder::CT_NEW |
                                              FlowBuilder::CT_RELATED);
-                            break;
-                        case flowutils::CA_REFLEX_REV_RELATED:
-                            f.conntrackState(FlowBuilder::CT_TRACKED |
-                                             FlowBuilder::CT_RELATED,
-                                             FlowBuilder::CT_TRACKED |
-                                             FlowBuilder::CT_RELATED |
-                                             FlowBuilder::CT_ESTABLISHED |
-                                             FlowBuilder::CT_INVALID |
-                                             FlowBuilder::CT_NEW);
                             break;
                         default:
                             // nothing
@@ -276,7 +300,6 @@ void add_classifier_entries(L24Classifier& clsfr, ClassAction act,
                             f.action().go(nextTable);
                             break;
                         case flowutils::CA_REFLEX_REV_ALLOW:
-                        case flowutils::CA_REFLEX_REV_RELATED:
                         case flowutils::CA_ALLOW:
                             f.action().go(nextTable);
                             break;

--- a/agent-ovs/ovs/test/AccessFlowManager_test.cpp
+++ b/agent-ovs/ovs/test/AccessFlowManager_test.cpp
@@ -568,7 +568,7 @@ uint16_t AccessFlowManagerFixture::initExpSecGrp2(uint32_t setId) {
          .isCtState("-new+est-rel+rpl-inv+trk").tcp().reg(SEPG, setId)
          .actions().go(OUT).done());
     ADDF(Bldr(SEND_FLOW_REM).table(IN_POL).priority(prio - 128).cookie(ruleId)
-         .isCtState("-new-est+rel-inv+trk").tcp().reg(SEPG, setId)
+         .isCtState("-new-est+rel+rpl-inv+trk").ip().reg(SEPG, setId)
          .actions().go(OUT).done());
     ADDF(Bldr(SEND_FLOW_REM).table(IN_POL).priority(prio - 128)
          .isCtState("-trk").tcp().reg(SEPG, setId)


### PR DESCRIPTION
- The related flows added against l24 classifer rules will not match
  since they have a different protocol (like icmp)
- Fix this by matching only on the l3 type
- The flags need to be a complete set of what ct returns, unspecified
  flags should be wildcarded but thats not how ovs is matching it.
- Fix the flags to include rel+rpl

Signed-off-by: Madhu Challa <challa@gmail.com>