### PR TITLE
Create/delete mirror and associated output port in same call

### DIFF
--- a/agent-ovs/ovs/include/OvsdbConnection.h
+++ b/agent-ovs/ovs/include/OvsdbConnection.h
@@ -74,7 +74,6 @@ class OvsdbConnection : public opflex::jsonrpc::RpcConnection {
         if (!connected) {
             return false;
         } else {
-            LOG(WARNING) << "Check if sync is complete";
             unique_lock<mutex> lock(OvsdbConnection::ovsdbMtx);
             if (!ready.wait_for(lock, std::chrono::milliseconds(WAIT_TIMEOUT),
                                 [=] { return isSyncComplete(); })) {
@@ -144,12 +143,6 @@ class OvsdbConnection : public opflex::jsonrpc::RpcConnection {
      * @param[in] handle pointer to uv_async_t
      */
     static void connect_cb(uv_async_t* handle);
-
-    /**
-     * callback for sending requests
-     * @param[in] handle pointer to uv_async_t
-     */
-    static void send_req_cb(uv_async_t* handle);
 
     /**
      * callback for sending queued requests
@@ -242,16 +235,9 @@ private:
     }
 
     yajr::Peer* peer;
-
-    typedef struct req_cb_data_ {
-        shared_ptr<OvsdbMessage> req;
-        yajr::Peer* peer;
-    } req_cb_data;
-
     uv_loop_t* client_loop;
     opflex::util::ThreadManager threadManager;
     uv_async_t connect_async;
-    uv_async_t send_req_async;
     uv_async_t writeq_async;
     std::atomic<bool> connected;
     std::atomic<bool> syncComplete;

--- a/agent-ovs/ovs/include/SpanRenderer.h
+++ b/agent-ovs/ovs/include/SpanRenderer.h
@@ -64,31 +64,18 @@ public:
      * @param[in] session name of mirror
      * @param[in] srcPorts source ports
      * @param[in] dstPorts dest ports
+     * @param[in] ipAddr remote destination
+     * @param[in] version erspan version
      */
-    void createMirror(const string& session, const set<string>& srcPorts, const set<string>& dstPorts);
+    void createMirrorAndOutputPort(const string& session, const set<string>& srcPorts,
+        const set<string>& dstPorts, const string& remoteIp, const uint8_t version);
 
     /**
      * deletes mirror session
      * @param[in] session name of session
      * @return true if success, false otherwise.
      */
-    void deleteMirror(const string& session);
-
-    /**
-     * add port used for erspan
-     * @param portName erspan port name
-     * @param ipAddr remote destination
-     * @param version erspan version
-     * @return true if success, false otherwise.
-     */
-    void addErspanPort(const string& portName, const string& ipAddr, const uint8_t version);
-
-    /**
-     * delete port used for erspan
-     * @param name port name
-     * @return true if success, false otherwise.
-     */
-    void deleteErspanPort(const string& name);
+    void deleteMirrorAndOutputPort(const string& session);
 
 private:
     /**

--- a/agent-ovs/ovs/test/SpanRenderer_test.cpp
+++ b/agent-ovs/ovs/test/SpanRenderer_test.cpp
@@ -68,6 +68,18 @@ public:
         portDetail["name"] = OvsdbValue(p2);
         portDetails[p2PortUuid] = portDetail;
 
+        const string erspanPortUuid2 = "f9f42dce-44cb-1234-8920-dfc32d88ec07";
+        portDetail["uuid"] = OvsdbValue(erspanPortUuid2);
+        const string portName2(ERSPAN_PORT_PREFIX + "test");
+        portDetail["name"] = OvsdbValue(portName2);
+        portDetails[erspanPortUuid2] = portDetail;
+
+        const string erspanPortUuid3 = "f9f42dce-44cb-1234-8920-dfc32d88dd07";
+        portDetail["uuid"] = OvsdbValue(erspanPortUuid3);
+        const string portName3(ERSPAN_PORT_PREFIX + "abc");
+        portDetail["name"] = OvsdbValue(portName3);
+        portDetails[erspanPortUuid3] = portDetail;
+
         conn->getOvsdbState().fullUpdate(OvsdbTable::PORT, portDetails);
 
         OvsdbTableDetails mirrorDetails;
@@ -86,6 +98,17 @@ public:
         dstPorts[p2PortUuid];
         mirrorDetail["select_dst_port"] = OvsdbValue(Dtype::SET, "set", dstPorts);
         mirrorDetails[uuid] = mirrorDetail;
+
+        OvsdbRowDetails mirrorDetail2;
+        uuid = "922108c7-ce2d-4d46-a419-1654a5bf47ef";
+        mirrorDetail2["uuid"] = OvsdbValue(uuid);
+        const string mirrorName2("abc");
+        mirrorDetail2["name"] = OvsdbValue(mirrorName2);
+        mirrorDetail2["out_port"] = OvsdbValue(erspanPortUuid2);
+        mirrorDetail2["select_src_port"] = OvsdbValue(Dtype::SET, "set", srcPorts);
+        mirrorDetail2["select_dst_port"] = OvsdbValue(Dtype::SET, "set", dstPorts);
+        mirrorDetails[uuid] = mirrorDetail2;
+
         conn->getOvsdbState().fullUpdate(OvsdbTable::MIRROR, mirrorDetails);
 
         OvsdbTableDetails interfaceDetails;
@@ -122,27 +145,19 @@ static bool verifyCreateDestroy(const shared_ptr<SpanRenderer>& spr, unique_ptr<
         LOG(WARNING) << "Unable to find UUID for port erspan";
         return false;
     }
-    spr->deleteErspanPort(ERSPAN_PORT_PREFIX);
 
     string sessionName("abc");
-    spr->deleteMirror(sessionName);
-
-    spr->addErspanPort(ERSPAN_PORT_PREFIX, "10.20.120.240", 1);
+    spr->deleteMirrorAndOutputPort(sessionName);
 
     set<string> src_ports = {"p1-tap", "p2-tap"};
     set<string> dst_ports = {"p1-tap", "p2-tap"};
     set<string> out_ports = {ERSPAN_PORT_PREFIX};
-    spr->createMirror("sess1", src_ports, dst_ports);
+    spr->createMirrorAndOutputPort("sess1", src_ports, dst_ports, "10.20.120.240", 1);
     return true;
 }
 
 BOOST_FIXTURE_TEST_CASE( verify_getport, SpanRendererFixture ) {
     BOOST_CHECK_EQUAL(true,verifyCreateDestroy(spr, conn));
-}
-
-BOOST_FIXTURE_TEST_CASE( verify_add_remote_port, SpanRendererFixture ) {
-    spr->addErspanPort(ERSPAN_PORT_PREFIX, "3.3.3.3", 2);
-    spr->deleteErspanPort(ERSPAN_PORT_PREFIX);
 }
 
 BOOST_FIXTURE_TEST_CASE( delete_session, SpanRendererFixture ) {

--- a/agent-ovs/ovs/test/include/MockRpcConnection.h
+++ b/agent-ovs/ovs/test/include/MockRpcConnection.h
@@ -11,6 +11,7 @@
 #define OPFLEX_MOCKRPCCONNECTION_H
 
 #include "OvsdbConnection.h"
+#include <opflex/rpc/JsonRpcMessage.h>
 
 namespace opflexagent {
 
@@ -47,6 +48,24 @@ public:
      * destructor
      */
     virtual ~MockRpcConnection() {}
+
+    /**
+     * mocked implementation of send message that emulates what the
+     * real implement does
+     *
+     * @param message the message to send.  Ownership of the object
+     * passes to the connection.
+     * @param sync if true, send the message synchronously.  This can
+     * only be called if it's called from the uv loop thread.
+     */
+    virtual void sendMessage(JsonRpcMessage* message, bool sync = false) {
+        boost::scoped_ptr<JsonRpcMessage> messagep(message);
+        opflex::jsonrpc::PayloadWrapper wrapper(message);
+        yajr::internal::GenericStringQueue<rapidjson::UTF8<> > sq;
+        ::yajr::rpc::SendHandler writer;
+        writer.Reset(sq);
+        wrapper(writer);
+    }
 };
 
 }


### PR DESCRIPTION
Create/delete mirror and associated output port in same call

Mock sendMessage behavior a little better to increase UT coverage
Remove some dead code related to removed sync OVSDB calls

Signed-off-by: Tom Flynn <tom.flynn@gmail.com>