### PR TITLE
Support for gprof profiler for libopflex and agent-ovs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ addons:
       - python-six
       - lcov
 
+# In case we need to run perf, install the below in bionic:
+# linux-tools-common
+# linux-tools-4.15.0-72-generic
+
 before_install:
   - pip install --user cpp-coveralls
 

--- a/.travis/travis-build.sh
+++ b/.travis/travis-build.sh
@@ -8,7 +8,7 @@ export BOOST_TEST_LOG_LEVEL=test_suite
 
 pushd libopflex
 ./autogen.sh
-./configure --enable-coverage &> /dev/null
+./configure --enable-coverage --enable-gprof &> /dev/null
 make -j2
 make check
 sudo make install
@@ -27,13 +27,27 @@ popd
 
 pushd agent-ovs
 ./autogen.sh &> /dev/null
-./configure --enable-coverage &> /dev/null
+./configure --enable-coverage --enable-gprof &> /dev/null
 make -j2
 sudo make install
 make check
 find . -name test-suite.log|xargs cat
+
+# Dump gprof output:
+# Note:
+# - https://linux.die.net/man/1/gprof
+# - https://ftp.gnu.org/old-gnu/Manuals/gprof-2.9.1/html_mono/gprof.html
+printf '\n\n'
+echo "Gprof - top methods consuming cpu cycles:"
+gprof -b -p .libs/agent_test gmon.out | head -n 20
+
+printf '\n\n'
+echo "Gprof - call graphs of first few top methods:"
+gprof -b -P .libs/agent_test gmon.out | head -n 100
 popd
 
+printf '\n\n'
+echo "Sorted time taken per unit test:"
 find . -name *_test.log | xargs grep "Leaving test case" | \
     awk '{gsub(/\"|\;/,"")}1' | sed 's/..$//; s/\// /g; s/\:/ /g' | \
     awk '{print $NF , $6 , $10}' | sort -nrk1 | \

--- a/agent-ovs/Makefile.am
+++ b/agent-ovs/Makefile.am
@@ -33,6 +33,9 @@ endif
 if ENABLE_COVERAGE
   AM_CPPFLAGS += --coverage
 endif
+if ENABLE_GPROF
+  AM_CPPFLAGS += -pg
+endif
 
 AM_LDFLAGS = $(BOOST_LDFLAGS)
 if ENABLE_TSAN
@@ -46,6 +49,9 @@ if ENABLE_UBSAN
 endif
 if ENABLE_COVERAGE
   AM_LDFLAGS += --coverage
+endif
+if ENABLE_GPROF
+  AM_LDFLAGS += -pg
 endif
 
 noinst_LTLIBRARIES =
@@ -232,6 +238,9 @@ endif
 if ENABLE_COVERAGE
   libopflex_agent_la_LDFLAGS += --coverage
 endif
+if ENABLE_GPROF
+  libopflex_agent_la_LDFLAGS += -pg
+endif
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libopflex_agent.pc
@@ -297,6 +306,9 @@ endif
 if ENABLE_COVERAGE
   librenderer_openvswitch_la_CXXFLAGS += --coverage
 endif
+if ENABLE_GPROF
+  librenderer_openvswitch_la_CXXFLAGS += -pg
+endif
   librenderer_openvswitch_la_LIBADD = \
 	$(libopflex_LIBS) \
 	$(libmodelgbp_LIBS) \
@@ -320,6 +332,9 @@ if ENABLE_UBSAN
 endif
 if ENABLE_COVERAGE
   libopflex_agent_renderer_openvswitch_la_LDFLAGS += --coverage
+endif
+if ENABLE_GPROF
+  libopflex_agent_renderer_openvswitch_la_LDFLAGS += -pg
 endif
 endif
 
@@ -361,6 +376,9 @@ endif
 if ENABLE_COVERAGE
   gbp_inspect_CXXFLAGS += --coverage
 endif
+if ENABLE_GPROF
+  gbp_inspect_CXXFLAGS += -pg
+endif
 
 gbp_inspect_SOURCES = \
 	cmd/gbp_inspect.cpp
@@ -384,6 +402,9 @@ if ENABLE_UBSAN
 endif
 if ENABLE_COVERAGE
   mcast_daemon_CXXFLAGS += --coverage
+endif
+if ENABLE_GPROF
+  mcast_daemon_CXXFLAGS += -pg
 endif
 
 mcast_daemon_SOURCES = \
@@ -417,6 +438,9 @@ if ENABLE_UBSAN
 endif
 if ENABLE_COVERAGE
   agent_test_CXXFLAGS += --coverage
+endif
+if ENABLE_GPROF
+  agent_test_CXXFLAGS += -pg
 endif
 
 agent_test_includedir = $(includedir)/opflexagent/test
@@ -508,6 +532,9 @@ endif
 if ENABLE_COVERAGE
 opflex_server_CXXFLAGS += --coverage
 endif
+if ENABLE_GPROF
+opflex_server_CXXFLAGS += -pg
+endif
 
 opflex_server_SOURCES = \
 	cmd/test/include/Policies.h \
@@ -561,6 +588,9 @@ if ENABLE_ASAN
 endif
 if ENABLE_COVERAGE
   policy_repo_stress_CXXFLAGS += --coverage
+endif
+if ENABLE_GPROF
+  policy_repo_stress_CXXFLAGS += -pg
 endif
 if ENABLE_UBSAN
   policy_repo_stress_CXXFLAGS += -fsanitize=undefined
@@ -632,6 +662,9 @@ if ENABLE_ASAN
 endif
 if ENABLE_COVERAGE
   integration_test_CXXFLAGS += --coverage
+endif
+if ENABLE_GPROF
+  integration_test_CXXFLAGS += -pg
 endif
 if ENABLE_UBSAN
   integration_test_CXXFLAGS += -fsanitize=undefined

--- a/agent-ovs/configure.ac
+++ b/agent-ovs/configure.ac
@@ -138,6 +138,13 @@ AM_COND_IF([ENABLE_COVERAGE],
           [AC_MSG_NOTICE([Code coverage is enabled])],
           [AC_MSG_NOTICE([Code coverage is disabled])])
 
+dnl Create an option to build with gprof enabled
+AC_ARG_ENABLE(gprof, AC_HELP_STRING([--enable-gprof], [Enable gprof]))
+AM_CONDITIONAL(ENABLE_GPROF, [test x$enable_gprof = 'xyes'])
+AM_COND_IF([ENABLE_GPROF],
+          [AC_MSG_NOTICE([gprof is enabled])],
+          [AC_MSG_NOTICE([gprof is disabled])])
+
 # ---------------------------------------------------------------
 # Dependency checks
 

--- a/libopflex/Makefile.am
+++ b/libopflex/Makefile.am
@@ -30,6 +30,10 @@ if ENABLE_COVERAGE
   AM_CPPFLAGS += --coverage
 endif
 
+if ENABLE_GPROF
+  AM_CPPFLAGS += -pg
+endif
+
 SUBDIRS  =
 SUBDIRS += util
 SUBDIRS += logging
@@ -142,6 +146,10 @@ endif
 
 if ENABLE_COVERAGE
   libopflex_la_LDFLAGS += --coverage
+endif
+
+if ENABLE_GPROF
+  libopflex_la_LDFLAGS += -pg
 endif
 
 pkgconfigdir = $(libdir)/pkgconfig

--- a/libopflex/comms/Makefile.am
+++ b/libopflex/comms/Makefile.am
@@ -45,6 +45,10 @@ if ENABLE_COVERAGE
   AM_CPPFLAGS += --coverage
 endif
 
+if ENABLE_GPROF
+  AM_CPPFLAGS += -pg
+endif
+
 libcomms_la_CPPFLAGS  = $(AM_CPPFLAGS)
 
 libcomms_la_CXXFLAGS  = $(AM_CXXFLAGS)
@@ -191,6 +195,10 @@ endif
 
 if ENABLE_COVERAGE
   comms_test_LDFLAGS += --coverage
+endif
+
+if ENABLE_GPROF
+  comms_test_LDFLAGS += -pg
 endif
 
 comms_test_LDADD  =

--- a/libopflex/configure.ac
+++ b/libopflex/configure.ac
@@ -107,6 +107,13 @@ AM_COND_IF([ENABLE_COVERAGE],
           [AC_MSG_NOTICE([Code coverage is enabled])],
           [AC_MSG_NOTICE([Code coverage is disabled])])
 
+dnl Create an option to build with gprof enabled
+AC_ARG_ENABLE(gprof, AC_HELP_STRING([--enable-gprof], [Enable gprof]))
+AM_CONDITIONAL(ENABLE_GPROF, [test x$enable_gprof = 'xyes'])
+AM_COND_IF([ENABLE_GPROF],
+          [AC_MSG_NOTICE([gprof is enabled])],
+          [AC_MSG_NOTICE([gprof is disabled])])
+
 dnl Create an option to build unit tests only with make check
 AC_ARG_ENABLE(tests-make-all,
               AC_HELP_STRING([--disable-tests-make-all],

--- a/libopflex/cwrapper/Makefile.am
+++ b/libopflex/cwrapper/Makefile.am
@@ -33,6 +33,10 @@ if ENABLE_COVERAGE
   AM_CPPFLAGS += --coverage
 endif
 
+if ENABLE_GPROF
+  AM_CPPFLAGS += -pg
+endif
+
 noinst_LTLIBRARIES = libcwrapper.la
 
 libcwrapper_la_SOURCES = \

--- a/libopflex/cwrapper/test/Makefile.am
+++ b/libopflex/cwrapper/test/Makefile.am
@@ -37,6 +37,10 @@ if ENABLE_COVERAGE
   AM_CPPFLAGS += --coverage
 endif
 
+if ENABLE_GPROF
+  AM_CPPFLAGS += -pg
+endif
+
 AM_LDFLAGS = $(BOOST_LDFLAGS)
 
 TESTS = cwrapper_test
@@ -60,6 +64,10 @@ endif
 
 if ENABLE_COVERAGE
   cwrapper_test_CXXFLAGS += --coverage
+endif
+
+if ENABLE_GPROF
+  cwrapper_test_CXXFLAGS += -pg
 endif
 
 cwrapper_test_LDADD = ../libcwrapper.la \

--- a/libopflex/engine/Makefile.am
+++ b/libopflex/engine/Makefile.am
@@ -37,6 +37,10 @@ if ENABLE_COVERAGE
   AM_CPPFLAGS += --coverage
 endif
 
+if ENABLE_GPROF
+  AM_CPPFLAGS += -pg
+endif
+
 noinst_LTLIBRARIES = libengine.la
 
 libengine_la_CXXFLAGS = $(UV_CFLAGS) $(OPENSSL_CFLAGS) $(RAPIDJSON_CFLAGS)

--- a/libopflex/engine/test/Makefile.am
+++ b/libopflex/engine/test/Makefile.am
@@ -38,6 +38,10 @@ if ENABLE_COVERAGE
   AM_CPPFLAGS += --coverage
 endif
 
+if ENABLE_GPROF
+  AM_CPPFLAGS += -pg
+endif
+
 AM_LDFLAGS = $(BOOST_LDFLAGS)
 
 if ENABLE_TSAN
@@ -54,6 +58,10 @@ endif
 
 if ENABLE_COVERAGE
   AM_LDFLAGS += --coverage
+endif
+
+if ENABLE_GPROF
+  AM_LDFLAGS += -pg
 endif
 
 TESTS = engine_test

--- a/libopflex/logging/Makefile.am
+++ b/libopflex/logging/Makefile.am
@@ -35,6 +35,10 @@ if ENABLE_COVERAGE
   AM_CPPFLAGS += --coverage
 endif
 
+if ENABLE_GPROF
+  AM_CPPFLAGS += -pg
+endif
+
 liblogging_la_SOURCES = \
 	include/opflex/logging/internal/logging.hpp \
 	OFLogHandler.cpp \

--- a/libopflex/modb/Makefile.am
+++ b/libopflex/modb/Makefile.am
@@ -35,6 +35,10 @@ if ENABLE_COVERAGE
   AM_CPPFLAGS += --coverage
 endif
 
+if ENABLE_GPROF
+  AM_CPPFLAGS += -pg
+endif
+
 noinst_LTLIBRARIES = libmodb.la
 
 libmodb_la_CXXFLAGS = $(UV_CFLAGS)

--- a/libopflex/modb/test/Makefile.am
+++ b/libopflex/modb/test/Makefile.am
@@ -33,6 +33,10 @@ if ENABLE_COVERAGE
   AM_CPPFLAGS += --coverage
 endif
 
+if ENABLE_GPROF
+  AM_CPPFLAGS += -pg
+endif
+
 AM_LDFLAGS = $(BOOST_LDFLAGS)
 
 if ENABLE_TSAN
@@ -49,6 +53,10 @@ endif
 
 if ENABLE_COVERAGE
   AM_LDFLAGS += --coverage
+endif
+
+if ENABLE_GPROF
+  AM_LDFLAGS += -pg
 endif
 
 TESTS = modb_test

--- a/libopflex/ofcore/Makefile.am
+++ b/libopflex/ofcore/Makefile.am
@@ -44,6 +44,10 @@ if ENABLE_COVERAGE
   AM_CPPFLAGS += --coverage
 endif
 
+if ENABLE_GPROF
+  AM_CPPFLAGS += -pg
+endif
+
 noinst_LTLIBRARIES = libcore.la
 
 libcore_la_CXXFLAGS = $(UV_CFLAGS) $(RAPIDJSON_CFLAGS)

--- a/libopflex/ofcore/test/Makefile.am
+++ b/libopflex/ofcore/test/Makefile.am
@@ -42,6 +42,10 @@ if ENABLE_COVERAGE
   AM_CPPFLAGS += --coverage
 endif
 
+if ENABLE_GPROF
+  AM_CPPFLAGS += -pg
+endif
+
 AM_LDFLAGS = $(BOOST_LDFLAGS)
 
 if ENABLE_TSAN
@@ -58,6 +62,10 @@ endif
 
 if ENABLE_COVERAGE
   AM_LDFLAGS += --coverage
+endif
+
+if ENABLE_GPROF
+  AM_LDFLAGS += -pg
 endif
 
 TESTS = core_test

--- a/libopflex/util/Makefile.am
+++ b/libopflex/util/Makefile.am
@@ -29,6 +29,10 @@ if ENABLE_COVERAGE
   AM_CPPFLAGS += --coverage
 endif
 
+if ENABLE_GPROF
+  AM_CPPFLAGS += -pg
+endif
+
 noinst_LTLIBRARIES = libutil.la
 
 libutil_la_CXXFLAGS = $(UV_CFLAGS)


### PR DESCRIPTION
- Config options added for libopflex and agent-ovs. By default its disabled.
- Gprof uses instrumentation and sampling to generate profiling data. Due to sampling it is fast, but might be inaccurate due to rate of sampling. But call counts and approximate call graphs will help pinpoint most common bottlenecks. More details here: https://ftp.gnu.org/old-gnu/Manuals/gprof-2.9.1/html_mono/gprof.html.
- To avoid overhead, gprof output is enabled only in vanilla agent-ovs build in travis (which will cover libopflex as well). And top 20 methods and top 100 lines of call stack are dumped for now.
- Will be useful to run it on standalone opflex-agent to analyze the bottlenecks.

Note: I tried perf as well. But the output was showing more info on kernel and system call profiling. Regarding call-graph with perf, it is suggested that we build with -fno-omit-frame-pointer. gprof should be good for now.

Signed-off-by: Gautam Venkataramanan <gautam.chennai@gmail.com>