### PR TITLE
Fix for flaky tests in agent-ovs

### DIFF
--- a/agent-ovs/Makefile.am
+++ b/agent-ovs/Makefile.am
@@ -457,7 +457,8 @@ if RENDERER_OVS
 	ovs/test/TableState_test.cpp \
 	ovs/test/SpanRenderer_test.cpp \
 	ovs/test/NetFlowRenderer_test.cpp \
-	ovs/test/PacketDecoder_test.cpp
+	ovs/test/PacketDecoder_test.cpp \
+	ovs/test/TableDropStatsManager_test.cpp
 endif
 
 opflex_server_CXXFLAGS = \

--- a/agent-ovs/Makefile.am
+++ b/agent-ovs/Makefile.am
@@ -456,6 +456,7 @@ if RENDERER_OVS
 	ovs/test/SecGrpStatsManager_test.cpp \
 	ovs/test/TableState_test.cpp \
 	ovs/test/SpanRenderer_test.cpp \
+	ovs/test/NetFlowRenderer_test.cpp \
 	ovs/test/PacketDecoder_test.cpp
 endif
 

--- a/agent-ovs/Makefile.am
+++ b/agent-ovs/Makefile.am
@@ -632,7 +632,9 @@ endif
 check-integration: integration_test
 	$(top_builddir)/integration_test
 doc/html: $(model_include_HEADERS) $(noinst_HEADERS) $(libopflex_agent_la_include_HEADERS) $(agent_test_include_HEADERS) doc/Doxyfile
+if HAVE_DOXYGEN
 	cd doc && ${DOXYGEN} Doxyfile
+endif
 doc: doc/html
 
 clean-doc:

--- a/agent-ovs/Makefile.am
+++ b/agent-ovs/Makefile.am
@@ -144,7 +144,7 @@ noinst_HEADERS = \
 	ovs/include/InterfaceStatsManager.h \
 	ovs/include/PolicyStatsManager.h \
 	ovs/include/ContractStatsManager.h \
-	ovs/include/PodSvcStatsManager.h \
+	ovs/include/ServiceStatsManager.h \
 	ovs/include/SecGrpStatsManager.h \
 	ovs/include/TableDropStatsManager.h \
 	ovs/include/CtZoneManager.h \
@@ -246,7 +246,7 @@ if RENDERER_OVS
 	ovs/PolicyStatsManager.cpp \
 	ovs/InterfaceStatsManager.cpp \
 	ovs/ContractStatsManager.cpp \
-	ovs/PodSvcStatsManager.cpp \
+	ovs/ServiceStatsManager.cpp \
 	ovs/SecGrpStatsManager.cpp \
 	ovs/TableDropStatsManager.cpp \
 	ovs/RangeMask.cpp \
@@ -452,7 +452,7 @@ if RENDERER_OVS
 	ovs/test/Packets_test.cpp \
 	ovs/test/InterfaceStatsManager_test.cpp \
 	ovs/test/ContractStatsManager_test.cpp \
-	ovs/test/PodSvcStatsManager_test.cpp \
+	ovs/test/ServiceStatsManager_test.cpp \
 	ovs/test/SecGrpStatsManager_test.cpp \
 	ovs/test/TableState_test.cpp \
 	ovs/test/SpanRenderer_test.cpp \

--- a/agent-ovs/cmd/opflex_agent.cpp
+++ b/agent-ovs/cmd/opflex_agent.cpp
@@ -152,6 +152,7 @@ public:
             return;
 
         {
+            LOG(INFO) << "Triggering reload because of change to " << filePath;
             std::unique_lock<std::mutex> lock(mutex);
             need_reload = true;
         }

--- a/agent-ovs/lib/Agent.cpp
+++ b/agent-ovs/lib/Agent.cpp
@@ -71,6 +71,7 @@ Agent::Agent(OFFramework& framework_, const LogParams& _logParams)
       prometheusEnabled(true),
       prometheusExposeLocalHostOnly(false),
       prometheusExposeEpSvcNan(false),
+      behaviorL34FlowsWithoutSubnet(false),
       logParams(_logParams) {
 #else
 Agent::Agent(OFFramework& framework_, const LogParams& _logParams)
@@ -84,6 +85,7 @@ Agent::Agent(OFFramework& framework_, const LogParams& _logParams)
       contractInterval(0), securityGroupInterval(0), interfaceInterval(0),
       spanManager(framework, agent_io),
       netflowManager(framework,agent_io),
+      behaviorL34FlowsWithoutSubnet(false),
       logParams(_logParams) {
 #endif
     std::random_device rng;
@@ -194,6 +196,7 @@ void Agent::setProperties(const boost::property_tree::ptree& properties) {
     static const std::string OPFLEX_PRR_INTERVAL("opflex.timers.prr");
     static const std::string OPFLEX_HANDSHAKE("opflex.timers.handshake-timeout");
     static const std::string DISABLED_FEATURES("feature.disabled");
+    static const std::string BEHAVIOR_L34FLOWS_WITHOUT_SUBNET("behavior.l34flows-without-subnet");
 
     // set feature flags to true
     clearFeatureFlags();
@@ -252,6 +255,12 @@ void Agent::setProperties(const boost::property_tree::ptree& properties) {
     if (disabledFeatures) {
         for (const ptree::value_type &v : disabledFeatures.get())
             disabledFeaturesSet.insert(v.second.data());
+    }
+
+    optional<bool> behaviorAddL34FlowsWithoutSubnet =
+        properties.get_optional<bool>(BEHAVIOR_L34FLOWS_WITHOUT_SUBNET);
+    if (behaviorAddL34FlowsWithoutSubnet) {
+        behaviorL34FlowsWithoutSubnet = behaviorAddL34FlowsWithoutSubnet.get();
     }
 
 #ifdef HAVE_PROMETHEUS_SUPPORT

--- a/agent-ovs/lib/Agent.cpp
+++ b/agent-ovs/lib/Agent.cpp
@@ -191,6 +191,7 @@ void Agent::setProperties(const boost::property_tree::ptree& properties) {
     static const std::string OPFLEX_STATS_SECGRP_SETTING("opflex.statistics.security-group.enabled");
     static const std::string OPFLEX_STATS_SECGRP_INTERVAL("opflex.statistics.security-group.interval");
     static const std::string OPFLEX_PRR_INTERVAL("opflex.timers.prr");
+    static const std::string OPFLEX_HANDSHAKE("opflex.timers.handshake-timeout");
     static const std::string DISABLED_FEATURES("feature.disabled");
 
     // set feature flags to true
@@ -457,6 +458,13 @@ void Agent::setProperties(const boost::property_tree::ptree& properties) {
         }
     }
     LOG(INFO) << "prr timer set to " << prr_timer << " secs";
+
+    boost::optional<uint32_t> handshakeOpt = properties.get_optional<uint32_t>(OPFLEX_HANDSHAKE);
+    if (handshakeOpt) {
+        peerHandshakeTimeout = handshakeOpt.get();
+        LOG(INFO) << "peer handshake timeout set to " << peerHandshakeTimeout << " ms";
+    }
+
     LOG(INFO) << "Agent mode set to " <<
        ((this->rendererFwdMode == opflex::ofcore::OFConstants::TRANSPORT_MODE)?
         "transport-mode" : "stitched-mode");
@@ -521,6 +529,7 @@ void Agent::applyProperties() {
     }
      
     framework.setPrrTimerDuration(prr_timer);
+    framework.setHandshakeTimeout(peerHandshakeTimeout);
 }
 
 void Agent::start() {

--- a/agent-ovs/lib/Agent.cpp
+++ b/agent-ovs/lib/Agent.cpp
@@ -35,7 +35,6 @@
 #include <opflexagent/Renderer.h>
 #include <opflexagent/SimStats.h>
 
-#include <unordered_map>
 #include <cstdlib>
 #include <mutex>
 #include <condition_variable>
@@ -465,8 +464,8 @@ void Agent::setProperties(const boost::property_tree::ptree& properties) {
         if (prr_timer < 15) {
            prr_timer = 15;  /* min is 15 seconds */
         }
+        LOG(INFO) << "prr timer set to " << prr_timer << " secs";
     }
-    LOG(INFO) << "prr timer set to " << prr_timer << " secs";
 
     boost::optional<uint32_t> handshakeOpt = properties.get_optional<uint32_t>(OPFLEX_HANDSHAKE);
     if (handshakeOpt) {

--- a/agent-ovs/lib/AgentLogHandler.cpp
+++ b/agent-ovs/lib/AgentLogHandler.cpp
@@ -41,6 +41,8 @@ void AgentLogHandler::handleMessage(const std::string& file,
     opflexagent::LogLevel agentLevel = opflexagent::INFO;
     switch (level) {
     case OFLogHandler::TRACE:
+        agentLevel = opflexagent::TRACE;
+        break;
     case OFLogHandler::DEBUG7:
     case OFLogHandler::DEBUG6:
     case OFLogHandler::DEBUG5:

--- a/agent-ovs/lib/FSEndpointSource.cpp
+++ b/agent-ovs/lib/FSEndpointSource.cpp
@@ -115,6 +115,7 @@ void FSEndpointSource::updated(const fs::path& filePath) {
     static const std::string SNAT_UUIDS("snat-uuids");
     static const std::string ACTIVE_ACTIVE_AAP("active-active-aap");
     static const std::string EP_DISABLE_ADV("disable-adv");
+    static const std::string EP_ACCESS_ALLOW_UNTAGGED("access-allow-untagged");
 
     try {
         using boost::property_tree::ptree;
@@ -447,6 +448,11 @@ void FSEndpointSource::updated(const fs::path& filePath) {
             properties.get_optional<bool>(EP_DISABLE_ADV);
         if (disableAdv)
             newep.setDisableAdv(disableAdv.get());
+
+        optional<bool> accessAllowUntagged =
+            properties.get_optional<bool>(EP_ACCESS_ALLOW_UNTAGGED);
+        if (accessAllowUntagged)
+            newep.setAccessAllowUntagged(accessAllowUntagged.get());
 
         optional<bool> provider_vlan =
                 properties.get_optional<bool>(EP_PROVIDER_VLAN_FLAG);

--- a/agent-ovs/lib/FSExternalEndpointSource.cpp
+++ b/agent-ovs/lib/FSExternalEndpointSource.cpp
@@ -90,6 +90,7 @@ void FSExternalEndpointSource::updated(const fs::path& filePath) {
     static const std::string DHCP_T2("t2");
     static const std::string DHCP_PREFERRED_LIFETIME("preferred-lifetime");
     static const std::string DHCP_VALID_LIFETIME("valid-lifetime");
+    static const std::string EP_ACCESS_ALLOW_UNTAGGED("access-allow-untagged");
 
     try {
         using boost::property_tree::ptree;
@@ -301,6 +302,11 @@ void FSExternalEndpointSource::updated(const fs::path& filePath) {
 
             newep.setDHCPv6Config(c);
         }
+
+        optional<bool> accessAllowUntagged =
+            properties.get_optional<bool>(EP_ACCESS_ALLOW_UNTAGGED);
+        if (accessAllowUntagged)
+            newep.setAccessAllowUntagged(accessAllowUntagged.get());
 
         ep_map_t::const_iterator it = knownEps.find(pathstr);
         if (it != knownEps.end()) {

--- a/agent-ovs/lib/FSServiceSource.cpp
+++ b/agent-ovs/lib/FSServiceSource.cpp
@@ -159,10 +159,11 @@ void FSServiceSource::updated(const fs::path& filePath) {
         // named "scope" with either "cluster" or "ext" or "nodeport" or something else.
         const auto& uuid = newserv.getUUID();
         if ((uuid.size() > sizeof("-external"))
-                && boost::algorithm::ends_with(uuid, "-external"))
+                && boost::algorithm::ends_with(uuid, "-external")) {
             newserv.addAttribute("scope", "ext");
-        else
+        } else {
             newserv.addAttribute("scope", "cluster");
+        }
 
         optional<ptree&> sms =
             properties.get_child_optional(SERVICE_MAPPING);

--- a/agent-ovs/lib/IdGenerator.cpp
+++ b/agent-ovs/lib/IdGenerator.cpp
@@ -50,7 +50,14 @@ uint32_t IdGenerator::getIdNoAlloc (const string& nmspc, const string& str) {
         return -1;
     }
 
+    // If its already in erasedIds, then the id got deleted
+    // either the id will get deleted from "ids" during garbage collection
+    // or if new alloc happens, then the id will get freed from erasedIds
     IdMap& idmap = nitr->second;
+    IdMap::Str2EIdMap::iterator eit = idmap.erasedIds.find(str);
+    if (eit != idmap.erasedIds.end())
+        return -1;
+
     IdMap::Str2IdMap::const_iterator it = idmap.ids.find(str);
     if (it == idmap.ids.end()) {
         return -1;

--- a/agent-ovs/lib/NetFlowManager.cpp
+++ b/agent-ovs/lib/NetFlowManager.cpp
@@ -52,8 +52,7 @@ namespace opflexagent {
 
     NetFlowManager::NetFlowUniverseListener::~NetFlowUniverseListener() {}
 
-    void NetFlowManager::NetFlowUniverseListener::objectUpdated(class_id_t classId,
-                                                          const URI &uri) {
+    void NetFlowManager::NetFlowUniverseListener::objectUpdated(class_id_t classId, const URI &uri) {
         LOG(DEBUG) << "update on NetFlowUniverseListener URI " << uri;
         lock_guard<recursive_mutex> guard(opflexagent::NetFlowManager::exporter_mutex);
         // updates on parent container for exporterconfig are received for
@@ -155,6 +154,11 @@ namespace opflexagent {
         } else {
             return itr->second;
         }
+    }
+
+    bool NetFlowManager::anyExporters() const {
+        lock_guard<recursive_mutex> guard(exporter_mutex);
+        return !exporter_map.empty();
     }
 
     void NetFlowManager::NetFlowUniverseListener::processExporterConfig(const shared_ptr<modelgbp::netflow::ExporterConfig>& exporterconfig) {

--- a/agent-ovs/lib/Network.cpp
+++ b/agent-ovs/lib/Network.cpp
@@ -141,7 +141,8 @@ bool is_link_local(const boost::asio::ip::address& addr) {
     return false;
 }
 
-bool cidr_from_string(const std::string& cidrStr, cidr_t& cidr) {
+bool cidr_from_string(const std::string& cidrStr, cidr_t& cidr,
+                      bool do_mask_addr /*=true */) {
     std::vector<std::string> parts;
     uint8_t prefixLen = 32;
 
@@ -159,7 +160,8 @@ bool cidr_from_string(const std::string& cidrStr, cidr_t& cidr) {
         } catch (const boost::bad_lexical_cast& ex) {
             return false;
         }
-        baseIp = mask_address(baseIp, prefixLen);
+        if (do_mask_addr)
+            baseIp = mask_address(baseIp, prefixLen);
     } else if (baseIp.is_v6()) {
         prefixLen = 128;
     }

--- a/agent-ovs/lib/PolicyManager.cpp
+++ b/agent-ovs/lib/PolicyManager.cpp
@@ -1848,8 +1848,10 @@ bool PolicyManager::updateExternalInterface(const URI& uri, bool &toRemove) {
     optional<URI> extDomURI, extBDURI, extRDURI, pfxURI;
     optional<shared_ptr<RoutingDomain>> newRD =
         boost::make_optional<shared_ptr<RoutingDomain>>(false, nullptr);
-    optional<shared_ptr<L3ExternalDomain>> newExtDom;
-    optional<shared_ptr<ExternalL3BridgeDomain>> newExtBD;
+    optional<shared_ptr<L3ExternalDomain>> newExtDom =
+        boost::make_optional<shared_ptr<L3ExternalDomain>>(false, nullptr);
+    optional<shared_ptr<ExternalL3BridgeDomain>> newExtBD =
+        boost::make_optional<shared_ptr<ExternalL3BridgeDomain>>(false, nullptr);
     optional<shared_ptr<InstContext>> newRDContext, newBDContext;
     subnet_map_t newsmap;
     ExternalInterfaceState  &eis = ext_int_map[uri];

--- a/agent-ovs/lib/PolicyManager.cpp
+++ b/agent-ovs/lib/PolicyManager.cpp
@@ -238,7 +238,7 @@ void PolicyManager::notifyConfig(const URI& configURI) {
 optional<shared_ptr<modelgbp::gbp::RoutingDomain> >
 PolicyManager::getRDForGroup(const opflex::modb::URI& eg) {
     lock_guard<mutex> guard(state_mutex);
-    group_map_t::iterator it = group_map.find(eg);
+    group_map_t::const_iterator it = group_map.find(eg);
     if (it == group_map.end()) return boost::none;
     return it->second.routingDomain;
 }
@@ -246,7 +246,7 @@ PolicyManager::getRDForGroup(const opflex::modb::URI& eg) {
 optional<shared_ptr<modelgbp::gbp::RoutingDomain> >
 PolicyManager::getRDForL3ExtNet(const opflex::modb::URI& l3n) {
     lock_guard<mutex> guard(state_mutex);
-    l3n_map_t::iterator it = l3n_map.find(l3n);
+    l3n_map_t::const_iterator it = l3n_map.find(l3n);
     if (it == l3n_map.end()) return boost::none;
     return it->second.routingDomain;
 }
@@ -254,7 +254,7 @@ PolicyManager::getRDForL3ExtNet(const opflex::modb::URI& l3n) {
 optional<shared_ptr<modelgbp::gbp::BridgeDomain> >
 PolicyManager::getBDForGroup(const opflex::modb::URI& eg) {
     lock_guard<mutex> guard(state_mutex);
-    group_map_t::iterator it = group_map.find(eg);
+    group_map_t::const_iterator it = group_map.find(eg);
     if (it == group_map.end()) return boost::none;
     return it->second.bridgeDomain;
 }
@@ -262,7 +262,7 @@ PolicyManager::getBDForGroup(const opflex::modb::URI& eg) {
 optional<shared_ptr<modelgbp::gbp::FloodDomain> >
 PolicyManager::getFDForGroup(const opflex::modb::URI& eg) {
     lock_guard<mutex> guard(state_mutex);
-    group_map_t::iterator it = group_map.find(eg);
+    group_map_t::const_iterator it = group_map.find(eg);
     if (it == group_map.end()) return boost::none;
     return it->second.floodDomain;
 }
@@ -270,7 +270,7 @@ PolicyManager::getFDForGroup(const opflex::modb::URI& eg) {
 optional<shared_ptr<modelgbp::gbpe::FloodContext> >
 PolicyManager::getFloodContextForGroup(const opflex::modb::URI& eg) {
     lock_guard<mutex> guard(state_mutex);
-    group_map_t::iterator it = group_map.find(eg);
+    group_map_t::const_iterator it = group_map.find(eg);
     if (it == group_map.end()) return boost::none;
     return it->second.floodContext;
 }
@@ -278,7 +278,7 @@ PolicyManager::getFloodContextForGroup(const opflex::modb::URI& eg) {
 void PolicyManager::getSubnetsForGroup(const opflex::modb::URI& eg,
                                        /* out */ subnet_vector_t& subnets) {
     lock_guard<mutex> guard(state_mutex);
-    group_map_t::iterator it = group_map.find(eg);
+    group_map_t::const_iterator it = group_map.find(eg);
     if (it == group_map.end()) return;
     for (const subnet_map_t::value_type& v :
              it->second.subnet_map) {
@@ -290,7 +290,7 @@ optional<shared_ptr<modelgbp::gbp::Subnet> >
 PolicyManager::findSubnetForEp(const opflex::modb::URI& eg,
                                const address& ip) {
     lock_guard<mutex> guard(state_mutex);
-    group_map_t::iterator it = group_map.find(eg);
+    group_map_t::const_iterator it = group_map.find(eg);
     if (it == group_map.end()) return boost::none;
     boost::system::error_code ec;
     for (const subnet_map_t::value_type& v :
@@ -521,7 +521,7 @@ bool PolicyManager::updateEPGDomains(const URI& egURI, bool& toRemove) {
 boost::optional<uint32_t>
 PolicyManager::getVnidForGroup(const opflex::modb::URI& eg) {
     lock_guard<mutex> guard(state_mutex);
-    group_map_t::iterator it = group_map.find(eg);
+    group_map_t::const_iterator it = group_map.find(eg);
     return it != group_map.end() && it->second.instContext &&
         it->second.instContext.get()->getEncapId()
         ? it->second.instContext.get()->getEncapId().get()
@@ -529,57 +529,19 @@ PolicyManager::getVnidForGroup(const opflex::modb::URI& eg) {
 }
 
 boost::optional<uint32_t>
-PolicyManager::getBDVnidForGroup(const opflex::modb::URI& eg) {
-    lock_guard<mutex> guard(state_mutex);
-    group_map_t::iterator it = group_map.find(eg);
-    return it != group_map.end() && it->second.instBDContext &&
-        it->second.instBDContext.get()->getEncapId()
-        ? it->second.instBDContext.get()->getEncapId().get()
-        : optional<uint32_t>();
-}
-
-boost::optional<uint32_t>
-PolicyManager::getRDVnidForGroup(const opflex::modb::URI& eg) {
-    lock_guard<mutex> guard(state_mutex);
-    group_map_t::iterator it = group_map.find(eg);
-    return it != group_map.end() && it->second.instRDContext &&
-        it->second.instRDContext.get()->getEncapId()
-        ? it->second.instRDContext.get()->getEncapId().get()
-        : optional<uint32_t>();
-}
-
-boost::optional<uint32_t>
 PolicyManager::getBDVnidForExternalInterface(const opflex::modb::URI& eg) {
     lock_guard<mutex> guard(state_mutex);
-    ext_int_map_t::iterator it = ext_int_map.find(eg);
+    ext_int_map_t::const_iterator it = ext_int_map.find(eg);
     return it != ext_int_map.end() && it->second.instContext &&
     it->second.instContext.get()->getEncapId()
     ? it->second.instContext.get()->getEncapId().get()
     : optional<uint32_t>();
 }
 
-boost::optional<shared_ptr<modelgbp::gbp::ExternalL3BridgeDomain>>
-PolicyManager::getBDForExternalInterface(const opflex::modb::URI& eg) {
-    lock_guard<mutex> guard(state_mutex);
-    ext_int_map_t::iterator it = ext_int_map.find(eg);
-    return it != ext_int_map.end() ? it->second.bridgeDomain
-    : optional<shared_ptr<modelgbp::gbp::ExternalL3BridgeDomain>>();
-}
-
-boost::optional<uint32_t>
-PolicyManager::getRDVnidForExternalInterface(const opflex::modb::URI& eg) {
-    lock_guard<mutex> guard(state_mutex);
-    ext_int_map_t::iterator it = ext_int_map.find(eg);
-    return it != ext_int_map.end() && it->second.instRDContext &&
-    it->second.instRDContext.get()->getEncapId()
-    ? it->second.instRDContext.get()->getEncapId().get()
-    : optional<uint32_t>();
-}
-
 boost::optional<shared_ptr<modelgbp::gbp::RoutingDomain>>
 PolicyManager::getRDForExternalInterface(const opflex::modb::URI& eg) {
     lock_guard<mutex> guard(state_mutex);
-    ext_int_map_t::iterator it = ext_int_map.find(eg);
+    ext_int_map_t::const_iterator it = ext_int_map.find(eg);
     return it != ext_int_map.end() ? it->second.routingDomain
     : optional<shared_ptr<modelgbp::gbp::RoutingDomain>>();
 }
@@ -587,7 +549,7 @@ PolicyManager::getRDForExternalInterface(const opflex::modb::URI& eg) {
 void PolicyManager::getSubnetsForExternalInterface(const opflex::modb::URI& eg,
                                          /* out */ subnet_vector_t& subnets) {
     lock_guard<mutex> guard(state_mutex);
-    ext_int_map_t::iterator it = ext_int_map.find(eg);
+    ext_int_map_t::const_iterator it = ext_int_map.find(eg);
     if (it == ext_int_map.end()) return;
     for (const subnet_map_t::value_type& v :
          it->second.subnet_map) {
@@ -598,51 +560,23 @@ void PolicyManager::getSubnetsForExternalInterface(const opflex::modb::URI& eg,
 boost::optional<opflex::modb::URI>
 PolicyManager::getGroupForVnid(uint32_t vnid) {
     lock_guard<mutex> guard(state_mutex);
-    vnid_map_t::iterator it = vnid_map.find(vnid);
+    vnid_map_t::const_iterator it = vnid_map.find(vnid);
     return it != vnid_map.end() ? optional<URI>(it->second) : boost::none;
 }
 
 optional<string> PolicyManager::getMulticastIPForGroup(const URI& eg) {
     lock_guard<mutex> guard(state_mutex);
-    group_map_t::iterator it = group_map.find(eg);
+    group_map_t::const_iterator it = group_map.find(eg);
     return it != group_map.end() && it->second.instContext &&
         it->second.instContext.get()->getMulticastGroupIP()
         ? it->second.instContext.get()->getMulticastGroupIP().get()
         : optional<string>();
 }
 
-optional<string> PolicyManager::getBDMulticastIPForGroup(const URI& eg) {
-    lock_guard<mutex> guard(state_mutex);
-    group_map_t::iterator it = group_map.find(eg);
-    return it != group_map.end() && it->second.instBDContext &&
-        it->second.instBDContext.get()->getMulticastGroupIP()
-        ? it->second.instBDContext.get()->getMulticastGroupIP().get()
-        : optional<string>();
-}
-
-optional<string> PolicyManager::getBDMulticastIPForExternalInterface(
-const URI& eg) {
-    lock_guard<mutex> guard(state_mutex);
-    ext_int_map_t::iterator it = ext_int_map.find(eg);
-    return it != ext_int_map.end() && it->second.instContext &&
-    it->second.instContext.get()->getMulticastGroupIP()
-    ? it->second.instContext.get()->getMulticastGroupIP().get()
-    : optional<string>();
-}
-
-optional<string> PolicyManager::getRDMulticastIPForGroup(const URI& eg) {
-    lock_guard<mutex> guard(state_mutex);
-    group_map_t::iterator it = group_map.find(eg);
-    return it != group_map.end() && it->second.instRDContext &&
-        it->second.instRDContext.get()->getMulticastGroupIP()
-        ? it->second.instRDContext.get()->getMulticastGroupIP().get()
-        : optional<string>();
-}
-
 optional<uint32_t> PolicyManager::getSclassForGroup(const opflex::modb::URI& eg)
 {
     lock_guard<mutex> guard(state_mutex);
-    group_map_t::iterator it = group_map.find(eg);
+    group_map_t::const_iterator it = group_map.find(eg);
     return it != group_map.end() && it->second.instContext
         ? it->second.instContext.get()->getClassid()
         : optional<uint32_t>();
@@ -651,7 +585,7 @@ optional<uint32_t> PolicyManager::getSclassForGroup(const opflex::modb::URI& eg)
 optional<uint32_t> PolicyManager::getSclassForExternalNet(
 const opflex::modb::URI& ei) {
     lock_guard<mutex> guard(state_mutex);
-    l3n_map_t::iterator it = l3n_map.find(ei);
+    l3n_map_t::const_iterator it = l3n_map.find(ei);
     return it != l3n_map.end() && it->second.instContext
     ? it->second.instContext.get()->getClassid()
     : optional<uint32_t>();
@@ -660,38 +594,10 @@ const opflex::modb::URI& ei) {
 optional<uint32_t> PolicyManager::getSclassForExternalInterface(
 const opflex::modb::URI& eg) {
     lock_guard<mutex> guard(state_mutex);
-    ext_int_map_t::iterator it = ext_int_map.find(eg);
+    ext_int_map_t::const_iterator it = ext_int_map.find(eg);
     return it != ext_int_map.end() && it->second.instContext
     ? it->second.instContext.get()->getClassid()
     : optional<uint32_t>();
-}
-
-optional<std::shared_ptr<modelgbp::gbp::L3ExternalDomain>>
-PolicyManager::getExternalDomainForExternalInterface(
-const opflex::modb::URI& eg) {
-    lock_guard<mutex> guard(state_mutex);
-    ext_int_map_t::iterator it = ext_int_map.find(eg);
-    return it != ext_int_map.end() && it->second.extDomain
-    ? it->second.extDomain
-    : optional<std::shared_ptr<modelgbp::gbp::L3ExternalDomain>>();
-}
-
-optional<shared_ptr<modelgbp::gbpe::EndpointRetention>>
-PolicyManager::getL2EPRetentionPolicyForGroup(const opflex::modb::URI& eg) {
-    lock_guard<mutex> guard(state_mutex);
-    group_map_t::iterator it = group_map.find(eg);
-    return it != group_map.end() && it->second.l2EpRetPolicy
-        ? it->second.l2EpRetPolicy
-        : optional<std::shared_ptr<modelgbp::gbpe::EndpointRetention>>();
-}
-
-optional<shared_ptr<modelgbp::gbpe::EndpointRetention>>
-PolicyManager::getL3EPRetentionPolicyForGroup(const opflex::modb::URI& eg) {
-    lock_guard<mutex> guard(state_mutex);
-    group_map_t::iterator it = group_map.find(eg);
-    return it != group_map.end() && it->second.l3EpRetPolicy
-        ? it->second.l3EpRetPolicy
-        : optional<std::shared_ptr<modelgbp::gbpe::EndpointRetention>>();
 }
 
 bool PolicyManager::groupExists(const opflex::modb::URI& eg) {
@@ -715,7 +621,7 @@ void PolicyManager::getRoutingDomains(uri_set_t& rdURIs) {
 
 bool PolicyManager::removeContractIfRequired(const URI& contractURI) {
     using namespace modelgbp::gbp;
-    contract_map_t::iterator itr = contractMap.find(contractURI);
+    auto itr = contractMap.find(contractURI);
     optional<shared_ptr<Contract> > contract =
         Contract::resolve(framework, contractURI);
     if (!contract && itr != contractMap.end() &&
@@ -920,7 +826,7 @@ bool PolicyManager::getPolicyDestGroup(const URI& redirURI,
                              uint8_t &hashParam_, uint8_t &hashOpt_)
 {
     lock_guard<mutex> guard(state_mutex);
-    redir_dst_grp_map_t::iterator it = redirGrpMap.find(redirURI);
+    redir_dst_grp_map_t::const_iterator it = redirGrpMap.find(redirURI);
     if(it == redirGrpMap.end()){
         return false;
     }
@@ -999,8 +905,7 @@ void PolicyManager::updateRedirectDestGroup(const URI& uri,
         newRedirDests.push_back(
             make_shared<PolicyRedirectDest>(redirDest,addr,
                                             redirDest->getMac().get(),
-                                            rd.get(), bd.get(),
-                                            rdInst.get(), bdInst.get()));
+                                            rd.get(), bd.get()));
     }
     redir_dest_list_t::const_iterator li = redirState.redirDstList.begin();
     redir_dest_list_t::const_iterator ri = newRedirDests.begin();
@@ -1029,8 +934,7 @@ void PolicyManager::updateRedirectDestGroup(const URI& uri,
 }
 
 void PolicyManager::updateRedirectDestGroups(uri_set_t &notifyGroup) {
-    for (PolicyManager::redir_dst_grp_map_t::iterator itr =
-         redirGrpMap.begin(); itr != redirGrpMap.end(); itr++) {
+    for (auto itr = redirGrpMap.begin(); itr != redirGrpMap.end(); itr++) {
         updateRedirectDestGroup(itr->first, notifyGroup);
     }
 }
@@ -1327,8 +1231,7 @@ void PolicyManager::updateContracts() {
 
     /* recompute the rules for all contracts if a policy
        object changed */
-    for (PolicyManager::contract_map_t::iterator itr =
-             contractMap.begin();
+    for (auto itr = contractMap.begin();
          itr != contractMap.end();) {
 
         bool notFound = false;
@@ -1369,8 +1272,7 @@ void PolicyManager::updateSecGrps() {
     unique_lock<mutex> guard(state_mutex);
 
     uri_set_t toNotify;
-    PolicyManager::secgrp_map_t::iterator it =
-        secGrpMap.begin();
+    auto it = secGrpMap.begin();
     while (it != secGrpMap.end()) {
         bool notfound = false;
         if (updateSecGrpRules(it->first, notfound)) {
@@ -1594,8 +1496,7 @@ void PolicyManager::updateL3Nets(const opflex::modb::URI& rdURI,
             L3NetworkState& l3s = l3n_map[net->getURI()];
             l3s.extNet = net;
             if (l3s.routingDomain && l3s.natEpg) {
-                uri_ref_map_t::iterator it =
-                    nat_epg_l3_ext.find(l3s.natEpg.get());
+                auto it = nat_epg_l3_ext.find(l3s.natEpg.get());
                 if (it != nat_epg_l3_ext.end()) {
                     it->second.erase(net->getURI());
                     if (it->second.empty())
@@ -1747,11 +1648,10 @@ void PolicyManager::updateL3Nets(const opflex::modb::URI& rdURI,
 
         for (const URI& net : rds.extNets) {
             if (newNets.find(net) == newNets.end()) {
-                l3n_map_t::iterator lit = l3n_map.find(net);
+                l3n_map_t::const_iterator lit = l3n_map.find(net);
                 if (lit != l3n_map.end()) {
                     if (lit->second.natEpg) {
-                        uri_ref_map_t::iterator git =
-                            nat_epg_l3_ext.find(lit->second.natEpg.get());
+                        auto git = nat_epg_l3_ext.find(lit->second.natEpg.get());
                         if (git != nat_epg_l3_ext.end()) {
                             git->second.erase(net);
                             if (git->second.empty())
@@ -2014,7 +1914,6 @@ bool PolicyManager::updateExternalInterface(const URI& uri, bool &toRemove) {
        newsmap != eis.subnet_map) {
         updated = true;
     }
-    eis.extInterface = extIntf;
     eis.extDomain = newExtDom;
     eis.routingDomain = newRD;
     eis.bridgeDomain = newExtBD;
@@ -2037,8 +1936,7 @@ void PolicyManager::updateDomain(class_id_t class_id, const URI& uri) {
     if (class_id == modelgbp::gbp::ExternalInterface::CLASS_ID) {
         ext_int_map[uri];
     }
-    for (PolicyManager::group_map_t::iterator itr = group_map.begin();
-         itr != group_map.end(); ) {
+    for (auto itr = group_map.begin(); itr != group_map.end(); ) {
         bool toRemove = false;
         if (updateEPGDomains(itr->first, toRemove)) {
             notifyGroups.insert(itr->first);
@@ -2047,17 +1945,17 @@ void PolicyManager::updateDomain(class_id_t class_id, const URI& uri) {
     }
     // Determine routing-domains that may be affected by changes to NAT EPG
     for (const URI& u : notifyGroups) {
-        uri_ref_map_t::iterator it = nat_epg_l3_ext.find(u);
+        uri_ref_map_t::const_iterator it = nat_epg_l3_ext.find(u);
         if (it != nat_epg_l3_ext.end()) {
             for (const URI& extNet : it->second) {
-                l3n_map_t::iterator it2 = l3n_map.find(extNet);
+                l3n_map_t::const_iterator it2 = l3n_map.find(extNet);
                 if (it2 != l3n_map.end()) {
                     notifyRds.insert(it2->second.routingDomain.get()->getURI());
                 }
             }
         }
     }
-    for (PolicyManager::ext_int_map_t::iterator itr = ext_int_map.begin();
+    for (auto itr = ext_int_map.begin();
          itr != ext_int_map.end(); ) {
         bool toRemove = false;
         if (updateExternalInterface(itr->first, toRemove)) {
@@ -2144,14 +2042,14 @@ bool PolicyManager::getRoute(
     are_nhs_remote = true;
     lock_guard<mutex> guard(state_mutex);
     if(route_type == modelgbp::gbp::StaticRoute::CLASS_ID) {
-        route_map_t::iterator iter = static_route_map.find(uri);
+        route_map_t::const_iterator iter = static_route_map.find(uri);
         if(iter == static_route_map.end()){
             return false;
         }
         iter->second->getRoute(rd_, rdInst_, addr_, pfx_len, nhList);
         return true;
     } else if(route_type == modelgbp::gbp::RemoteRoute::CLASS_ID) {
-        route_map_t::iterator iter = remote_route_map.find(uri);
+        route_map_t::const_iterator iter = remote_route_map.find(uri);
         if(iter == remote_route_map.end()){
             return false;
         }
@@ -2166,14 +2064,14 @@ bool PolicyManager::getRoute(
         auto lrtToPrt = localRoute.get()->resolveEpdrLocalRouteToPrtRSrc();
         if(lrtToPrt) {
             auto extNetURI = lrtToPrt.get()->getTargetURI().get();
-            l3n_map_t::iterator it = l3n_map.find(extNetURI);
+            l3n_map_t::const_iterator it = l3n_map.find(extNetURI);
             if(it != l3n_map.end() && it->second.instContext) {
                 sclass = it->second.instContext.get()->getClassid();
             }
         }
         if(lrtToRrt) {
             auto remoteRtURI = lrtToRrt.get()->getTargetURI().get();
-            route_map_t::iterator iter = remote_route_map.find(remoteRtURI);
+            route_map_t::const_iterator iter = remote_route_map.find(remoteRtURI);
             if(iter == remote_route_map.end()){
                 return true;
             }
@@ -2197,7 +2095,7 @@ bool PolicyManager::getRoute(
             list<boost::asio::ip::address> newNhList;
             for(auto const &stRoute: lrtToSrt) {
                 auto stRouteURI = stRoute->getTargetURI().get();
-                route_map_t::iterator iter = static_route_map.find(stRouteURI);
+                route_map_t::const_iterator iter = static_route_map.find(stRouteURI);
                 if(iter == static_route_map.end()){
                     continue;
                 }
@@ -2230,7 +2128,7 @@ void PolicyManager::updateExternalNode(const URI& uri,
         return;
     }
     extNode.get()->resolveGbpStaticRoute(staticRoutes);
-    for(shared_ptr<StaticRoute> route: staticRoutes) {
+    for(shared_ptr<StaticRoute>& route: staticRoutes) {
         route_map_t::iterator routeIter;
         optional<shared_ptr<StaticRouteToVrfRSrc>> vrfRef =
         route->resolveGbpStaticRouteToVrfRSrc();
@@ -2315,7 +2213,7 @@ void PolicyManager::updateExternalNode(const URI& uri,
         }
     }
     //Deleted static routes
-    uri_set_t::iterator itr = ens.static_routes.begin();
+    auto itr = ens.static_routes.begin();
     while(itr != ens.static_routes.end()) {
         route_map_t::iterator routeIter;
         routeIter = static_route_map.find(*itr);
@@ -2384,7 +2282,7 @@ void PolicyManager::updateStaticRoutes(class_id_t class_id,
         optional<shared_ptr<ExternalNode>> extNode =
             ExternalNode::resolve(framework, uri);
         if(!extNode){
-            ext_node_map_t::iterator extIter = ext_node_map.find(uri);
+            auto extIter = ext_node_map.find(uri);
             if(extIter != ext_node_map.end()) {
                 //Remove all static routes under external node
                 for(const auto &iter: extIter->second.static_routes) {
@@ -2411,7 +2309,7 @@ void PolicyManager::updateStaticRoute(class_id_t class_id, const URI& uri,
                                       uri_set_t &notifyLocalRoutes) {
     using namespace modelgbp::gbp;
     if(class_id == StaticRoute::CLASS_ID) {
-        route_map_t::iterator iter = static_route_map.find(uri);
+        route_map_t::const_iterator iter = static_route_map.find(uri);
         if(iter == static_route_map.end())
             return;
         boost::optional<opflex::modb::URI> extNodeURI;
@@ -2535,7 +2433,7 @@ void PolicyManager::updateRemoteRoutes(const URI& uri,
     optional<shared_ptr<modelgbp::gbpe::InstContext>> rdInst;
     rd = RoutingDomain::resolve(framework,uri);
     if(!rd){
-        rd_map_t::iterator rdIter = rd_map.find(uri);
+        auto rdIter = rd_map.find(uri);
         if(rdIter != rd_map.end()) {
 
             for(const auto &iter: rdIter->second.remote_routes) {
@@ -2554,7 +2452,7 @@ void PolicyManager::updateRemoteRoutes(const URI& uri,
     }
     RoutingDomainState &rs = rd_map[uri];
     rd.get()->resolveGbpRemoteRoute(remoteRoutes);
-    for(shared_ptr<RemoteRoute> route: remoteRoutes) {
+    for(shared_ptr<RemoteRoute>& route: remoteRoutes) {
         if(!route->getAddress() || !route->getPrefixLen()) {
             continue;
         }
@@ -2673,7 +2571,7 @@ void PolicyManager::updateRemoteRoutes(const URI& uri,
         }
     }
     //Deleted remote routes
-    uri_set_t::iterator itr = rs.remote_routes.begin();
+    auto itr = rs.remote_routes.begin();
     while(itr != rs.remote_routes.end()) {
         route_map_t::iterator routeIter;
         routeIter = remote_route_map.find(*itr);
@@ -2726,7 +2624,7 @@ void PolicyManager::updateRemoteRoute(class_id_t class_id, const URI& uri,
                                       uri_set_t &notifyLocalRoutes) {
     using namespace modelgbp::gbp;
     if(class_id == RemoteRoute::CLASS_ID) {
-        route_map_t::iterator iter = remote_route_map.find(uri);
+        route_map_t::const_iterator iter = remote_route_map.find(uri);
         if(iter == remote_route_map.end()) {
             return;
         }
@@ -2736,7 +2634,7 @@ void PolicyManager::updateRemoteRoute(class_id_t class_id, const URI& uri,
     }
     if(class_id == RemoteNextHop::CLASS_ID) {
         /*TBD:This should be optimized*/
-        rd_map_t::iterator iter = rd_map.begin();
+        rd_map_t::const_iterator iter = rd_map.begin();
         while(iter != rd_map.end()) {
             updateRemoteRoutes(iter->first, notifyRemoteRoutes,
                                notifyLocalRoutes);

--- a/agent-ovs/lib/PolicyManager.cpp
+++ b/agent-ovs/lib/PolicyManager.cpp
@@ -1932,6 +1932,7 @@ void PolicyManager::updateDomain(class_id_t class_id, const URI& uri) {
     uri_set_t notifyRds;
     uri_set_t notifyExtIntfs;
 
+    LOG(DEBUG) << "Updating cid:" << class_id << " uri:" << uri;
     if (class_id == modelgbp::gbp::EpGroup::CLASS_ID) {
         group_map[uri];
     }

--- a/agent-ovs/lib/PrometheusManager.cpp
+++ b/agent-ovs/lib/PrometheusManager.cpp
@@ -2681,7 +2681,7 @@ void PrometheusManager::addNUpdateSvcTargetCounter (const string& uuid,
         }
         if (mgauge)
             mgauge.get().second->Set(static_cast<double>(metric_val));
-        if (!mgauge) {
+        if (!mgauge && createIfNotPresent) {
             LOG(ERROR) << "svc-target stats invalid update for uuid: " << key;
             break;
         }
@@ -2734,7 +2734,7 @@ void PrometheusManager::addNUpdateSvcCounter (const string& uuid,
         }
         if (mgauge)
             mgauge.get().second->Set(static_cast<double>(metric_val));
-        if (!mgauge) {
+        if (!mgauge && !svc_attr_map.empty()) {
             LOG(ERROR) << "svc stats invalid update for uuid: " << uuid;
             break;
         }

--- a/agent-ovs/lib/PrometheusManager.cpp
+++ b/agent-ovs/lib/PrometheusManager.cpp
@@ -1305,7 +1305,7 @@ string PrometheusManager::stringizeClassifier (const string& tenant,
         if (ct)
             compressed += "ct:" + to_string(ct.get());
     } else {
-        LOG(ERROR) << "No classifier found for tenant: " << tenant
+        LOG(DEBUG) << "No classifier found for tenant: " << tenant
                    << " classifier: " << classifier;
     }
 

--- a/agent-ovs/lib/PrometheusManager.cpp
+++ b/agent-ovs/lib/PrometheusManager.cpp
@@ -1362,10 +1362,11 @@ void PrometheusManager::createDynamicGaugeRDDrop (RDDROP_METRICS metric,
 void PrometheusManager::createDynamicGaugeSvcTarget (SVC_TARGET_METRICS metric,
                                                      const string& uuid,
                                                      const string& nhip,
-                    const unordered_map<string, string>&    ep_attr_map)
+                    const unordered_map<string, string>&    ep_attr_map,
+                                                     bool updateLabels)
 {
     // During counter update from stats manager, dont create new gauge metric
-    if (ep_attr_map.size() == 0)
+    if (!updateLabels)
         return;
 
     auto const &label_map = createLabelMapFromSvcTargetAttr(nhip, ep_attr_map);
@@ -2609,7 +2610,8 @@ void PrometheusManager::addNUpdateSvcTargetCounter (const string& uuid,
                                                     uint64_t rx_pkts,
                                                     uint64_t tx_bytes,
                                                     uint64_t tx_pkts,
-                         const unordered_map<string, string>& ep_attr_map)
+                         const unordered_map<string, string>& ep_attr_map,
+                                                    bool updateLabels)
 {
     RETURN_IF_DISABLED
     const lock_guard<mutex> lock(svc_target_counter_mutex);
@@ -2622,7 +2624,8 @@ void PrometheusManager::addNUpdateSvcTargetCounter (const string& uuid,
         createDynamicGaugeSvcTarget(metric,
                                     key,
                                     nhip,
-                                    ep_attr_map);
+                                    ep_attr_map,
+                                    updateLabels);
     }
 
     // Update the metrics

--- a/agent-ovs/lib/PrometheusManager.cpp
+++ b/agent-ovs/lib/PrometheusManager.cpp
@@ -1845,7 +1845,7 @@ mgauge_pair_t PrometheusManager::getDynamicGaugeSvcTarget (SVC_TARGET_METRICS me
     mgauge_pair_t mgauge = boost::none;
     auto itr = svc_target_gauge_map[metric].find(uuid);
     if (itr == svc_target_gauge_map[metric].end()) {
-        LOG(DEBUG) << "Dyn Gauge SvcTargetCounter not found"
+        LOG(TRACE) << "Dyn Gauge SvcTargetCounter not found"
                    << " metric: " << metric
                    << " uuid: " << uuid;
     } else {
@@ -1862,7 +1862,7 @@ mgauge_pair_t PrometheusManager::getDynamicGaugeSvc (SVC_METRICS metric,
     mgauge_pair_t mgauge = boost::none;
     auto itr = svc_gauge_map[metric].find(uuid);
     if (itr == svc_gauge_map[metric].end()) {
-        LOG(DEBUG) << "Dyn Gauge SvcCounter not found"
+        LOG(TRACE) << "Dyn Gauge SvcCounter not found"
                    << " metric: " << metric
                    << " uuid: " << uuid;
     } else {
@@ -1879,7 +1879,7 @@ mgauge_pair_t PrometheusManager::getDynamicGaugePodSvc (PODSVC_METRICS metric,
     mgauge_pair_t mgauge = boost::none;
     auto itr = podsvc_gauge_map[metric].find(uuid);
     if (itr == podsvc_gauge_map[metric].end()) {
-        LOG(DEBUG) << "Dyn Gauge PodSvcCounter not found"
+        LOG(TRACE) << "Dyn Gauge PodSvcCounter not found"
                    << " metric: " << metric
                    << " uuid: " << uuid;
     } else {
@@ -2213,7 +2213,7 @@ bool PrometheusManager::removeDynamicGaugePodSvc (PODSVC_METRICS metric,
         gauge_check.remove(mgauge.get().second);
         gauge_podsvc_family_ptr[metric]->Remove(mgauge.get().second);
     } else {
-        LOG(DEBUG) << "remove dynamic gauge podsvc not found uuid:" << uuid;
+        LOG(TRACE) << "remove dynamic gauge podsvc not found uuid:" << uuid;
         return false;
     }
     return true;
@@ -3208,23 +3208,30 @@ void PrometheusManager::removePodSvcCounter (bool isEpToSvc,
     RETURN_IF_DISABLED
     const lock_guard<mutex> lock(podsvc_counter_mutex);
 
-    LOG(DEBUG) << "remove podsvc counter"
-               << " isEpToSvc: " << isEpToSvc
-               << " uuid: " << uuid;
 
     if (isEpToSvc) {
         for (PODSVC_METRICS metric=PODSVC_EP2SVC_MIN;
                 metric <= PODSVC_EP2SVC_MAX;
                     metric = PODSVC_METRICS(metric+1)) {
-            if (!removeDynamicGaugePodSvc(metric, uuid))
+            if (!removeDynamicGaugePodSvc(metric, uuid)) {
                 break;
+            } else {
+                LOG(DEBUG) << "remove podsvc counter"
+                           << " eptosvc uuid: " << uuid
+                           << " metric: " << metric;
+            }
         }
     } else {
         for (PODSVC_METRICS metric=PODSVC_SVC2EP_MIN;
                 metric <= PODSVC_SVC2EP_MAX;
                     metric = PODSVC_METRICS(metric+1)) {
-            if (!removeDynamicGaugePodSvc(metric, uuid))
+            if (!removeDynamicGaugePodSvc(metric, uuid)) {
                 break;
+            } else {
+                LOG(DEBUG) << "remove podsvc counter"
+                           << " svctoep uuid: " << uuid
+                           << " metric: " << metric;
+            }
         }
     }
 }

--- a/agent-ovs/lib/Service.cpp
+++ b/agent-ovs/lib/Service.cpp
@@ -26,6 +26,16 @@ std::ostream & operator<<(std::ostream &os, const Service& s) {
     } else if (s.getServiceMode() == Service::LOADBALANCER) {
         os << ",loadbalancer";
     }
+
+    if (s.getServiceType() == Service::CLUSTER_IP)
+        os << ",clusterIp";
+    else if (s.getServiceType() == Service::NODE_PORT)
+        os << ",nodePort";
+    else if (s.getServiceType() == Service::LOAD_BALANCER)
+        os << ",loadBalancer";
+    else
+        os << ",unknown";
+
     if (s.getDomainURI())
         os << ",domain=" << s.getDomainURI().get();
 
@@ -55,6 +65,9 @@ std::ostream & operator<<(std::ostream &os, const Service& s) {
 
             if (sm.getServicePort())
                 os << ":" << sm.getServicePort().get();
+
+            if (sm.getNodePort())
+                os << ":" << sm.getNodePort().get();
 
             if (!sm.getNextHopIPs().empty()) {
                 os << "->[" << join(sm.getNextHopIPs(), ",") << "]";

--- a/agent-ovs/lib/ServiceManager.cpp
+++ b/agent-ovs/lib/ServiceManager.cpp
@@ -268,9 +268,7 @@ ServiceManager::updateSvcObserverMoDB (const opflexagent::Service& service, bool
         auto scopeItr = svcAttr.find("scope");
         if (scopeItr != svcAttr.end()) {
             pService->setScope(scopeItr->second);
-            // For cluster services, create service targets as well
-            if (scopeItr->second == "cluster")
-                updateSvcTargetObserverMoDB(service, true, pService);
+            updateSvcTargetObserverMoDB(service, true, pService);
         } else
             pService->unsetScope();
 
@@ -284,7 +282,6 @@ ServiceManager::updateSvcObserverMoDB (const opflexagent::Service& service, bool
 #endif
     } else {
         if (opService) {
-            // For external services, svc target removal will be noop
             updateSvcTargetObserverMoDB(service, false, opService.get());
             opService.get()->remove();
 #ifdef HAVE_PROMETHEUS_SUPPORT

--- a/agent-ovs/lib/ServiceManager.cpp
+++ b/agent-ovs/lib/ServiceManager.cpp
@@ -16,6 +16,7 @@
 #include <opflex/modb/Mutator.h>
 #include <modelgbp/svc/ServiceUniverse.hpp>
 #include <modelgbp/svc/ServiceModeEnumT.hpp>
+#include <modelgbp/svc/ServiceTypeEnumT.hpp>
 #include <modelgbp/svc/ConnTrackEnumT.hpp>
 #include <modelgbp/gbpe/EncapTypeEnumT.hpp>
 
@@ -134,7 +135,7 @@ void ServiceManager::clearSvcCounterStats (const Service& service,
                                    pSvc->getTxbytes(0),
                                    pSvc->getTxpackets(0),
                                    attr_map_t());
-    if (!service.isExternal()) {
+    if (!service.isExternal() && service.isNodePort()) {
         prometheusManager.addNUpdateSvcCounter("nodeport-"+service.getUUID(),
                                        pSvc->getNodePortRxbytes(0),
                                        pSvc->getNodePortRxpackets(0),
@@ -181,14 +182,14 @@ ServiceManager::updateSvcTargetObserverMoDB (const opflexagent::Service& service
                                                                  0, 0, 0, 0,
                                                                  service.getAttributes(),
                                                                  attr_map_t(),
-                                                                 true);
-                    if (!service.isExternal()) {
+                                                                 true, true);
+                    if (!service.isExternal() && sm.getNodePort()) {
                         prometheusManager.addNUpdateSvcTargetCounter("nodeport-"+service.getUUID(),
                                                              ip,
                                                              0, 0, 0, 0,
                                                              service.getAttributes(),
                                                              attr_map_t(),
-                                                             true, true);
+                                                             true, true, true);
                     }
 #endif
                 } else {
@@ -207,8 +208,8 @@ ServiceManager::updateSvcTargetObserverMoDB (const opflexagent::Service& service
                                                                  pSvcTarget->getTxpackets(0),
                                                                  service.getAttributes(),
                                                                  attr_map_t(),
-                                                                 true);
-                    if (!service.isExternal()) {
+                                                                 true, true);
+                    if (!service.isExternal() && sm.getNodePort()) {
                         prometheusManager.addNUpdateSvcTargetCounter("nodeport-"+service.getUUID(),
                                                              ip,
                                                              pSvcTarget->getNodePortRxbytes(0),
@@ -217,7 +218,7 @@ ServiceManager::updateSvcTargetObserverMoDB (const opflexagent::Service& service
                                                              pSvcTarget->getNodePortTxpackets(0),
                                                              service.getAttributes(),
                                                              attr_map_t(),
-                                                             true, true);
+                                                             true, true, true);
                     } else {
                         prometheusManager.removeSvcTargetCounter("nodeport-"+service.getUUID(), ip);
                     }
@@ -232,7 +233,7 @@ ServiceManager::updateSvcTargetObserverMoDB (const opflexagent::Service& service
                     clearSvcCounterStats(service, pSvcCounter, opSvcTarget.get());
 #ifdef HAVE_PROMETHEUS_SUPPORT
                     prometheusManager.removeSvcTargetCounter(service.getUUID(), ip);
-                    if (!service.isExternal())
+                    if (!service.isExternal() && service.isNodePort())
                         prometheusManager.removeSvcTargetCounter("nodeport-"+service.getUUID(), ip);
 #endif
                     opSvcTarget.get()->remove();
@@ -248,7 +249,7 @@ ServiceManager::updateSvcTargetObserverMoDB (const opflexagent::Service& service
         auto nhip = pSvcTarget->getIp();
         if (nhip) {
             prometheusManager.removeSvcTargetCounter(service.getUUID(), nhip.get());
-            if (!service.isExternal())
+            if (!service.isExternal() && service.isNodePort())
                 prometheusManager.removeSvcTargetCounter("nodeport-"+service.getUUID(), nhip.get());
         }
 #endif
@@ -323,7 +324,7 @@ ServiceManager::updateSvcObserverMoDB (const opflexagent::Service& service, bool
                                                pService->getTxbytes(0),
                                                pService->getTxpackets(0),
                                                svcAttr);
-        if (!service.isExternal()) {
+        if (!service.isExternal() && service.isNodePort()) {
             prometheusManager.addNUpdateSvcCounter("nodeport-"+service.getUUID(),
                                                pService->getNodePortRxbytes(0),
                                                pService->getNodePortRxpackets(0),
@@ -345,7 +346,7 @@ ServiceManager::updateSvcObserverMoDB (const opflexagent::Service& service, bool
 #ifdef HAVE_PROMETHEUS_SUPPORT
             prometheusManager.decSvcCounter();
             prometheusManager.removeSvcCounter(service.getUUID());
-            if (!service.isExternal())
+            if (!service.isExternal() && service.isNodePort())
                 prometheusManager.removeSvcCounter("nodeport-"+service.getUUID());
 #endif
         }
@@ -411,6 +412,16 @@ ServiceManager::updateConfigMoDB (const opflexagent::Service& service, bool add)
         else
             pService->unsetMode();
 
+        Service::ServiceType type = service.getServiceType();
+        if (type == Service::ServiceType::CLUSTER_IP)
+            pService->setType(ServiceTypeEnumT::CONST_CLUSTERIP);
+        else if (type == Service::ServiceType::NODE_PORT)
+            pService->setType(ServiceTypeEnumT::CONST_NODEPORT);
+        else if (type == Service::ServiceType::LOAD_BALANCER)
+            pService->setType(ServiceTypeEnumT::CONST_LOADBALANCER);
+        else
+            pService->setType(ServiceTypeEnumT::CONST_UNKNOWN);
+
         const optional<uint16_t>& ifaceVlan = service.getIfaceVlan();
         if (ifaceVlan) {
             pService->setInterfaceEncapType(EncapTypeEnumT::CONST_VLAN);
@@ -447,6 +458,12 @@ ServiceManager::updateConfigMoDB (const opflexagent::Service& service, bool add)
                     pSM->setNexthopPort(nhPort.get());
                 else
                     pSM->unsetNexthopPort();
+
+                const auto& nodePort = sm.getNodePort();
+                if (nodePort)
+                    pSM->setNodePort(nodePort.get());
+                else
+                    pSM->unsetNodePort();
 
                 const auto& gwIP = sm.getGatewayIP();
                 if (gwIP)

--- a/agent-ovs/lib/include/opflexagent/Agent.h
+++ b/agent-ovs/lib/include/opflexagent/Agent.h
@@ -408,6 +408,7 @@ private:
     // Prometheus related parameters
     bool prometheusEnabled;
     bool prometheusExposeLocalHostOnly;
+    bool prometheusExposeEpSvcNan;
     std::unordered_set<std::string> prometheusEpAttributes;
 #endif
     LogParams logParams;

--- a/agent-ovs/lib/include/opflexagent/Agent.h
+++ b/agent-ovs/lib/include/opflexagent/Agent.h
@@ -343,7 +343,9 @@ private:
 
     // timers
     // prr timer - policy resolve request timer
-    boost::uint_t<64>::fast prr_timer = 5400;  /* seconds */
+    boost::uint_t<64>::fast prr_timer = 7200;  /* seconds */
+    /* handshake timeout */
+    uint32_t peerHandshakeTimeout = 45000;
 
     std::set<std::string> endpointSourceFSPaths;
     std::set<std::string> disabledFeaturesSet;

--- a/agent-ovs/lib/include/opflexagent/Agent.h
+++ b/agent-ovs/lib/include/opflexagent/Agent.h
@@ -290,6 +290,21 @@ public:
     bool isFeatureEnabled(FeatureList feature) { return featureFlag[feature];}
 
     /**
+     * get behavior for adding l34flows without subnet
+     * @return true if l34flows should be added without subnet,
+     * false otherwise, defaults to false
+     */
+    bool addL34FlowsWithoutSubnet() { return behaviorL34FlowsWithoutSubnet; }
+
+    /**
+     * set behavior for adding l34flows without subnet
+     * @param value the new value for behaviorL34FlowsWithoutSubnet
+     */
+    void setAddL34FlowsWithoutSubnet(bool value) {
+        behaviorL34FlowsWithoutSubnet = value;
+    }
+
+    /**
      * clear feature flags. set them to true.
      */
     void clearFeatureFlags();
@@ -411,6 +426,7 @@ private:
     bool prometheusExposeEpSvcNan;
     std::unordered_set<std::string> prometheusEpAttributes;
 #endif
+    bool behaviorL34FlowsWithoutSubnet;
     LogParams logParams;
 };
 

--- a/agent-ovs/lib/include/opflexagent/Endpoint.h
+++ b/agent-ovs/lib/include/opflexagent/Endpoint.h
@@ -38,7 +38,8 @@ public:
      * Default constructor for containers
      */
     Endpoint() : promiscuousMode(false), discoveryProxyMode(false), natMode(false),
-                 external(false), aapModeAA(false), disableAdv(false), extEncap(0) {}
+                 external(false), aapModeAA(false), disableAdv(false),
+                 accessAllowUntagged(false), extEncap(0) {}
 
     /**
      * Construct a new Endpoint with the given uuid.  Note that
@@ -49,7 +50,8 @@ public:
      */
     explicit Endpoint(const std::string& uuid_)
         : uuid(uuid_), promiscuousMode(false), discoveryProxyMode(false), natMode(false),
-          external(false), aapModeAA(false), disableAdv(false), extEncap(0) {
+          external(false), aapModeAA(false), disableAdv(false),
+          accessAllowUntagged(false), extEncap(0) {
 #ifdef HAVE_PROMETHEUS_SUPPORT
         attr_hash = 0;
 #endif
@@ -499,6 +501,28 @@ public:
     */
     bool isDisableAdv() const {
         return disableAdv;
+    }
+
+    /**
+      * Set if access vlan should also allow untagged
+      * traffic like Openshift bootstrap use case
+      *
+      * @param accessAllowUntagged the new value of
+      * accessAllowUntagged flag
+      */
+    void setAccessAllowUntagged(bool accessAllowUntagged) {
+        this->accessAllowUntagged = accessAllowUntagged;
+    }
+
+    /**
+      * Get the current value of accessAllowUntagged flag
+      * for this endpoint
+      *
+      * @return true if untagged traffic should also be allowed
+      * else return false
+      */
+    bool isAccessAllowUntagged() const {
+        return accessAllowUntagged;
     }
 
     /**
@@ -1301,6 +1325,7 @@ private:
     bool external;
     bool aapModeAA;
     bool disableAdv;
+    bool accessAllowUntagged;
     attr_map_t attributes;
 #ifdef HAVE_PROMETHEUS_SUPPORT
     /**

--- a/agent-ovs/lib/include/opflexagent/NetFlowManager.h
+++ b/agent-ovs/lib/include/opflexagent/NetFlowManager.h
@@ -15,7 +15,6 @@
 
 #include <opflex/ofcore/OFFramework.h>
 #include <opflex/modb/ObjectListener.h>
-#include <opflexagent/PolicyListener.h>
 #include <opflexagent/NetFlowListener.h>
 
 #include <modelgbp/platform/Config.hpp>
@@ -38,8 +37,8 @@ using namespace opflex::modb;
 
 namespace opflexagent {
 
-    namespace netflow = modelgbp::netflow;
-    using namespace netflow;
+namespace netflow = modelgbp::netflow;
+using namespace netflow;
 
 /**
  * class to represent information on net flow
@@ -70,13 +69,19 @@ public:
      */
     void stop();
 
-     /**
-      * retrieve the session state pointer using Session URI as key.
-      * @param[in] uri URI pointing to the Session object.
-      * @return shared pointer to ExporterConfigState or none.
-      */
-      boost::optional<shared_ptr<ExporterConfigState>>
-          getExporterConfigState(const URI& uri) const;
+    /**
+     * retrieve the session state pointer using Session URI as key.
+     * @param[in] uri URI pointing to the Session object.
+     * @return shared pointer to ExporterConfigState or none.
+     */
+    boost::optional<shared_ptr<ExporterConfigState>> getExporterConfigState(const URI& uri) const;
+
+    /**
+     * Are there any exporters
+     *
+     */
+    bool anyExporters() const;
+
     /**
      * Register a listener for NetFlow change events
      *
@@ -157,8 +162,7 @@ private:
     mutex listener_mutex;
     TaskQueue taskQueue;
     static recursive_mutex exporter_mutex;
-    unordered_map<opflex::modb::URI, shared_ptr<ExporterConfigState>>
-           exporter_map;
+    unordered_map<opflex::modb::URI, shared_ptr<ExporterConfigState>> exporter_map;
    // list of URIs to send to listeners
     unordered_set<URI> notifyUpdate;
     unordered_set<shared_ptr<ExporterConfigState>> notifyDelete;

--- a/agent-ovs/lib/include/opflexagent/Network.h
+++ b/agent-ovs/lib/include/opflexagent/Network.h
@@ -178,10 +178,12 @@ typedef std::pair<boost::asio::ip::address, uint8_t> cidr_t;
  *
  * @param cidrStr the CIDR string to parse
  * @param cidr the output CIDR object if parsing was successful
+ * @param do_mask_addr mask the IP address if true
  * @return true if the provided CIDR string is valid and was successfully
  * parsed
  */
-bool cidr_from_string(const std::string& cidrStr, cidr_t& cidr);
+bool cidr_from_string(const std::string& cidrStr, cidr_t& cidr,
+                      bool do_mask_addr = true);
 
 /**
  * Check if provided IP address belong to a CIDR range.

--- a/agent-ovs/lib/include/opflexagent/PolicyManager.h
+++ b/agent-ovs/lib/include/opflexagent/PolicyManager.h
@@ -148,18 +148,13 @@ public:
      * @param mac_ Redirect mac address
      * @param rd_ Routing Domain object
      * @param bd_ Bridge Domain object
-     * @param rdInstCtxt_ Routing Domain Instance context
-     * @param bdInstCtxt_ Bridge Domain Instance context
      */
     PolicyRedirectDest(const std::shared_ptr<modelgbp::gbp::RedirectDest> dst_,
                        const boost::asio::ip::address& ip_,
                        const opflex::modb::MAC& mac_,
                        const std::shared_ptr<modelgbp::gbp::RoutingDomain>& rd_,
-                       const std::shared_ptr<modelgbp::gbp::BridgeDomain>& bd_,
-                       const std::shared_ptr<modelgbp::gbpe::InstContext>& rdInstCtxt_,
-                       const std::shared_ptr<modelgbp::gbpe::InstContext>& bdInstCtxt_
-                       ):ip(ip_), mac(mac_), redirDst(dst_), rd(rd_), bd(bd_),
-                         rdInstCtxt(rdInstCtxt_), bdInstCtxt(bdInstCtxt_){}
+                       const std::shared_ptr<modelgbp::gbp::BridgeDomain>& bd_
+                       ):ip(ip_), mac(mac_), redirDst(dst_), rd(rd_), bd(bd_){}
     /**
      * Get the RoutingDomain for the redirect destination.
      * @return the RoutingDomain object.
@@ -169,27 +164,11 @@ public:
     }
 
     /**
-     * Get the RoutingDomain for the redirect destination.
-     * @return the RoutingDomain object.
-     */
-    uint32_t getRDVnid() {
-        return rdInstCtxt->getEncapId().get();
-    }
-
-    /**
      * Get the BridgeDomain for the redirect destination.
      * @return the BridgeDomain object.
      */
     const std::shared_ptr<modelgbp::gbp::BridgeDomain> getBD () const {
         return bd;
-    }
-
-    /**
-     * Get the BDVnid for the redirect destination.
-     * @return the bd vnid .
-     */
-    uint32_t getBDVnid() {
-        return bdInstCtxt->getEncapId().get();
     }
 
     /**
@@ -214,8 +193,6 @@ private:
     std::shared_ptr<modelgbp::gbp::RedirectDest> redirDst;
     std::shared_ptr<modelgbp::gbp::RoutingDomain> rd;
     std::shared_ptr<modelgbp::gbp::BridgeDomain> bd;
-    std::shared_ptr<modelgbp::gbpe::InstContext> rdInstCtxt;
-    std::shared_ptr<modelgbp::gbpe::InstContext> bdInstCtxt;
     friend bool operator==(const PolicyRedirectDest& lhs,
                            const PolicyRedirectDest& rhs);
 };
@@ -281,7 +258,7 @@ public:
     /**
      * Check whether internal flag is set on this route.
      */
-    bool isPresent() {
+    bool isPresent() const {
         return present;
     }
 
@@ -339,7 +316,7 @@ public:
      * Get prefix length.
      * @return prefix length
      */
-    uint32_t getPrefixLen() {
+    uint32_t getPrefixLen() const {
         return prefix_len;
     }
 
@@ -530,26 +507,6 @@ public:
     boost::optional<uint32_t> getVnidForGroup(const opflex::modb::URI& eg);
 
     /**
-     * Get the virtual-network identifier (vnid) associated with the
-     * specified endpoint group's bridge domain.
-     *
-     * @param eg the URI for the endpoint group
-     * @return vnid of the group if group is found and its vnid is set,
-     * boost::none otherwise
-     */
-    boost::optional<uint32_t> getBDVnidForGroup(const opflex::modb::URI& eg);
-
-    /**
-     * Get the virtual-network identifier (vnid) associated with the
-     * specified endpoint group's routing domain.
-     *
-     * @param eg the URI for the endpoint group
-     * @return vnid of the group if group is found and its vnid is set,
-     * boost::none otherwise
-     */
-    boost::optional<uint32_t> getRDVnidForGroup(const opflex::modb::URI& eg);
-
-    /**
      * Get the endpoint group associated with the specified identifier
      *
      * @param vnid the VNID to look up
@@ -566,24 +523,6 @@ public:
      */
     boost::optional<std::string>
     getMulticastIPForGroup(const opflex::modb::URI& eg);
-
-    /**
-     * Get the multicast IP group configured for an endpoint group.
-     *
-     * @param eg the URI for the endpoint group
-     * @return Multicast IP for the group if any, boost::none otherwise
-     */
-    boost::optional<std::string>
-    getBDMulticastIPForGroup(const opflex::modb::URI& eg);
-
-    /**
-     * Get the multicast IP group configured for an endpoint group.
-     *
-     * @param eg the URI for the endpoint group
-     * @return Multicast IP for the group if any, boost::none otherwise
-     */
-    boost::optional<std::string>
-    getRDMulticastIPForGroup(const opflex::modb::URI& eg);
 
     /**
      * Get the sclass or source pctag for an endpoint group.
@@ -604,24 +543,6 @@ public:
     getBDVnidForExternalInterface(const opflex::modb::URI& eg);
 
     /**
-     * Get the external bd for an external interface.
-     *
-     * @param eg the URI for the external interface
-     * @return bd for the external interface if any, boost::none otherwise
-     */
-    boost::optional<std::shared_ptr<modelgbp::gbp::ExternalL3BridgeDomain>>
-    getBDForExternalInterface(const opflex::modb::URI& eg);
-
-    /**
-     * Get the rdvnid for an external interface.
-     *
-     * @param eg the URI for the external interface
-     * @return rd vnid for the external interface if any, boost::none otherwise
-     */
-    boost::optional<uint32_t>
-    getRDVnidForExternalInterface(const opflex::modb::URI& eg);
-
-    /**
      * Get the rd for an external interface.
      *
      * @param eg the URI for the external interface
@@ -640,17 +561,6 @@ public:
                             /* out */ subnet_vector_t& subnets);
 
     /**
-     * Get the multicastIP associated with the external BD of an
-     * external interface.
-     *
-     * @param eg the URI for the external interface
-     * @return multicast IP for the external interface if any,
-     * boost::none otherwise
-     */
-    boost::optional<std::string> getBDMulticastIPForExternalInterface(
-        const opflex::modb::URI& eg);
-
-    /**
      * Get the sclass associated with the external BD of an
      * external interface.
      *
@@ -662,17 +572,6 @@ public:
     getSclassForExternalInterface(const opflex::modb::URI& eg);
 
     /**
-     * Get the external domain associated with an
-     * external interface.
-     *
-     * @param eg the URI for the external interface
-     * @return external domain for the external interface if any,
-     * boost::none otherwise
-     */
-    boost::optional<std::shared_ptr<modelgbp::gbp::L3ExternalDomain>>
-        getExternalDomainForExternalInterface(const opflex::modb::URI& eg);
-
-    /**
      * Get sclass associated with an external network (external epg).
      *
      * @param en the URI for the external network
@@ -681,22 +580,6 @@ public:
      */
     boost::optional<uint32_t> getSclassForExternalNet(
         const opflex::modb::URI& en);
-
-    /**
-     * Get the L2EPRetention Policy for an endpoint group.
-     *
-     * @param eg the URI for the endpoint group
-     * @return EP retention policy for the epg if any, boost::none otherwise
-     */
-    boost::optional<std::shared_ptr<modelgbp::gbpe::EndpointRetention>>getL2EPRetentionPolicyForGroup(const opflex::modb::URI& eg );
-
-    /**
-     * Get the L3EPRetention Policy for an endpoint group.
-     *
-     * @param eg the URI for the endpoint group
-     * @return EP retention policy for the epg if any, boost::none otherwise
-     */
-    boost::optional<std::shared_ptr<modelgbp::gbpe::EndpointRetention>>getL3EPRetentionPolicyForGroup(const opflex::modb::URI& eg );
 
     /**
      * Check if an endpoint group exists
@@ -905,7 +788,6 @@ private:
     };
 
     struct ExternalInterfaceState {
-        boost::optional<std::shared_ptr<modelgbp::gbp::ExternalInterface> > extInterface;
         boost::optional<std::shared_ptr<modelgbp::gbpe::InstContext> > instContext;
         boost::optional<std::shared_ptr<modelgbp::gbpe::InstContext> > instRDContext;
         boost::optional<std::shared_ptr<modelgbp::gbp::RoutingDomain> > routingDomain;
@@ -1005,8 +887,6 @@ private:
 
     DomainListener domainListener;
 
-    friend class DomainListener;
-
     /**
      * Set of URIs in sorted order.
      */
@@ -1067,8 +947,6 @@ private:
     };
     ContractListener contractListener;
 
-    friend class ContractListener;
-
     /**
      * Listener for changes related to policy objects.
      */
@@ -1083,8 +961,6 @@ private:
         PolicyManager& pmanager;
     };
     SecGroupListener secGroupListener;
-
-    friend class SecGroupListener;
 
     /**
      * Listener for changes related to plaform config.
@@ -1101,8 +977,6 @@ private:
     };
     ConfigListener configListener;
 
-    friend class ConfigListener;
-
     /**
      * Listener for changes related to routes.
      */
@@ -1117,8 +991,6 @@ private:
         PolicyManager& pmanager;
     };
     RouteListener routeListener;
-
-    friend class RouteListener;
 
     /**
      * The policy listeners that have been registered
@@ -1298,7 +1170,6 @@ private:
     struct RedirectDestGrpState {
         uint8_t resilientHashEnabled;
         uint8_t hashAlgo;
-        std::shared_ptr<modelgbp::gbp::RedirectDestGroup> redirDstGrp;
         redir_dest_list_t redirDstList;
         uri_set_t ctrctSet;
     };

--- a/agent-ovs/lib/include/opflexagent/PrometheusManager.h
+++ b/agent-ovs/lib/include/opflexagent/PrometheusManager.h
@@ -65,8 +65,10 @@ public:
      *
      * @param exposeLocalHostOnly     flag to indicate if the the exposer
      *                                should be bound with local host only.
+     * @param exposeEpSvcNan          flag to indicate if Nan ep<-->svc
+     *                                metrics need to be exposed.
      */
-    void start(bool exposeLocalHostOnly);
+    void start(bool exposeLocalHostOnly, bool exposeEpSvcNan);
     /**
      * Stop the prometheus manager
      */
@@ -170,11 +172,15 @@ public:
      *
      * @param isEpToSvc       true if EpToSvc reporting
      * @param uuid            uuid of POD+SVC
+     * @param bytes           new byte count
+     * @param pkts            new packet count
      * @param ep_attr_map     map of all ep attributes
      * @param svc_attr_map    map of all svc attributes
      */
     void addNUpdatePodSvcCounter(bool isEpToSvc,
                                  const string& uuid,
+                                 uint64_t bytes,
+                                 uint64_t pkts,
         const unordered_map<string, string>& ep_attr_map,
         const unordered_map<string, string>& svc_attr_map);
     /**
@@ -998,7 +1004,10 @@ private:
      * True if shutting down or not start()'ed
      */
     std::atomic<bool> disabled;
-
+    /**
+     * True if Nan ep<-->svc metrics can be exposed
+     */
+    std::atomic<bool> exposeEpSvcNan;
     /* TODO: Other Counter related apis and state */
 };
 

--- a/agent-ovs/lib/include/opflexagent/PrometheusManager.h
+++ b/agent-ovs/lib/include/opflexagent/PrometheusManager.h
@@ -121,6 +121,7 @@ public:
      * @param svc_attr_map    map of svc attributes
      * @param ep_attr_map     map of ep/pod attributes
      * @param updateLabels    update label annotations during cfg updates
+     * @param isNodePort      true if the metric is for nodePort svc
      */
     void addNUpdateSvcTargetCounter(const string& uuid,
                                     const string& nhip,
@@ -130,7 +131,8 @@ public:
                                     uint64_t tx_pkts,
         const unordered_map<string, string>& svc_attr_map,
         const unordered_map<string, string>& ep_attr_map,
-                                    bool updateLabels);
+                                    bool updateLabels,
+                                    bool isNodePort=false);
     /**
      * Remove SvcTargetCounter metrics given it's uuid
      *
@@ -151,13 +153,15 @@ public:
      * @param tx_bytes        egress bytes
      * @param tx_pkts         egress packets
      * @param svc_attr_map    map of all svc attributes
+     * @param isNodePort      true if the metric is for nodePort svc
      */
     void addNUpdateSvcCounter(const string& uuid,
                               uint64_t rx_bytes,
                               uint64_t rx_pkts,
                               uint64_t tx_bytes,
                               uint64_t tx_pkts,
-        const unordered_map<string, string>& svc_attr_map);
+        const unordered_map<string, string>& svc_attr_map,
+                              bool isNodePort=false);
     /**
      * Remove SvcCounter metrics given it's uuid
      *
@@ -509,7 +513,8 @@ private:
                                      const string& nhip,
         const unordered_map<string, string>& svc_attr_map,
         const unordered_map<string, string>& ep_attr_map,
-                                     bool updateLabels);
+                                     bool updateLabels,
+                                     bool isNodePort);
 
     // func to get label map and Gauge for SvcTargetCounter given metric type, uuid
     mgauge_pair_t getDynamicGaugeSvcTarget(SVC_TARGET_METRICS metric, const string& uuid);
@@ -531,7 +536,8 @@ private:
     static const map<string,string> createLabelMapFromSvcTargetAttr(
                                                           const string& nhip,
                            const unordered_map<string, string>&  svc_attr_map,
-                           const unordered_map<string, string>&  ep_attr_map);
+                           const unordered_map<string, string>&  ep_attr_map,
+                           bool isNodePort);
     /* End of SvcTargetCounter related apis and state */
 
 
@@ -595,7 +601,8 @@ private:
     // uuid of svc & attr map of svc
     void createDynamicGaugeSvc(SVC_METRICS metric,
                                const string& uuid,
-        const unordered_map<string, string>& svc_attr_map);
+        const unordered_map<string, string>& svc_attr_map,
+                               bool isNodePort);
 
     // func to get label map and Gauge for SvcCounter given metric type, uuid
     mgauge_pair_t getDynamicGaugeSvc(SVC_METRICS metric, const string& uuid);
@@ -615,7 +622,8 @@ private:
     //Utility apis
     // Create a label map that can be used for annotation, given the svc attr map
     static const map<string,string> createLabelMapFromSvcAttr(
-                           const unordered_map<string, string>&  svc_attr_map);
+                           const unordered_map<string, string>&  svc_attr_map,
+                           bool isNodePort);
     /* End of SvcCounter related apis and state */
 
 

--- a/agent-ovs/lib/include/opflexagent/PrometheusManager.h
+++ b/agent-ovs/lib/include/opflexagent/PrometheusManager.h
@@ -120,6 +120,7 @@ public:
      * @param tx_pkts         egress packets
      * @param svc_attr_map    map of svc attributes
      * @param ep_attr_map     map of ep/pod attributes
+     * @param createIfNotPresent  Create new metrics only if this flag is set
      * @param updateLabels    update label annotations during cfg updates
      * @param isNodePort      true if the metric is for nodePort svc
      */
@@ -131,6 +132,7 @@ public:
                                     uint64_t tx_pkts,
         const unordered_map<string, string>& svc_attr_map,
         const unordered_map<string, string>& ep_attr_map,
+                                    bool createIfNotPresent,
                                     bool updateLabels,
                                     bool isNodePort=false);
     /**
@@ -513,6 +515,7 @@ private:
                                      const string& nhip,
         const unordered_map<string, string>& svc_attr_map,
         const unordered_map<string, string>& ep_attr_map,
+                                     bool createIfNotPresent,
                                      bool updateLabels,
                                      bool isNodePort);
 

--- a/agent-ovs/lib/include/opflexagent/PrometheusManager.h
+++ b/agent-ovs/lib/include/opflexagent/PrometheusManager.h
@@ -116,7 +116,8 @@ public:
      * @param rx_pkts         ingress packets
      * @param tx_bytes        egress bytes
      * @param tx_pkts         egress packets
-     * @param ep_attr_map     map of all ep/pod attributes
+     * @param svc_attr_map    map of svc attributes
+     * @param ep_attr_map     map of ep/pod attributes
      * @param updateLabels    update label annotations during cfg updates
      */
     void addNUpdateSvcTargetCounter(const string& uuid,
@@ -125,6 +126,7 @@ public:
                                     uint64_t rx_pkts,
                                     uint64_t tx_bytes,
                                     uint64_t tx_pkts,
+        const unordered_map<string, string>& svc_attr_map,
         const unordered_map<string, string>& ep_attr_map,
                                     bool updateLabels);
     /**
@@ -499,6 +501,7 @@ private:
     void createDynamicGaugeSvcTarget(SVC_TARGET_METRICS metric,
                                      const string& uuid,
                                      const string& nhip,
+        const unordered_map<string, string>& svc_attr_map,
         const unordered_map<string, string>& ep_attr_map,
                                      bool updateLabels);
 
@@ -521,6 +524,7 @@ private:
     // Create a label map that can be used for annotation, given the ep attr map
     static const map<string,string> createLabelMapFromSvcTargetAttr(
                                                           const string& nhip,
+                           const unordered_map<string, string>&  svc_attr_map,
                            const unordered_map<string, string>&  ep_attr_map);
     /* End of SvcTargetCounter related apis and state */
 

--- a/agent-ovs/lib/include/opflexagent/PrometheusManager.h
+++ b/agent-ovs/lib/include/opflexagent/PrometheusManager.h
@@ -105,6 +105,60 @@ public:
     void removeEpCounter(const string& uuid,
                          const string& ep_name);
 
+    /* SvcTargetCounter related APIs */
+    /**
+     * Create SvcTargetCounter metric family if its not present.
+     * Update SvcTargetCounter metric family if its already present
+     *
+     * @param uuid            uuid of SVC
+     * @param nhip            IP addr of svc-target
+     * @param rx_bytes        ingress bytes
+     * @param rx_pkts         ingress packets
+     * @param tx_bytes        egress bytes
+     * @param tx_pkts         egress packets
+     * @param ep_attr_map     map of all ep/pod attributes
+     */
+    void addNUpdateSvcTargetCounter(const string& uuid,
+                                    const string& nhip,
+                                    uint64_t rx_bytes,
+                                    uint64_t rx_pkts,
+                                    uint64_t tx_bytes,
+                                    uint64_t tx_pkts,
+        const unordered_map<string, string>& ep_attr_map);
+    /**
+     * Remove SvcTargetCounter metrics given it's uuid
+     *
+     * @param uuid          uuid of SVC
+     * @param nhip          IP addr of svc-target
+     */
+    void removeSvcTargetCounter(const string& uuid,
+                                const string& nhip);
+
+    /* SvcCounter related APIs */
+    /**
+     * Create SvcCounter metric family if its not present.
+     * Update SvcCounter metric family if its already present
+     *
+     * @param uuid            uuid of SVC
+     * @param rx_bytes        ingress bytes
+     * @param rx_pkts         ingress packets
+     * @param tx_bytes        egress bytes
+     * @param tx_pkts         egress packets
+     * @param svc_attr_map    map of all svc attributes
+     */
+    void addNUpdateSvcCounter(const string& uuid,
+                              uint64_t rx_bytes,
+                              uint64_t rx_pkts,
+                              uint64_t tx_bytes,
+                              uint64_t tx_pkts,
+        const unordered_map<string, string>& svc_attr_map);
+    /**
+     * Remove SvcCounter metrics given it's uuid
+     *
+     * @param uuid          uuid of SVC
+     */
+    void removeSvcCounter(const string& uuid);
+
     /* PodSvcCounter related APIs */
     /**
      * Create PodSvcCounter metric family if its not present.
@@ -415,6 +469,63 @@ private:
     /* End of EpCounter related apis and state */
 
 
+    /* Start of SvcTargetCounter related apis and state */
+    // Lock to safe guard SvcTargetCounter related state
+    mutex svc_target_counter_mutex;
+
+    // create any svc target gauge metric families during start
+    void createStaticGaugeFamiliesSvcTarget(void);
+    // remove any svc target gauge metric families during stop
+    void removeStaticGaugeFamiliesSvcTarget(void);
+    // create any svc target gauge metric during start
+    void createStaticGaugesSvcTarget(void);
+    // remove any svc target gauge metric during stop
+    void removeStaticGaugesSvcTarget(void);
+
+    enum SVC_TARGET_METRICS {
+        SVC_TARGET_METRICS_MIN,
+        SVC_TARGET_RX_BYTES = SVC_TARGET_METRICS_MIN,
+        SVC_TARGET_RX_PKTS,
+        SVC_TARGET_TX_BYTES,
+        SVC_TARGET_TX_PKTS,
+        SVC_TARGET_METRICS_MAX = SVC_TARGET_TX_PKTS
+    };
+
+    // metric families to track all SvcTargetCounter metrics
+    Family<Gauge>      *gauge_svc_target_family_ptr[SVC_TARGET_METRICS_MAX+1];
+
+    // Dynamic Metric families and metrics
+    // CRUD for every SvcTarget counter metric
+    // func to create gauge for SvcTargetCounter given metric type,
+    // uuid of svc-target & attr map of ep
+    void createDynamicGaugeSvcTarget(SVC_TARGET_METRICS metric,
+                                     const string& uuid,
+                                     const string& nhip,
+        const unordered_map<string, string>& ep_attr_map);
+
+    // func to get label map and Gauge for SvcTargetCounter given metric type, uuid
+    mgauge_pair_t getDynamicGaugeSvcTarget(SVC_TARGET_METRICS metric, const string& uuid);
+
+    // func to remove gauge for SvcTargetCounter given metric type, uuid
+    bool removeDynamicGaugeSvcTarget(SVC_TARGET_METRICS metric, const string& uuid);
+    // func to remove all gauge of every SvcTargetCounter for a metric type
+    void removeDynamicGaugeSvcTarget(SVC_TARGET_METRICS metric);
+    // func to remove all gauges of every SvcTargetCounter
+    void removeDynamicGaugeSvcTarget(void);
+
+    /**
+     * cache the label map and Gauge ptr for every service target uuid
+     */
+    unordered_map<string, mgauge_pair_t> svc_target_gauge_map[SVC_TARGET_METRICS_MAX+1];
+
+    //Utility apis
+    // Create a label map that can be used for annotation, given the ep attr map
+    static const map<string,string> createLabelMapFromSvcTargetAttr(
+                                                          const string& nhip,
+                           const unordered_map<string, string>&  ep_attr_map);
+    /* End of SvcTargetCounter related apis and state */
+
+
     /* Start of SvcCounter related apis and state */
     // Lock to safe guard SvcCounter related state
     mutex svc_counter_mutex;
@@ -456,6 +567,46 @@ private:
     void createStaticCountersSvc(void);
     // remove any svc counter metric during stop
     void removeStaticCountersSvc(void);
+
+    enum SVC_METRICS {
+        SVC_METRICS_MIN,
+        SVC_RX_BYTES = SVC_METRICS_MIN,
+        SVC_RX_PKTS,
+        SVC_TX_BYTES,
+        SVC_TX_PKTS,
+        SVC_METRICS_MAX = SVC_TX_PKTS
+    };
+
+    // metric families to track all SvcCounter metrics
+    Family<Gauge>      *gauge_svc_family_ptr[SVC_METRICS_MAX+1];
+
+    // Dynamic Metric families and metrics
+    // CRUD for every Svc counter metric
+    // func to create gauge for SvcCounter given metric type,
+    // uuid of svc & attr map of svc
+    void createDynamicGaugeSvc(SVC_METRICS metric,
+                               const string& uuid,
+        const unordered_map<string, string>& svc_attr_map);
+
+    // func to get label map and Gauge for SvcCounter given metric type, uuid
+    mgauge_pair_t getDynamicGaugeSvc(SVC_METRICS metric, const string& uuid);
+
+    // func to remove gauge for SvcCounter given metric type, uuid
+    bool removeDynamicGaugeSvc(SVC_METRICS metric, const string& uuid);
+    // func to remove all gauge of every SvcCounter for a metric type
+    void removeDynamicGaugeSvc(SVC_METRICS metric);
+    // func to remove all gauges of every SvcCounter
+    void removeDynamicGaugeSvc(void);
+
+    /**
+     * cache the label map and Gauge ptr for every service uuid
+     */
+    unordered_map<string, mgauge_pair_t> svc_gauge_map[SVC_METRICS_MAX+1];
+
+    //Utility apis
+    // Create a label map that can be used for annotation, given the svc attr map
+    static const map<string,string> createLabelMapFromSvcAttr(
+                           const unordered_map<string, string>&  svc_attr_map);
     /* End of SvcCounter related apis and state */
 
 

--- a/agent-ovs/lib/include/opflexagent/PrometheusManager.h
+++ b/agent-ovs/lib/include/opflexagent/PrometheusManager.h
@@ -234,9 +234,13 @@ public:
      *
      * @param rdURI       URI of routing domain
      * @param isAdd       flag to indicate if its create or update
+     * @param bytes       delta byte count
+     * @param pkts        delta packet count
      */
     void addNUpdateRDDropCounter(const string& rdURI,
-                                 bool isAdd);
+                                 bool isAdd,
+                                 uint64_t bytes,
+                                 uint64_t pkts);
     /**
      * Remove RDDropCounter metric given URI of routing domain
      *
@@ -281,8 +285,16 @@ public:
      * Update SGClassifierCounter metric family if its already present
      *
      * @param classifier       name of the classifier
+     * @param rx_bytes         delta rx byte count
+     * @param rx_pkts          delta rx packet count
+     * @param tx_bytes         delta tx byte count
+     * @param tx_pkts          delta tx packet count
      */
-    void addNUpdateSGClassifierCounter(const string& classifier);
+    void addNUpdateSGClassifierCounter(const string& classifier,
+                                       uint64_t rx_bytes,
+                                       uint64_t rx_pkts,
+                                       uint64_t tx_bytes,
+                                       uint64_t tx_pkts);
     /**
      * Remove SGClassifierCounter metric given the classifier
      *
@@ -299,10 +311,14 @@ public:
      * @param srcEpg           name of the srcEpg
      * @param dstEpg           name of the dstEpg
      * @param classifier       name of the classifier
+     * @param bytes            delta byte count
+     * @param pkts             delta packet count
      */
     void addNUpdateContractClassifierCounter(const string& srcEpg,
                                              const string& dstEpg,
-                                             const string& classifier);
+                                             const string& classifier,
+                                             uint64_t bytes,
+                                             uint64_t pkts);
     /**
      * Remove ContractClassifierCounter metric given the classifier
      *
@@ -827,11 +843,6 @@ private:
     // func to remove all gauges of every RDDropCounter
     void removeDynamicGaugeRDDrop(void);
 
-    // RDDropCounter diffs are stored in a circular buffer. Each buffer element
-    // has a unique running genID. Keep track of the last processed genId by
-    // PrometheusManager to avoid double counting
-    uint64_t rddrop_last_genId;
-
     /**
      * cache Gauge ptr for every RDDropCounter metric
      */
@@ -926,11 +937,6 @@ private:
     // func to remove all gauges of every SGClassifierCounter
     void removeDynamicGaugeSGClassifier(void);
 
-    // SGClassifierCounter diffs are stored in a circular buffer. Each buffer element
-    // has a unique running genID. Keep track of the last processed genId by
-    // PrometheusManager to avoid double counting
-    uint64_t sgclassifier_last_genId;
-
     /**
      * cache Gauge ptr for every SGClassifierCounter metric
      */
@@ -993,11 +999,6 @@ private:
     void removeDynamicGaugeContractClassifier(CONTRACT_METRICS metric);
     // func to remove all gauges of every ContractClassifierCounter
     void removeDynamicGaugeContractClassifier(void);
-
-    // ContractClassifierCounter diffs are stored in a circular buffer. Each buffer element
-    // has a unique running genID. Keep track of the last processed genId by
-    // PrometheusManager to avoid double counting
-    uint64_t contract_last_genId;
 
     /**
      * cache Gauge ptr for every ContractClassifierCounter metric

--- a/agent-ovs/lib/include/opflexagent/PrometheusManager.h
+++ b/agent-ovs/lib/include/opflexagent/PrometheusManager.h
@@ -117,6 +117,7 @@ public:
      * @param tx_bytes        egress bytes
      * @param tx_pkts         egress packets
      * @param ep_attr_map     map of all ep/pod attributes
+     * @param updateLabels    update label annotations during cfg updates
      */
     void addNUpdateSvcTargetCounter(const string& uuid,
                                     const string& nhip,
@@ -124,7 +125,8 @@ public:
                                     uint64_t rx_pkts,
                                     uint64_t tx_bytes,
                                     uint64_t tx_pkts,
-        const unordered_map<string, string>& ep_attr_map);
+        const unordered_map<string, string>& ep_attr_map,
+                                    bool updateLabels);
     /**
      * Remove SvcTargetCounter metrics given it's uuid
      *
@@ -477,10 +479,6 @@ private:
     void createStaticGaugeFamiliesSvcTarget(void);
     // remove any svc target gauge metric families during stop
     void removeStaticGaugeFamiliesSvcTarget(void);
-    // create any svc target gauge metric during start
-    void createStaticGaugesSvcTarget(void);
-    // remove any svc target gauge metric during stop
-    void removeStaticGaugesSvcTarget(void);
 
     enum SVC_TARGET_METRICS {
         SVC_TARGET_METRICS_MIN,
@@ -501,7 +499,8 @@ private:
     void createDynamicGaugeSvcTarget(SVC_TARGET_METRICS metric,
                                      const string& uuid,
                                      const string& nhip,
-        const unordered_map<string, string>& ep_attr_map);
+        const unordered_map<string, string>& ep_attr_map,
+                                     bool updateLabels);
 
     // func to get label map and Gauge for SvcTargetCounter given metric type, uuid
     mgauge_pair_t getDynamicGaugeSvcTarget(SVC_TARGET_METRICS metric, const string& uuid);

--- a/agent-ovs/lib/include/opflexagent/Service.h
+++ b/agent-ovs/lib/include/opflexagent/Service.h
@@ -33,7 +33,7 @@ public:
     /**
      * Default constructor
      */
-    Service() : serviceMode(LOCAL_ANYCAST) {}
+    Service() : serviceMode(LOCAL_ANYCAST), serviceType(CLUSTER_IP) {}
 
     /**
      * Construct a new Service with the given uuid.
@@ -41,7 +41,7 @@ public:
      * @param uuid_ the unique ID for the service.
      */
     explicit Service(const std::string& uuid_)
-        : uuid(uuid_), serviceMode(LOCAL_ANYCAST) {}
+        : uuid(uuid_), serviceMode(LOCAL_ANYCAST), serviceType(CLUSTER_IP) {}
 
     /**
      * Get the UUID for this service
@@ -231,15 +231,49 @@ public:
     }
 
     /**
-     * Check if the scope is external
+     * Types of service
+     */
+    enum ServiceType {
+        CLUSTER_IP,
+        NODE_PORT,
+        LOAD_BALANCER
+    };
+
+    /**
+     * Set the service type
      *
-     * @return returns true if the scope is external
+     * @param serviceType the new value for the service type
+     */
+    void setServiceType(ServiceType serviceType) {
+        this->serviceType = serviceType;
+    }
+
+    /**
+     * Get the service type
+     *
+     * @return the service type
+     */
+    ServiceType getServiceType() const {
+        return serviceType;
+    }
+
+    /**
+     * Check if service type is "loadBalancer"
+     *
+     * @return returns true if type is external LB
      */
     bool isExternal (void) const {
-        const Service::attr_map_t& svcAttr = getAttributes();
-        auto scopeItr = svcAttr.find("scope");
-        if (scopeItr != svcAttr.end())
-            if (scopeItr->second == "ext")
+        return (getServiceType() == LOAD_BALANCER);
+    }
+
+    /**
+     * Check if there is a nodePort configured
+     *
+     * @return returns true if there is a nodePort under SM
+     */
+    bool isNodePort (void) const {
+        for (const auto& sm : getServiceMappings())
+            if (sm.getNodePort())
                 return true;
         return false;
     }
@@ -417,6 +451,29 @@ public:
         }
 
         /**
+         * @return the node port number
+         */
+        const boost::optional<uint16_t>& getNodePort() const {
+            return nodePort;
+        }
+
+        /**
+         * Set the node port for the service mapping
+         *
+         * @param nodePort  the node port number
+         */
+        void setNodePort(uint16_t nodePort) {
+            this->nodePort = nodePort;
+        }
+
+        /**
+         * Unset the node port
+         */
+        void unsetNodePort() {
+            nodePort = boost::none;
+        }
+
+        /**
          * Set the connection tracking mode flag to the value
          * specified.  If connection tracking is enabled, reverse flow
          * mapping requires a stateful connection
@@ -444,6 +501,7 @@ public:
         boost::optional<std::string> gatewayIp;
         std::set<std::string> nextHopIps;
         boost::optional<uint16_t> nextHopPort;
+        boost::optional<uint16_t> nodePort;
         bool ctMode;
     };
 
@@ -524,6 +582,7 @@ private:
     boost::optional<opflex::modb::MAC> serviceMac;
     boost::optional<std::string> ifaceIP;
     ServiceMode serviceMode;
+    ServiceType serviceType;
     sm_set serviceMappings;
     attr_map_t attributes;
 };

--- a/agent-ovs/lib/include/opflexagent/ServiceManager.h
+++ b/agent-ovs/lib/include/opflexagent/ServiceManager.h
@@ -146,14 +146,17 @@ private:
     /**
      * Update service target observer in modb
      *
-     * @param service  the state of service
-     * @param add      indicates if service is added or removed
+     * @param service   the state of service
+     * @param add       indicates if service is added or removed
+     * @param pService  SvcCounter pointer
      */
-    void updateSvcTargetObserverMoDB(const Service& service, bool add,
+    void updateSvcTargetObserverMoDB(const Service& service,
+                                     bool add,
                  std::shared_ptr<modelgbp::gbpe::SvcCounter> pService);
 
     // Remove the stats of SvcTarget from SvcCounter
-    void clearSvcCounterStats(std::shared_ptr<SvcCounter> pSvc,
+    void clearSvcCounterStats(const Service& service,
+                              std::shared_ptr<SvcCounter> pSvc,
                               std::shared_ptr<SvcTargetCounter> pSvcTgt);
 
     // reference to opflex agent

--- a/agent-ovs/lib/include/opflexagent/ServiceManager.h
+++ b/agent-ovs/lib/include/opflexagent/ServiceManager.h
@@ -172,6 +172,7 @@ private:
         std::shared_ptr<const Service> service;
     };
 
+    typedef std::unordered_map<std::string, std::string> attr_map_t;
     typedef std::unordered_map<std::string, ServiceState> aserv_map_t;
     typedef std::unordered_map<std::string,
                                std::unordered_set<std::string> > string_serv_map_t;

--- a/agent-ovs/lib/include/opflexagent/ServiceManager.h
+++ b/agent-ovs/lib/include/opflexagent/ServiceManager.h
@@ -152,6 +152,10 @@ private:
     void updateSvcTargetObserverMoDB(const Service& service, bool add,
                  std::shared_ptr<modelgbp::gbpe::SvcCounter> pService);
 
+    // Remove the stats of SvcTarget from SvcCounter
+    void clearSvcCounterStats(std::shared_ptr<SvcCounter> pSvc,
+                              std::shared_ptr<SvcTargetCounter> pSvcTgt);
+
     // reference to opflex agent
     Agent& agent;
 

--- a/agent-ovs/lib/include/opflexagent/logging.h
+++ b/agent-ovs/lib/include/opflexagent/logging.h
@@ -23,7 +23,7 @@ namespace opflexagent {
 /**
  * Supported log levels
  */
-enum LogLevel { FATAL, ERROR, WARNING, INFO, DEBUG };
+enum LogLevel { FATAL, ERROR, WARNING, INFO, DEBUG, TRACE };
 
 extern LogLevel logLevel;
 

--- a/agent-ovs/lib/include/opflexagent/test/BaseFixture.h
+++ b/agent-ovs/lib/include/opflexagent/test/BaseFixture.h
@@ -29,8 +29,11 @@ namespace opflexagent {
  * A fixture that adds an object store
  */
 class BaseFixture {
-typedef opflex::ofcore::OFConstants::OpflexElementMode opflex_elem_t;
 public:
+/**
+ * Mode for opflex peer
+ */
+typedef opflex::ofcore::OFConstants::OpflexElementMode opflex_elem_t;
     BaseFixture(opflex_elem_t mode = opflex_elem_t::INVALID_MODE) :
     agent(framework, std::make_tuple("debug",false,"")), tunnelEpManager(&agent) {
         agent.setRendererForwardingMode(mode);

--- a/agent-ovs/lib/include/opflexagent/test/ModbFixture.h
+++ b/agent-ovs/lib/include/opflexagent/test/ModbFixture.h
@@ -47,7 +47,6 @@ public:
  */
 class ModbFixture : public BaseFixture {
     //! @cond Doxygen_Suppress
-    typedef opflex::ofcore::OFConstants::OpflexElementMode opflex_elem_t;
 public:
     ModbFixture(opflex_elem_t mode = opflex_elem_t::INVALID_MODE) :
                     BaseFixture(mode),

--- a/agent-ovs/lib/include/opflexagent/test/ModbFixture.h
+++ b/agent-ovs/lib/include/opflexagent/test/ModbFixture.h
@@ -67,7 +67,7 @@ public:
     std::shared_ptr<modelgbp::policy::Universe> universe;
     std::shared_ptr<modelgbp::policy::Space> space;
     std::shared_ptr<modelgbp::platform::Config> config;
-    std::shared_ptr<Endpoint> ep0, ep1, ep2, ep3, ep4, ep5;
+    std::shared_ptr<Endpoint> ep0, ep1, ep2, ep3, ep4, ep5, vethhostac;
     std::shared_ptr<modelgbp::gbp::EpGroup> epg0, epg1, epg2, epg3, epg4;
     std::shared_ptr<modelgbp::gbp::FloodDomain> fd0, fd1;
     std::shared_ptr<modelgbp::gbpe::FloodContext> fd0ctx;
@@ -240,7 +240,20 @@ protected:
         ep5->setExternal();
         ep5->setExtEncap(1000);
         epSrc.updateEndpoint(*ep5);
+    }
 
+    // Add vethhostac for nodeport tests
+    void createVethHostAccessObjects () {
+        vethhostac.reset(new Endpoint("veth_host_ac"));
+        vethhostac->setInterfaceName("veth_host_ac");
+        vethhostac->setAccessInterface("veth_host_ac");
+        vethhostac->setDisableAdv(true);
+        vethhostac->setMAC(opflex::modb::MAC("00:00:00:00:00:11"));
+        vethhostac->addIP("1.100.201.11");
+        vethhostac->setEgURI(epg0->getURI());
+        vethhostac->addAttribute("vm-name", "host-access");
+        vethhostac->addAttribute("namespace", "default");
+        epSrc.updateEndpoint(*vethhostac);
     }
 
     void createPolicyObjects() {

--- a/agent-ovs/lib/include/opflexagent/test/ModbFixture.h
+++ b/agent-ovs/lib/include/opflexagent/test/ModbFixture.h
@@ -200,6 +200,8 @@ protected:
         ep0->addAnycastReturnIP("10.20.44.2");
         ep0->addAnycastReturnIP("2001:db8::2");
         ep0->setEgURI(epg0->getURI());
+        ep0->addAttribute("vm-name", "coredns");
+        ep0->addAttribute("namespace", "default");
         epSrc.updateEndpoint(*ep0);
 
         ep1.reset(new Endpoint("0-0-0-1"));

--- a/agent-ovs/lib/logging.cpp
+++ b/agent-ovs/lib/logging.cpp
@@ -68,6 +68,7 @@ public:
                const char *functionName, const std::string& message) {
         const char *levelStr = LEVEL_STR_DEBUG;
         switch (level) {
+        case TRACE:   levelStr = LEVEL_STR_TRACE; break;
         case DEBUG:   levelStr = LEVEL_STR_DEBUG; break;
         case INFO:    levelStr = LEVEL_STR_INFO; break;
         case WARNING: levelStr = LEVEL_STR_WARNING; break;
@@ -84,6 +85,7 @@ private:
     std::fstream fileStream;
     std::ostream *out;
     std::mutex logMtx;
+    static const char * LEVEL_STR_TRACE;
     static const char * LEVEL_STR_DEBUG;
     static const char * LEVEL_STR_INFO;
     static const char * LEVEL_STR_WARNING;
@@ -91,6 +93,7 @@ private:
     static const char * LEVEL_STR_FATAL;
 };
 
+const char * OStreamLogSink::LEVEL_STR_TRACE = "trace";
 const char * OStreamLogSink::LEVEL_STR_DEBUG = "debug";
 const char * OStreamLogSink::LEVEL_STR_INFO = "info";
 const char * OStreamLogSink::LEVEL_STR_WARNING = "warning";
@@ -113,6 +116,8 @@ public:
                const char *functionName, const std::string& message) {
         int priority = LOG_DEBUG;
         switch (level) {
+        // No level lower than LOG_DEBUG in syslog
+        case TRACE:   // fall through
         case DEBUG:   priority = LOG_DEBUG; break;
         case INFO:    priority = LOG_INFO; break;
         case WARNING: priority = LOG_WARNING; break;
@@ -182,7 +187,7 @@ void setLoggingLevel(const std::string& newLevelstr) {
         logLevel = DEBUG;
     } else if (levelstr == "trace") {
         level = OFLogHandler::TRACE;
-        logLevel = DEBUG;
+        logLevel = TRACE;
     } else if (levelstr == "info") {
         level = OFLogHandler::INFO;
         logLevel = INFO;

--- a/agent-ovs/lib/test/ServiceManager_test.cpp
+++ b/agent-ovs/lib/test/ServiceManager_test.cpp
@@ -54,7 +54,7 @@ public:
     Service as;
 #ifdef HAVE_PROMETHEUS_SUPPORT
     void checkServicePromMetrics(bool isAdd, bool isUpdate);
-    void checkServiceTargetPromMetrics(bool isAdd, const string& ip);
+    void checkServiceTargetPromMetrics(bool isAdd, const string& ip, bool isUpdate);
     void checkServiceExists(bool isAdd, bool isUpdate=false);
     /**
      * Following commented commands didnt work in test environment, but will work from a regular terminal:
@@ -288,17 +288,24 @@ void ServiceManagerFixture::checkServicePromMetrics (bool isAdd, bool isUpdate)
     expPosition(isAdd, pos);
 }
 // Check prom dyn gauge service target metrics
-void ServiceManagerFixture::checkServiceTargetPromMetrics (bool isAdd, const string& ip)
+void ServiceManagerFixture::checkServiceTargetPromMetrics (bool isAdd,
+                                                           const string& ip,
+                                                           bool isUpdate)
 {
     const string& output = BaseFixture::getOutputFromCommand(cmd);
     size_t pos = std::string::npos;
-    pos = output.find("opflex_svc_target_rx_bytes{ip=\""+ip+"\"} 0.000000");
+    string str;
+    if (isUpdate)
+        str = "\",svc_name=\"nginx\",svc_scope=\"cluster\"} 0.000000";
+    else
+        str = "\",svc_name=\"coredns\",svc_namespace=\"kube-system\",svc_scope=\"cluster\"} 0.000000";
+    pos = output.find("opflex_svc_target_rx_bytes{ip=\""+ip+str);
     expPosition(isAdd, pos);
-    pos = output.find("opflex_svc_target_rx_packets{ip=\""+ip+"\"} 0.000000");
+    pos = output.find("opflex_svc_target_rx_packets{ip=\""+ip+str);
     expPosition(isAdd, pos);
-    pos = output.find("opflex_svc_target_tx_bytes{ip=\""+ip+"\"} 0.000000");
+    pos = output.find("opflex_svc_target_tx_bytes{ip=\""+ip+str);
     expPosition(isAdd, pos);
-    pos = output.find("opflex_svc_target_tx_packets{ip=\""+ip+"\"} 0.000000");
+    pos = output.find("opflex_svc_target_tx_packets{ip=\""+ip+str);
     expPosition(isAdd, pos);
 }
 #endif
@@ -336,7 +343,7 @@ void ServiceManagerFixture::checkServiceExists (bool isAdd)
                                        500,,
                                        LOG(ERROR) << "SvcTargetCounter obs Obj not resolved";);
 #ifdef HAVE_PROMETHEUS_SUPPORT
-                    checkServiceTargetPromMetrics(isAdd, ip);
+                    checkServiceTargetPromMetrics(isAdd, ip, isUpdate);
 #endif
                 }
             }
@@ -344,10 +351,10 @@ void ServiceManagerFixture::checkServiceExists (bool isAdd)
             BOOST_CHECK(!ssu.get()->resolveGbpeSvcCounter(as.getUUID()));
 #ifdef HAVE_PROMETHEUS_SUPPORT
             checkServicePromMetrics(false, isUpdate);
-            checkServiceTargetPromMetrics(false, "10.20.44.2");
-            checkServiceTargetPromMetrics(false, "169.254.169.2");
-            checkServiceTargetPromMetrics(false, "2001:db8::2");
-            checkServiceTargetPromMetrics(false, "fe80::a9:fe:a9:2");
+            checkServiceTargetPromMetrics(false, "10.20.44.2", isUpdate);
+            checkServiceTargetPromMetrics(false, "169.254.169.2", isUpdate);
+            checkServiceTargetPromMetrics(false, "2001:db8::2", isUpdate);
+            checkServiceTargetPromMetrics(false, "fe80::a9:fe:a9:2", isUpdate);
 #endif
         }
     } else {
@@ -359,10 +366,10 @@ void ServiceManagerFixture::checkServiceExists (bool isAdd)
                            LOG(ERROR) << "Service obs Obj still present";);
 #ifdef HAVE_PROMETHEUS_SUPPORT
         checkServicePromMetrics(isAdd, isUpdate);
-        checkServiceTargetPromMetrics(isAdd, "10.20.44.2");
-        checkServiceTargetPromMetrics(isAdd, "169.254.169.2");
-        checkServiceTargetPromMetrics(isAdd, "2001:db8::2");
-        checkServiceTargetPromMetrics(isAdd, "fe80::a9:fe:a9:2");
+        checkServiceTargetPromMetrics(isAdd, "10.20.44.2", isUpdate);
+        checkServiceTargetPromMetrics(isAdd, "169.254.169.2", isUpdate);
+        checkServiceTargetPromMetrics(isAdd, "2001:db8::2", isUpdate);
+        checkServiceTargetPromMetrics(isAdd, "fe80::a9:fe:a9:2", isUpdate);
 #endif
     }
 }

--- a/agent-ovs/lib/test/ServiceManager_test.cpp
+++ b/agent-ovs/lib/test/ServiceManager_test.cpp
@@ -290,13 +290,15 @@ void ServiceManagerFixture::checkServicePromMetrics (bool isAdd, bool isExternal
     } else
         scope = "cluster";
 
-    string str;
-    if (isUpdate)
+    string str, str2;
+    if (isUpdate) {
         str = "name=\"nginx\",scope=\"" + scope + "\"";
-    else
+        str2 = "name=\"nginx\",scope=\"nodePort\"";
+    } else {
         str = "name=\"coredns\",namespace=\"kube-system\",scope=\"" + scope + "\"";
+        str2 = "name=\"coredns\",namespace=\"kube-system\",scope=\"nodePort\"";
+    }
 
-    LOG(DEBUG) << "str is " << str;
     pos = output.find("opflex_svc_rx_bytes{" + str + "} 0.000000");
     expPosition(isAdd, pos);
     pos = output.find("opflex_svc_rx_packets{" + str + "} 0.000000");
@@ -305,6 +307,26 @@ void ServiceManagerFixture::checkServicePromMetrics (bool isAdd, bool isExternal
     expPosition(isAdd, pos);
     pos = output.find("opflex_svc_tx_packets{" + str + "} 0.000000");
     expPosition(isAdd, pos);
+
+    if (isExternal) {
+        pos = output.find("opflex_svc_rx_bytes{" + str2 + "} 0.000000");
+        expPosition(false, pos);
+        pos = output.find("opflex_svc_rx_packets{" + str2 + "} 0.000000");
+        expPosition(false, pos);
+        pos = output.find("opflex_svc_tx_bytes{" + str2 + "} 0.000000");
+        expPosition(false, pos);
+        pos = output.find("opflex_svc_tx_packets{" + str2 + "} 0.000000");
+        expPosition(false, pos);
+    } else {
+        pos = output.find("opflex_svc_rx_bytes{" + str2 + "} 0.000000");
+        expPosition(isAdd, pos);
+        pos = output.find("opflex_svc_rx_packets{" + str2 + "} 0.000000");
+        expPosition(isAdd, pos);
+        pos = output.find("opflex_svc_tx_bytes{" + str2 + "} 0.000000");
+        expPosition(isAdd, pos);
+        pos = output.find("opflex_svc_tx_packets{" + str2 + "} 0.000000");
+        expPosition(isAdd, pos);
+    }
 }
 // Check prom dyn gauge service target metrics
 void ServiceManagerFixture::checkServiceTargetPromMetrics (bool isAdd,
@@ -321,11 +343,15 @@ void ServiceManagerFixture::checkServiceTargetPromMetrics (bool isAdd,
     else
         scope = "cluster";
 
-    string str;
-    if (isUpdate)
+    string str, str2;
+    if (isUpdate) {
         str = "\",svc_name=\"nginx\",svc_scope=\"" + scope + "\"} 0.000000";
-    else
+        str2 = "\",svc_name=\"nginx\",svc_scope=\"nodePort\"} 0.000000";
+    } else {
         str = "\",svc_name=\"coredns\",svc_namespace=\"kube-system\",svc_scope=\"" + scope + "\"} 0.000000";
+        str2 = "\",svc_name=\"coredns\",svc_namespace=\"kube-system\",svc_scope=\"nodePort\"} 0.000000";
+    }
+
     pos = output.find("opflex_svc_target_rx_bytes{ip=\""+ip+str);
     expPosition(isAdd, pos);
     pos = output.find("opflex_svc_target_rx_packets{ip=\""+ip+str);
@@ -334,6 +360,26 @@ void ServiceManagerFixture::checkServiceTargetPromMetrics (bool isAdd,
     expPosition(isAdd, pos);
     pos = output.find("opflex_svc_target_tx_packets{ip=\""+ip+str);
     expPosition(isAdd, pos);
+
+    if (isExternal) {
+        pos = output.find("opflex_svc_target_rx_bytes{ip=\""+ip+str2);
+        expPosition(false, pos);
+        pos = output.find("opflex_svc_target_rx_packets{ip=\""+ip+str2);
+        expPosition(false, pos);
+        pos = output.find("opflex_svc_target_tx_bytes{ip=\""+ip+str2);
+        expPosition(false, pos);
+        pos = output.find("opflex_svc_target_tx_packets{ip=\""+ip+str2);
+        expPosition(false, pos);
+    } else {
+        pos = output.find("opflex_svc_target_rx_bytes{ip=\""+ip+str2);
+        expPosition(isAdd, pos);
+        pos = output.find("opflex_svc_target_rx_packets{ip=\""+ip+str2);
+        expPosition(isAdd, pos);
+        pos = output.find("opflex_svc_target_tx_bytes{ip=\""+ip+str2);
+        expPosition(isAdd, pos);
+        pos = output.find("opflex_svc_target_tx_packets{ip=\""+ip+str2);
+        expPosition(isAdd, pos);
+    }
 }
 #endif
 

--- a/agent-ovs/opflex-agent-ovs.conf.in
+++ b/agent-ovs/opflex-agent-ovs.conf.in
@@ -179,10 +179,20 @@
     //    needs to be disabled during agent bootup, then set the below flag
     //    to false
     //    "enabled": "true",
+    //
     //    By default prometheus exposer will bind with all IPs. Set
     //    localhost-only to true if prometheus export should happen only
     //    on 127.0.0.1.
     //    "localhost-only": "true",
+    //
+    //    Stats metrics for flows between local Endpoints and East-West Services
+    //    can lead to potentially large number of metrics. There might be cases
+    //    where only few of these ep <--> service metrics will actually report
+    //    traffic counts. To not overwhelm prometheus with Nans, these metrics
+    //    by default are not created in prometheus unless there is a valid stats
+    //    value.
+    //    "expose-epsvc-nan": "false",
+    //
     //    EP annotation for metrics:
     //    vm-name and namespace will be displayed as "name" and "namespace"
     //    by default if they are available. In case, vm-name isnt available,

--- a/agent-ovs/opflex-agent-ovs.conf.in
+++ b/agent-ovs/opflex-agent-ovs.conf.in
@@ -94,8 +94,12 @@
        "timers": {
            // Custom settings for various timers related to opflex
            // prr - Policy Resolve Request timer duration in seconds.
-           // default 5400 secs, min 15 secs
-           // "prr": 5400
+           // default 7200 secs, min 15 secs
+           // "prr": 7200,
+           //
+           // How long to wait for the initial peer
+           // handshake to complete (in ms)
+           // "handshake-timeout" : 45000
        },
        // Statistics. Counters for various artifacts.
        // mode: can have three values, viz.

--- a/agent-ovs/opflex-agent-ovs.conf.in
+++ b/agent-ovs/opflex-agent-ovs.conf.in
@@ -3,6 +3,7 @@
     // "log": {
     //     // Set the log level.
     //     // Possible values in descending order of verbosity:
+    //     // "trace" (least level verbose logs"),
     //     // "debug7"-"debug0", "debug" (synonym for "debug0"),
     //     // "info", "warning", "error", "fatal"
     //     // Default: "info"

--- a/agent-ovs/opflex-agent-ovs.conf.in
+++ b/agent-ovs/opflex-agent-ovs.conf.in
@@ -125,6 +125,9 @@
        //      "interval": 10
        //   },
        //   "service": {
+       //      // Disable/Enable stats flow creation
+       //      "flow-disabled": false,
+       //      // Disable/Enable stats collection
        //      "enabled": true,
        //      "interval": 10
        //   },

--- a/agent-ovs/opflex-agent-ovs.conf.in
+++ b/agent-ovs/opflex-agent-ovs.conf.in
@@ -120,6 +120,10 @@
        //      "enabled": true,
        //      "interval": 10
        //   },
+       //   "service": {
+       //      "enabled": true,
+       //      "interval": 10
+       //   },
        //   "table-drop": {
        //      "enabled": true,
        //      "interval": 10

--- a/agent-ovs/ovs/AccessFlowManager.cpp
+++ b/agent-ovs/ovs/AccessFlowManager.cpp
@@ -47,9 +47,9 @@ static const char* ID_NAMESPACES[] =
 static const char* ID_NMSPC_SECGROUP     = ID_NAMESPACES[0];
 static const char* ID_NMSPC_SECGROUP_SET = ID_NAMESPACES[1];
 
-void AccessFlowManager::populateTableDescriptionMap() {
+void AccessFlowManager::populateTableDescriptionMap(
+        SwitchManager::TableDescriptionMap &fwdTblDescr) {
     // Populate descriptions of flow tables
-    SwitchManager::TableDescriptionMap fwdTblDescr;
 #define TABLE_DESC(table_id, table_name, drop_reason) \
         fwdTblDescr.insert( \
                     std::make_pair(table_id, \
@@ -61,7 +61,6 @@ void AccessFlowManager::populateTableDescriptionMap() {
             "Ingress security group missing/incorrect")
     TABLE_DESC(OUT_TABLE_ID, "OUT_TABLE", "Output port missing/incorrect")
 #undef TABLE_DESC
-    switchManager.setForwardingTableList(fwdTblDescr);
 }
 
 AccessFlowManager::AccessFlowManager(Agent& agent_,
@@ -73,7 +72,9 @@ AccessFlowManager::AccessFlowManager(Agent& agent_,
       conntrackEnabled(false), stopping(false), dropLogRemotePort(0) {
     // set up flow tables
     switchManager.setMaxFlowTables(NUM_FLOW_TABLES);
-    populateTableDescriptionMap();
+    SwitchManager::TableDescriptionMap fwdTblDescr;
+    populateTableDescriptionMap(fwdTblDescr);
+    switchManager.setForwardingTableList(fwdTblDescr);
 }
 
 static string getSecGrpSetId(const uri_set_t& secGrps) {

--- a/agent-ovs/ovs/ContractStatsManager.cpp
+++ b/agent-ovs/ovs/ContractStatsManager.cpp
@@ -154,7 +154,9 @@ void ContractStatsManager::handleDropStats(struct ofputil_flow_stats* fentry) {
                                       diffCounters);
 #ifdef HAVE_PROMETHEUS_SUPPORT
         prometheusManager.addNUpdateRDDropCounter(idStr.get(),
-                                                  false);
+                                                  false,
+                                                  diffCounters.byte_count.get(),
+                                                  diffCounters.packet_count.get());
 #endif
     }
 }
@@ -177,13 +179,15 @@ updatePolicyStatsCounters(const std::string& srcEpg,
             ->setPackets(newVals.packet_count.get())
             .setBytes(newVals.byte_count.get());
         counterObjectKeys_[nextId] = counter_key_t(l24Classifier,srcEpg,dstEpg);
+#ifdef HAVE_PROMETHEUS_SUPPORT
+        prometheusManager.addNUpdateContractClassifierCounter(srcEpg,
+                                                              dstEpg,
+                                                              l24Classifier,
+                                                              newVals.byte_count.get(),
+                                                              newVals.packet_count.get());
+#endif
     }
     mutator.commit();
-#ifdef HAVE_PROMETHEUS_SUPPORT
-    prometheusManager.addNUpdateContractClassifierCounter(srcEpg,
-                                                          dstEpg,
-                                                          l24Classifier);
-#endif
 }
 
 void ContractStatsManager::clearCounterObject(const std::string& key,

--- a/agent-ovs/ovs/FlowBuilder.cpp
+++ b/agent-ovs/ovs/FlowBuilder.cpp
@@ -305,8 +305,8 @@ FlowBuilder& FlowBuilder::tunId(uint64_t tunId) {
     return *this;
 }
 
-FlowBuilder& FlowBuilder::reg(uint8_t reg, uint32_t value) {
-    match_set_reg(match(), reg, value);
+FlowBuilder& FlowBuilder::reg(uint8_t reg, uint32_t value, uint32_t mask) {
+    match_set_reg_masked(match(), reg, value, mask);
     return *this;
 }
 

--- a/agent-ovs/ovs/FlowUtils.cpp
+++ b/agent-ovs/ovs/FlowUtils.cpp
@@ -151,6 +151,7 @@ void add_classifier_entries(L24Classifier& clsfr, ClassAction act,
                             uint32_t flags, uint64_t cookie,
                             uint32_t svnid, uint32_t dvnid,
                             /* out */ FlowEntryList& entries) {
+    using modelgbp::l2::EtherTypeEnumT;
     using modelgbp::l4::TcpFlagsEnumT;
 
     ovs_be64 ckbe = ovs_htonll(cookie);
@@ -195,6 +196,38 @@ void add_classifier_entries(L24Classifier& clsfr, ClassAction act,
         for (const network::subnet_t& ds : effDestSub) {
             flow_func dst_func(make_flow_functor(ds, &FlowBuilder::ipDst));
 
+            /*
+             * For EtherType IPV4 and IPV6 add related flows based on
+             * EtherType and skip matching on L4 Proto and ports
+             */
+            if (act == flowutils::CA_REFLEX_REV_RELATED) {
+                FlowBuilder f;
+                uint16_t ethT = clsfr.getEtherT(EtherTypeEnumT::CONST_UNSPECIFIED);
+
+                if (ethT == EtherTypeEnumT::CONST_IPV4 ||
+                    ethT == EtherTypeEnumT::CONST_IPV6) {
+                    f.ethType(ethT);
+                } else {
+                    continue;
+                }
+
+                f.cookie(ckbe);
+                f.flags(flags);
+                f.conntrackState(FlowBuilder::CT_TRACKED |
+                                 FlowBuilder::CT_RELATED |
+                                 FlowBuilder::CT_REPLY,
+                                 FlowBuilder::CT_TRACKED |
+                                 FlowBuilder::CT_RELATED |
+                                 FlowBuilder::CT_REPLY |
+                                 FlowBuilder::CT_ESTABLISHED |
+                                 FlowBuilder::CT_INVALID |
+                                 FlowBuilder::CT_NEW);
+                 flowutils::match_group(f, priority, svnid, dvnid);
+                 f.action().go(nextTable);
+                 entries.push_back(f.build());
+                 continue;
+           }
+
             for (const Mask& sm : srcPorts) {
                 for (const Mask& dm : dstPorts) {
                     for (uint32_t flagMask : tcpFlagsVec) {
@@ -217,15 +250,6 @@ void add_classifier_entries(L24Classifier& clsfr, ClassAction act,
                                              FlowBuilder::CT_INVALID |
                                              FlowBuilder::CT_NEW |
                                              FlowBuilder::CT_RELATED);
-                            break;
-                        case flowutils::CA_REFLEX_REV_RELATED:
-                            f.conntrackState(FlowBuilder::CT_TRACKED |
-                                             FlowBuilder::CT_RELATED,
-                                             FlowBuilder::CT_TRACKED |
-                                             FlowBuilder::CT_RELATED |
-                                             FlowBuilder::CT_ESTABLISHED |
-                                             FlowBuilder::CT_INVALID |
-                                             FlowBuilder::CT_NEW);
                             break;
                         default:
                             // nothing
@@ -276,7 +300,6 @@ void add_classifier_entries(L24Classifier& clsfr, ClassAction act,
                             f.action().go(nextTable);
                             break;
                         case flowutils::CA_REFLEX_REV_ALLOW:
-                        case flowutils::CA_REFLEX_REV_RELATED:
                         case flowutils::CA_ALLOW:
                             f.action().go(nextTable);
                             break;

--- a/agent-ovs/ovs/IntFlowManager.cpp
+++ b/agent-ovs/ovs/IntFlowManager.cpp
@@ -2196,6 +2196,10 @@ updateSvcStatsCounters (const uint64_t &cookie,
     // antosvc:svc-tgt:svc-uuid:nh-ip
     // svctoan:svc-tgt:svc-uuid:nh-ip
 
+    // The idgen strings for extToSvc and svcToExt will have below format
+    // extosvc:svc-ext:svc-uuid:nh-ip
+    // svctoex:svc-ext:svc-uuid:nh-ip
+
     const string& statType = str.get().substr(0,7);
     if ((statType == "eptosvc") || (statType == "svctoep")) {
         updatePodSvcStatsCounters(cookie,
@@ -2205,9 +2209,10 @@ updateSvcStatsCounters (const uint64_t &cookie,
                                   newByteCount,
                                   attr_map(),
                                   attr_map());
-    } else if ((statType == "antosvc") || (statType == "svctoan")) {
+    } else if ((statType == "antosvc") || (statType == "svctoan")
+                || (statType == "extosvc") || (statType == "svctoex")) {
         updateSvcTgtStatsCounters(cookie,
-                                  statType == "antosvc",
+                                  (statType == "antosvc") || (statType == "extosvc"),
                                   str.get(),
                                   newPktCount,
                                   newByteCount,
@@ -2283,7 +2288,7 @@ updateSvcStatsCounters (const bool &isIngress,
 
 void IntFlowManager::
 updateSvcTgtStatsCounters (const uint64_t &cookie,
-                           const bool &isAnyToSvc,
+                           const bool &isIngress,
                            const string& idStr,
                            const uint64_t &newPktCount,
                            const uint64_t &newByteCount,
@@ -2301,7 +2306,7 @@ updateSvcTgtStatsCounters (const uint64_t &cookie,
                                               svcUuid, nhipStr);
     if (opSvcTgt) {
         uint64_t updPktCount = 0, updByteCount = 0;
-        if (isAnyToSvc) {
+        if (isIngress) {
             auto oldPktCount = opSvcTgt.get()->getRxpackets(0);
             auto oldByteCount = opSvcTgt.get()->getRxbytes(0);
             updPktCount = oldPktCount + newPktCount;
@@ -2338,7 +2343,7 @@ updateSvcTgtStatsCounters (const uint64_t &cookie,
         // with actual value if possible that getting the values from modb.
         // This is to keep prom and modb in sync. Not doing this will update
         // prom to prior modb value during next stats update.
-        if (isAnyToSvc) {
+        if (isIngress) {
             prometheusManager.addNUpdateSvcTargetCounter(svcUuid,
                                                      nhipStr,
                                                      updByteCount,
@@ -2361,7 +2366,7 @@ updateSvcTgtStatsCounters (const uint64_t &cookie,
         }
 #endif
     }
-    updateSvcStatsCounters(isAnyToSvc, svcUuid, newPktCount, newByteCount, true);
+    updateSvcStatsCounters(isIngress, svcUuid, newPktCount, newByteCount, true);
 }
 
 // Private function to update stats and attributes
@@ -2452,10 +2457,23 @@ void IntFlowManager::clearPodSvcStatsCounters (const std::string& uuid)
 // ServiceManager
 void IntFlowManager::clearSvcTgtStatsCounters (const std::string& svcUuid,
                                                const std::string& nhipStr,
-                                               const attr_map& svcAttr)
+                                               const attr_map& svcAttr,
+                                               bool isExternal)
 {
     using modelgbp::observer::SvcStatUniverse;
     Mutator mutator(agent.getFramework(), "policyelement");
+    optional<shared_ptr<SvcStatUniverse> > ssu =
+                SvcStatUniverse::resolve(agent.getFramework());
+    if (!ssu)
+        return;
+
+    optional<shared_ptr<SvcCounter> > opSvc =
+                    ssu.get()->resolveGbpeSvcCounter(svcUuid);
+    if (opSvc) {
+        if ((isExternal && opSvc.get()->getScope("").compare("ext"))
+            || (!isExternal && opSvc.get()->getScope("").compare("cluster")))
+            return;
+    }
 
     auto opSvcTgt = SvcTargetCounter::resolve(agent.getFramework(),
                                               svcUuid, nhipStr);
@@ -2489,7 +2507,8 @@ void IntFlowManager::clearSvcTgtStatsCounters (const std::string& svcUuid,
 // Reset svc counter stats, deletion of the object will be handled in
 // ServiceManager
 void IntFlowManager::clearSvcStatsCounters (const std::string& uuid,
-                                            const attr_map& svcAttr)
+                                            const attr_map& svcAttr,
+                                            bool isExternal)
 {
     using modelgbp::observer::SvcStatUniverse;
     Mutator mutator(agent.getFramework(), "policyelement");
@@ -2500,6 +2519,10 @@ void IntFlowManager::clearSvcStatsCounters (const std::string& uuid,
     optional<shared_ptr<SvcCounter> > opSvc =
                     ssu.get()->resolveGbpeSvcCounter(uuid);
     if (opSvc) {
+        if ((isExternal && opSvc.get()->getScope("").compare("ext"))
+            || (!isExternal && opSvc.get()->getScope("").compare("cluster")))
+            return;
+
         std::vector<shared_ptr<SvcTargetCounter> > out;
         opSvc.get()->resolveGbpeSvcTargetCounter(out);
         for (auto& pSvcTarget : out) {
@@ -2554,6 +2577,217 @@ void IntFlowManager::updateSvcStatsFlows (const string& uuid,
 
     updatePodSvcStatsFlows(uuid, is_svc, is_add);
     updateSvcTgtStatsFlows(uuid, is_svc, is_add);
+    updateSvcExtStatsFlows(uuid, is_svc, is_add);
+}
+
+void IntFlowManager::updateSvcExtStatsFlows (const string &uuid,
+                                             const bool& is_svc,
+                                             const bool &is_add)
+{
+
+    LOG(DEBUG) << "##### Updating ext<-->svc-tgt flows:"
+               << " uuid: " << uuid
+               << " is_svc: " << is_svc
+               << " is_add: " << is_add << "#######";
+
+    /* Create/Delete cookies per service-mapping of a service.
+     * Each of these "ext<-->svc-tgt" are tracked together under
+     * their respective "svc" uuids.
+     * i.e. All of these flows are clubbed together with "svc-ext:svc-uuid". */
+    unordered_set<string> uuid_ck_set;
+
+    // Expr to del stats flow between "ext to svc" and "svc to ext"
+    auto svcTgtCkRemExpr =
+        [this] (const string &flow_uuid,
+                const string &svc_uuid) -> void {
+        // Idgen would have restored the ids during agent restart. If flows for this
+        // service needs to be removed, then free up the restored IDs as well.
+        ServiceManager& srvMgr = agent.getServiceManager();
+        shared_ptr<const Service> asWrapper = srvMgr.getService(svc_uuid);
+        if (asWrapper) {
+            const Service& as = *asWrapper;
+            for (auto const& sm : as.getServiceMappings()) {
+                for (const string& nhip : sm.getNextHopIPs()) {
+                    idGen.erase(ID_NMSPC_SVCSTATS, "extosvc:"+flow_uuid+":"+nhip);
+                    idGen.erase(ID_NMSPC_SVCSTATS, "svctoex:"+flow_uuid+":"+nhip);
+                    if (svc_nh_map.find(flow_uuid) != svc_nh_map.end())
+                        svc_nh_map[flow_uuid].erase(nhip);
+                }
+            }
+            clearSvcStatsCounters(svc_uuid, as.getAttributes(), true);
+        } else {
+            // Note: the only time asWrapper will be null is when service is
+            // removed. In such a case, the observer mo and prom metrics
+            // would have been deleted from ServiceManager already. The below
+            // call will be a no-op.
+            clearSvcStatsCounters(svc_uuid, attr_map(), true);
+        }
+
+        // Above should have freed up all the ids. But during svc delete, asWrapper will be
+        // null. Use svc_nh_map to free up in that case.
+        if (svc_nh_map.find(flow_uuid) != svc_nh_map.end()) {
+            for (const string& nhip : svc_nh_map[flow_uuid]) {
+                idGen.erase(ID_NMSPC_SVCSTATS, "extosvc:"+flow_uuid+":"+nhip);
+                idGen.erase(ID_NMSPC_SVCSTATS, "svctoex:"+flow_uuid+":"+nhip);
+            }
+        }
+        svc_nh_map[flow_uuid].clear();
+        svc_nh_map.erase(flow_uuid);
+    };
+
+    // build this set to detect if any svc-tgt state needs to be removed
+    // after an update of svc or ep/nh
+    unordered_set<string> nhips;
+
+    // Expr to add stats cookies between "ext to svc" and "svc to ext"
+    // note: as of now flows arent created in stats table for on-prem
+    // service pod stats. if at all we need to create flows in future
+    // then flow_uuid will be used during write_flow()
+    auto svcTgtCkAddExpr =
+        [this, &uuid_ck_set, &nhips](const string &flow_uuid,
+                                     const string &svc_uuid,
+                                     const string &nhipStr,
+                                     const Service::ServiceMapping &sm,
+                                     const Service& as,
+                                     const attr_map &svcAttr,
+                                     const attr_map &epAttr) -> void {
+
+        boost::system::error_code ec;
+        address::from_string(nhipStr, ec);
+        if (ec) {
+            LOG(WARNING) << "Invalid nexthop IP: "
+                         << nhipStr << ": " << ec.message();
+            return;
+        }
+
+        const optional<string>& ofPortName = as.getInterfaceName();
+        if (!ofPortName) {
+            LOG(DEBUG) << "ofPort not valid for svc: " << svc_uuid;
+            return;
+        }
+
+        if (!as.getIfaceVlan()) {
+            LOG(DEBUG) << "vlan not valid for svc: " << svc_uuid;
+            return;
+        }
+
+        // check if service IP is valid for safety
+        if (!sm.getServiceIP())
+            return;
+        address::from_string(sm.getServiceIP().get(), ec);
+        if (ec) {
+            LOG(WARNING) << "Invalid service IP: "
+                         << sm.getServiceIP().get()
+                         << ": " << ec.message();
+            return;
+        }
+
+        const string& ingStr = "extosvc:"+flow_uuid+":"+nhipStr;
+        const string& egrStr = "svctoex:"+flow_uuid+":"+nhipStr;
+        uint64_t cookieIdIg = (uint64_t)idGen.getId(ID_NMSPC_SVCSTATS, ingStr);
+        uint64_t cookieIdEg = (uint64_t)idGen.getId(ID_NMSPC_SVCSTATS, egrStr);
+        svc_nh_map[flow_uuid].insert(nhipStr);
+        nhips.insert(nhipStr);
+
+        LOG(DEBUG) << "Creating ext<-->svc-tgt counters for"
+                   << " flow_uuid: " << flow_uuid
+                   << " NH IP: " << nhipStr
+                   << " SVC-SM IP: " << sm.getServiceIP().get()
+                   << " cookieIg: " << cookieIdIg
+                   << " cookieEg: " << cookieIdEg;
+
+        // updates to take care of pod name and namespace change
+        updateSvcTgtStatsCounters(cookieIdIg, true, ingStr, 0, 0, svcAttr, epAttr);
+        updateSvcTgtStatsCounters(cookieIdEg, false, egrStr, 0, 0, svcAttr, epAttr);
+
+        uuid_ck_set.insert(flow_uuid);
+    };
+
+    if (is_svc) {
+        const string& flow_uuid = "svc-ext:"+uuid;
+        if (!is_add) {
+            svcTgtCkRemExpr(flow_uuid, uuid);
+            return;
+        }
+
+        ServiceManager& srvMgr = agent.getServiceManager();
+        shared_ptr<const Service> asWrapper = srvMgr.getService(uuid);
+
+        if (!asWrapper || !asWrapper->getDomainURI()) {
+            LOG(DEBUG) << "unable to get service from uuid";
+            return;
+        }
+
+        const Service& as = *asWrapper;
+        if ((as.getServiceMode() != Service::LOADBALANCER)
+                                  || !as.isExternal()) {
+            LOG(DEBUG) << "ext<-->svc-tgt not handled for non-LB or non-ext services - svc_uuid: " << uuid;
+            // clear obs and prom metrics during update;
+            // below will be no-op during create
+            svcTgtCkRemExpr(flow_uuid, uuid);
+            return;
+        }
+
+        for (auto const& sm : as.getServiceMappings()) {
+            for (const string& nhipstr : sm.getNextHopIPs()) {
+                const ip_ep_map_t& ip_ep_map = agent.getEndpointManager().getIPLocalEpMap();
+                const auto& itr = ip_ep_map.find(nhipstr);
+                if (itr != ip_ep_map.end()) {
+                    svcTgtCkAddExpr(flow_uuid,
+                                    uuid,
+                                    nhipstr, sm, as,
+                                    as.getAttributes(),
+                                    itr->second->getAttributes());
+                }
+            }
+        }
+
+        // flush svc-tgt counters and idgen cookies of NH's that got
+        // removed due to config updates of svc or ep/nh
+        if (!uuid_ck_set.size()) {
+            LOG(DEBUG) << "#### ext<-->svc-tgt no cookies created for svc_uuid: " << uuid;
+            // clear obs and prom metrics during update;
+            // below will be no-op during create
+            svcTgtCkRemExpr(flow_uuid, uuid);
+        } else if (svc_nh_map.find(flow_uuid) != svc_nh_map.end()) {
+            auto nh_itr = svc_nh_map[flow_uuid].begin();
+            while (nh_itr != svc_nh_map[flow_uuid].end()) {
+                if (nhips.find(*nh_itr) == nhips.end()) {
+                    LOG(DEBUG) << "#### ext<-->svc-tgt: deleting"
+                               << " svc_uuid: " << uuid
+                               << " nh_ip: " << *nh_itr;
+                    idGen.erase(ID_NMSPC_SVCSTATS, "extosvc:"+flow_uuid+":"+*nh_itr);
+                    idGen.erase(ID_NMSPC_SVCSTATS, "svctoex:"+flow_uuid+":"+*nh_itr);
+                    clearSvcTgtStatsCounters(uuid, *nh_itr, as.getAttributes(), true);
+                    nh_itr = svc_nh_map[flow_uuid].erase(nh_itr);
+                } else {
+                    nh_itr++;
+                }
+            }
+            nhips.clear();
+        }
+    } else {
+        unordered_set<string> svcUuids;
+        ServiceManager& svcMgr = agent.getServiceManager();
+        svcMgr.getServiceUUIDs(svcUuids);
+
+        // check if this ep is servicemapping.nhIP. If so, the idgen cookies
+        // for this svc-tgt will get updated
+        // If the EP became external, then cookie need to be removed
+        // If the EP became local, then cookie need to be added
+        // If new IP is added, then cookie will be added
+        // If an IP is modified, then cookie will be added/deleted
+        // If an IP is deleted, then cookie will be deleted
+        for (const string& svcUuid : svcUuids) {
+            updateSvcExtStatsFlows(svcUuid, true, true);
+            // If EP IP is modified:
+            //  - if it became NH of this service, then SNAT/DNAT flows should be
+            //    updated with stats cookie
+            //  - if it moved away from being NH of this service, then SNAT/DNAT
+            //    flows shouldnt match on stats cookie
+            programServiceSnatDnatFlows(svcUuid);
+        }
+    }
 }
 
 void IntFlowManager::updateSvcTgtStatsFlows (const string &uuid,
@@ -2593,29 +2827,29 @@ void IntFlowManager::updateSvcTgtStatsFlows (const string &uuid,
                 for (const string& nhip : sm.getNextHopIPs()) {
                     idGen.erase(ID_NMSPC_SVCSTATS, "antosvc:"+flow_uuid+":"+nhip);
                     idGen.erase(ID_NMSPC_SVCSTATS, "svctoan:"+flow_uuid+":"+nhip);
-                    if (svc_nh_map.find(svc_uuid) != svc_nh_map.end())
-                        svc_nh_map[svc_uuid].erase(nhip);
+                    if (svc_nh_map.find(flow_uuid) != svc_nh_map.end())
+                        svc_nh_map[flow_uuid].erase(nhip);
                 }
             }
-            clearSvcStatsCounters(svc_uuid, as.getAttributes());
+            clearSvcStatsCounters(svc_uuid, as.getAttributes(), false);
         } else {
             // Note: the only time asWrapper will be null is when service is
             // removed. In such a case, the observer mo and prom metrics
             // would have been deleted from ServiceManager already. The below
             // call will be a no-op.
-            clearSvcStatsCounters(svc_uuid, attr_map());
+            clearSvcStatsCounters(svc_uuid, attr_map(), false);
         }
 
         // Above should have freed up all the ids. But during svc delete, asWrapper will be
         // null. Use svc_nh_map to free up in that case.
-        if (svc_nh_map.find(svc_uuid) != svc_nh_map.end()) {
-            for (const string& nhip : svc_nh_map[svc_uuid]) {
+        if (svc_nh_map.find(flow_uuid) != svc_nh_map.end()) {
+            for (const string& nhip : svc_nh_map[flow_uuid]) {
                 idGen.erase(ID_NMSPC_SVCSTATS, "antosvc:"+flow_uuid+":"+nhip);
                 idGen.erase(ID_NMSPC_SVCSTATS, "svctoan:"+flow_uuid+":"+nhip);
             }
         }
-        svc_nh_map[svc_uuid].clear();
-        svc_nh_map.erase(svc_uuid);
+        svc_nh_map[flow_uuid].clear();
+        svc_nh_map.erase(flow_uuid);
     };
 
     // build this set to detect if any svc-tgt state needs to be removed
@@ -2670,7 +2904,7 @@ void IntFlowManager::updateSvcTgtStatsFlows (const string &uuid,
         const string& egrStr = "svctoan:"+flow_uuid+":"+nhipStr;
         uint64_t cookieIdIg = (uint64_t)idGen.getId(ID_NMSPC_SVCSTATS, ingStr);
         uint64_t cookieIdEg = (uint64_t)idGen.getId(ID_NMSPC_SVCSTATS, egrStr);
-        svc_nh_map[svc_uuid].insert(nhipStr);
+        svc_nh_map[flow_uuid].insert(nhipStr);
         nhips.insert(nhipStr);
 
         LOG(DEBUG) << "Creating any<-->svc counters for"
@@ -2691,22 +2925,26 @@ void IntFlowManager::updateSvcTgtStatsFlows (const string &uuid,
         if (nhAddr.is_v4()) {
             anyToSvc.priority(97).ethType(eth::type::IP)
                     .ipDst(nhAddr)
+                    .reg(12, 0, 1<<31)
                     .flags(OFPUTIL_FF_SEND_FLOW_REM)
                     .cookie(ovs_htonll(cookieIdIg))
                     .action().go(OUT_TABLE_ID);
             svcToAny.priority(97).ethType(eth::type::IP)
                     .ipSrc(nhAddr)
+                    .reg(12, 0, 1<<31)
                     .flags(OFPUTIL_FF_SEND_FLOW_REM)
                     .cookie(ovs_htonll(cookieIdEg))
                     .action().go(OUT_TABLE_ID);
         } else {
             anyToSvc.priority(97).ethType(eth::type::IPV6)
                     .ipDst(nhAddr)
+                    .reg(12, 0, 1<<31)
                     .flags(OFPUTIL_FF_SEND_FLOW_REM)
                     .cookie(ovs_htonll(cookieIdIg))
                     .action().go(OUT_TABLE_ID);
             svcToAny.priority(97).ethType(eth::type::IPV6)
                     .ipSrc(nhAddr)
+                    .reg(12, 0, 1<<31)
                     .flags(OFPUTIL_FF_SEND_FLOW_REM)
                     .cookie(ovs_htonll(cookieIdEg))
                     .action().go(OUT_TABLE_ID);
@@ -2716,8 +2954,9 @@ void IntFlowManager::updateSvcTgtStatsFlows (const string &uuid,
     };
 
     if (is_svc) {
+        const string& flow_uuid = "svc-tgt:"+uuid;
         if (!is_add) {
-            svcTgtFlowRemExpr("svc-tgt:"+uuid, uuid);
+            svcTgtFlowRemExpr(flow_uuid, uuid);
             return;
         }
 
@@ -2738,7 +2977,7 @@ void IntFlowManager::updateSvcTgtStatsFlows (const string &uuid,
             LOG(DEBUG) << "*<-->svc-tgt not handled for non-LB or ext services";
             // clear obs and prom metrics during update;
             // below will be no-op during create
-            svcTgtFlowRemExpr("svc-tgt:"+uuid, uuid);
+            svcTgtFlowRemExpr(flow_uuid, uuid);
             return;
         }
 
@@ -2747,7 +2986,7 @@ void IntFlowManager::updateSvcTgtStatsFlows (const string &uuid,
                 const ip_ep_map_t& ip_ep_map = agent.getEndpointManager().getIPLocalEpMap();
                 const auto& itr = ip_ep_map.find(nhipstr);
                 if (itr != ip_ep_map.end()) {
-                    svcTgtFlowAddExpr("svc-tgt:"+uuid,
+                    svcTgtFlowAddExpr(flow_uuid,
                                       uuid,
                                       nhipstr, sm,
                                       as.getAttributes(),
@@ -2762,18 +3001,18 @@ void IntFlowManager::updateSvcTgtStatsFlows (const string &uuid,
             LOG(DEBUG) << "####*<-->svc-tgt no flows created for svc_uuid: " << uuid;
             // clear obs and prom metrics during update;
             // below will be no-op during create
-            svcTgtFlowRemExpr("svc-tgt:"+uuid, uuid);
-        } else if (svc_nh_map.find(uuid) != svc_nh_map.end()) {
-            auto nh_itr = svc_nh_map[uuid].begin();
-            while (nh_itr != svc_nh_map[uuid].end()) {
+            svcTgtFlowRemExpr(flow_uuid, uuid);
+        } else if (svc_nh_map.find(flow_uuid) != svc_nh_map.end()) {
+            auto nh_itr = svc_nh_map[flow_uuid].begin();
+            while (nh_itr != svc_nh_map[flow_uuid].end()) {
                 if (nhips.find(*nh_itr) == nhips.end()) {
                     LOG(DEBUG) << "#### *<-->svc-tgt: deleting"
                                << " svc_uuid: " << uuid
                                << " nh_ip: " << *nh_itr;
-                    idGen.erase(ID_NMSPC_SVCSTATS, "antosvc:svc-tgt:"+uuid+":"+*nh_itr);
-                    idGen.erase(ID_NMSPC_SVCSTATS, "svctoan:svc-tgt:"+uuid+":"+*nh_itr);
-                    clearSvcTgtStatsCounters(uuid, *nh_itr, as.getAttributes());
-                    nh_itr = svc_nh_map[uuid].erase(nh_itr);
+                    idGen.erase(ID_NMSPC_SVCSTATS, "antosvc:"+flow_uuid+":"+*nh_itr);
+                    idGen.erase(ID_NMSPC_SVCSTATS, "svctoan:"+flow_uuid+":"+*nh_itr);
+                    clearSvcTgtStatsCounters(uuid, *nh_itr, as.getAttributes(), false);
+                    nh_itr = svc_nh_map[flow_uuid].erase(nh_itr);
                 } else {
                     nh_itr++;
                 }
@@ -3240,18 +3479,27 @@ void IntFlowManager::programServiceSnatDnatFlows (const string& uuid)
                                            flow::meta::FROM_SERVICE_INTERFACE);
 
                             ActionBuilder setMark;
+                            // Carry the ctMark information in reg12 so that cluster
+                            // service-pod stats flows can use this info to avoid getting
+                            // get hit for traffic coming from on-prem.
                             setMark.reg(MFF_CT_MARK, ctMark);
                             ipMap.action()
+                                .reg(MFF_REG12, ctMark)
                                 .conntrack(ActionBuilder::CT_COMMIT,
                                            static_cast<mf_field_id>(0),
                                            zoneId, 0xff, 0, setMark);
                         }
 
-                        // If a cookie was already allocated by updateSvcTgtStatsFlows(), then
-                        // use it.
+                        // If a cookie was already allocated by updateSvcTgtStatsFlows()
+                        // or updateSvcExtStatsFlows() then use it.
                         if (!serviceStatsFlowDisabled) {
+                            const string& extStr = "extosvc:svc-ext:"+uuid+":"+nextHopAddr.to_string();
                             const string& ingStr = "antosvc:svc-tgt:"+uuid+":"+nextHopAddr.to_string();
-                            uint32_t cookieIdIg = idGen.getIdNoAlloc(ID_NMSPC_SVCSTATS, ingStr);
+                            uint32_t cookieIdIg = 0;
+                            if ((ofPort != OFPP_NONE) && as.getIfaceVlan())
+                                cookieIdIg = idGen.getIdNoAlloc(ID_NMSPC_SVCSTATS, extStr);
+                            else
+                                cookieIdIg = idGen.getIdNoAlloc(ID_NMSPC_SVCSTATS, ingStr);
                             if (cookieIdIg != static_cast<uint32_t>(-1)) {
                                 ipMap.cookie(ovs_htonll((uint64_t)cookieIdIg))
                                      .flags(OFPUTIL_FF_SEND_FLOW_REM);
@@ -3293,11 +3541,16 @@ void IntFlowManager::programServiceSnatDnatFlows (const string& uuid)
                         matchActionServiceProto(ipRevMap, proto, sm,
                                                 false, true);
 
-                        // If a cookie was already allocated by updateSvcTgtStatsFlows(), then
-                        // use it.
+                        // If a cookie was already allocated by updateSvcTgtStatsFlows(),
+                        // or updateSvcExtStatsFlows() then use it.
                         if (!serviceStatsFlowDisabled) {
+                            const string& extStr = "svctoex:svc-ext:"+uuid+":"+nextHopAddr.to_string();
                             const string& egrStr = "svctoan:svc-tgt:"+uuid+":"+nextHopAddr.to_string();
-                            uint32_t cookieIdEg = idGen.getIdNoAlloc(ID_NMSPC_SVCSTATS, egrStr);
+                            uint32_t cookieIdEg = 0;
+                            if ((ofPort != OFPP_NONE) && as.getIfaceVlan())
+                                cookieIdEg = idGen.getIdNoAlloc(ID_NMSPC_SVCSTATS, extStr);
+                            else
+                                cookieIdEg = idGen.getIdNoAlloc(ID_NMSPC_SVCSTATS, egrStr);
                             if (cookieIdEg != static_cast<uint32_t>(-1)) {
                                 ipRevMap.cookie(ovs_htonll((uint64_t)cookieIdEg))
                                         .flags(OFPUTIL_FF_SEND_FLOW_REM);
@@ -5169,6 +5422,10 @@ static bool svcStatsIdGarbageCb(EndpointManager& epManager,
     // antosvc:svc-tgt:svc-uuid:nh-ip
     // svctoan:svc-tgt:svc-uuid:nh-ip
 
+    // The idgen strings for extToSvc and svcToExt will have below format
+    // extosvc:svc-ext:svc-uuid:nh-ip
+    // svctoex:svc-ext:svc-uuid:nh-ip
+
     const string& statType = str.substr(0,7);
     if ((statType == "eptosvc") || (statType == "svctoep")) {
         size_t pos1 = str.find(":");
@@ -5177,7 +5434,8 @@ static bool svcStatsIdGarbageCb(EndpointManager& epManager,
         const string& svcUuid = str.substr(pos2+1);
         return ((bool)serviceManager.getService(svcUuid)
                  && (bool)epManager.getEndpoint(epUuid));
-    } else if ((statType == "antosvc") || (statType == "svctoan")) {
+    } else if ((statType == "antosvc") || (statType == "svctoan")
+                || (statType == "extosvc") || (statType == "svctoex")) {
         size_t pos1 = str.find(":");
         size_t pos2 = str.find(":", pos1+1);
         size_t pos3 = str.find(":", pos2+1);

--- a/agent-ovs/ovs/IntFlowManager.cpp
+++ b/agent-ovs/ovs/IntFlowManager.cpp
@@ -1302,7 +1302,7 @@ static void flowsEndpointSource(FlowEntryList& elSrc,
 
         for (const string& ipStr : endPoint.getIPs()) {
             network::cidr_t cidr;
-            if (!network::cidr_from_string(ipStr, cidr), false) {
+            if (!network::cidr_from_string(ipStr, cidr, false)) {
                 LOG(WARNING) << "Invalid endpoint IP: "
                              << ipStr;
                 continue;

--- a/agent-ovs/ovs/IntFlowManager.cpp
+++ b/agent-ovs/ovs/IntFlowManager.cpp
@@ -1268,6 +1268,7 @@ static void flowsEndpointDHCPSource(IntFlowManager& flowMgr,
 static void flowsEndpointSource(FlowEntryList& elSrc,
                                 const Endpoint& endPoint,
                                 uint32_t ofPort,
+                                bool hostAcc,
                                 bool hasMac,
                                 uint8_t* macAddr,
                                 uint8_t unkFloodMode,
@@ -1286,7 +1287,7 @@ static void flowsEndpointSource(FlowEntryList& elSrc,
         // Map on L2. Port security rules filter L2
         // and L3 before we reach this table, except
         // for promiscuous endpoints.
-        if (!endPoint.isNatMode()) {
+        if (!endPoint.isNatMode() && !hostAcc) {
             actionSource(l2Classify, epgVnid, bdId, fgrpId, rdId)
                 .build(elSrc);
             return;
@@ -1300,17 +1301,14 @@ static void flowsEndpointSource(FlowEntryList& elSrc,
             .build(elSrc);
 
         for (const string& ipStr : endPoint.getIPs()) {
-
-            boost::system::error_code ec;
-
-            address addr = address::from_string(ipStr, ec);
-            if (ec) {
+            network::cidr_t cidr;
+            if (!network::cidr_from_string(ipStr, cidr), false) {
                 LOG(WARNING) << "Invalid endpoint IP: "
-                             << ipStr << ": " << ec.message();
+                             << ipStr;
                 continue;
             }
             actionSource(FlowBuilder().priority(140)
-                         .ipSrc(addr)
+                         .ipSrc(cidr.first, cidr.second)
                          .inPort(ofPort).ethSrc(macAddr),
                          epgVnid, bdId, fgrpId, rdId)
                 .build(elSrc);
@@ -1396,6 +1394,29 @@ static void flowRevMapCt(FlowEntryList& serviceRevFlows,
     ipRevMapCt.build(serviceRevFlows);
 }
 
+bool getHostAccess(EndpointManager& epMgr,
+                   SwitchManager& switchMgr,
+                   uint32_t& hostPort,
+                   uint8_t* hostMac) {
+    unordered_set<std::string> eps;
+    epMgr.getEndpointsByAccessIface("veth_host_ac", eps);
+    for (const std::string& ep : eps) {
+        shared_ptr<const Endpoint> epWrapper = epMgr.getEndpoint(ep);
+        if (epWrapper) {
+           const Endpoint& endPoint = *epWrapper.get();
+           bool hasMac = endPoint.getMAC() != boost::none;
+           if (hasMac)
+               endPoint.getMAC().get().toUIntArray(hostMac);
+           hostPort = OFPP_NONE;
+           const optional<string>& ofPortName = endPoint.getInterfaceName();
+           if (ofPortName)
+               hostPort = switchMgr.getPortMapper().FindPort(ofPortName.get());
+           return (hasMac && hostPort != OFPP_NONE);
+        }
+    }
+    return false;
+}
+
 void IntFlowManager::handleRemoteEndpointUpdate(const string& uuid) {
     LOG(DEBUG) << "Updating remote endpoint " << uuid;
 
@@ -1405,6 +1426,7 @@ void IntFlowManager::handleRemoteEndpointUpdate(const string& uuid) {
     if (!ep || (encapType == ENCAP_VLAN || encapType == ENCAP_NONE)) {
         switchManager.clearFlows(uuid, BRIDGE_TABLE_ID);
         switchManager.clearFlows(uuid, ROUTE_TABLE_ID);
+        switchManager.clearFlows(uuid, SRC_TABLE_ID);
         return;
     }
 
@@ -1445,18 +1467,24 @@ void IntFlowManager::handleRemoteEndpointUpdate(const string& uuid) {
 
     FlowEntryList elBridgeDst;
     FlowEntryList elRouteDst;
+    FlowEntryList elSrc;
     std::vector<std::shared_ptr<modelgbp::inv::RemoteIp>> invIps;
 
     if (hasForwardingInfo) {
         FlowBuilder bridgeFlow;
         uint32_t outReg = 0;
         uint64_t meta;
+        uint32_t hostPort = OFPP_NONE;
+        bool hasHostMac = false;
+        uint8_t hostMac[6];
 
         if (hasTunDest) {
             outReg = tunDst->to_v4().to_ulong();
             meta = flow::meta::out::REMOTE_TUNNEL;
         } else {
             meta = flow::meta::out::HOST_ACCESS;
+            hasHostMac = getHostAccess(agent.getEndpointManager(),
+                                       switchManager, hostPort, hostMac);
         }
 
         if (hasMac) {
@@ -1470,6 +1498,7 @@ void IntFlowManager::handleRemoteEndpointUpdate(const string& uuid) {
                 .go(POL_TABLE_ID)
                 .parent().build(elBridgeDst);
         }
+
 
         // Get remote endpoint IP addresses
         ep.get()->resolveInvRemoteIp(invIps);
@@ -1507,6 +1536,25 @@ void IntFlowManager::handleRemoteEndpointUpdate(const string& uuid) {
                     .go(POL_TABLE_ID)
                     .parent().build(elRouteDst);
             } else {
+                /*
+                 * ingress (=> pod) uses veth_host mac and inPort
+                 * but epg from the subnet. A priority 140 rule
+                 * for veth_host subnets overrides these rules
+                 * in the source table. So the SEPG will either
+                 * be EPG of veth_host for its subnets or EPG
+                 * of ext policy for ext policy subnets programmed
+                 * here. These flows only depend on veth_host
+                 * endpoint file which should always be there in
+                 * the cloud case.
+                 */
+                if (hasHostMac && hostPort != OFPP_NONE) {
+                    actionSource(FlowBuilder().priority(10 + prefix)
+                                 .ipSrc(addr, prefix)
+                                 .inPort(hostPort).ethSrc(hostMac),
+                                 epgVnid, bdId, fgrpId, rdId)
+                         .build(elSrc);
+                }
+                // egress (<= pod)
                 routeFlow
                     .priority(10 + prefix)
                     .ethType(eth::type::IP)
@@ -1543,6 +1591,7 @@ void IntFlowManager::handleRemoteEndpointUpdate(const string& uuid) {
         }
     }
 
+    switchManager.writeFlow(uuid, SRC_TABLE_ID, elSrc);
     switchManager.writeFlow(uuid, BRIDGE_TABLE_ID, elBridgeDst);
     switchManager.writeFlow(uuid, ROUTE_TABLE_ID, elRouteDst);
 }
@@ -1605,9 +1654,8 @@ static void flowsEndpointSNAT(SnatManager& snatMgr,
     uint8_t prefixlen = 0;
 
     for (const string& ipStr : endPoint.getIPs()) {
-        address nwSrc =
-            address::from_string(ipStr, ec);
-        if (ec) {
+        network::cidr_t cidr;
+        if (!network::cidr_from_string(ipStr, cidr, false)) {
             LOG(WARNING) << "Invalid endpoint IP: "
                          << ipStr << ": " << ec.message();
             continue;
@@ -1617,14 +1665,14 @@ static void flowsEndpointSNAT(SnatManager& snatMgr,
         for (auto it = as.getDest().begin(); it != as.getDest().end(); ++it) {
             if (count >= 32) {
                 LOG(WARNING) << "Limit 32 reached when adding SNAT for rdId "
-                             << rdId << " src " << nwSrc << " dst " << *it
+                             << rdId << " src " << cidr.first << " dst " << *it
                              << " , hence skipping";
                 continue;
             }
             FlowBuilder frd;
             frd.priority(300 - count)
                .reg(6, rdId)
-               .ipSrc(nwSrc);
+               .ipSrc(cidr.first);
             std::stringstream ss(*it);
             std::string addr, mask;
             std::getline(ss, addr, '/');
@@ -1650,7 +1698,7 @@ static void flowsEndpointSNAT(SnatManager& snatMgr,
             boost::optional<Snat::PortRanges> prs = as.getPortRanges("local");
             if (prs != boost::none && prs.get().size() > 0) {
                 for (const auto& pr : prs.get()) {
-                    flowsEndpointPortRangeSNAT(as, nwSrc, nwDst, prefixlen,
+                    flowsEndpointPortRangeSNAT(as, cidr.first, nwDst, prefixlen,
                                                pr.start, pr.end,
                                                rdId, zoneId, ofPort, count,
                                                elSnat);
@@ -1662,7 +1710,7 @@ static void flowsEndpointSNAT(SnatManager& snatMgr,
         // Program reverse flows to reach this endpoint
         FlowBuilder()
             .priority(10)
-            .ipDst(nwSrc)
+            .ipDst(cidr.first)
             .conntrackState(FlowBuilder::CT_TRACKED |
                             FlowBuilder::CT_ESTABLISHED,
                             FlowBuilder::CT_TRACKED |
@@ -1705,12 +1753,12 @@ void IntFlowManager::handleEndpointUpdate(const string& uuid) {
 
     std::vector<address> ipAddresses;
     for (const string& ipStr : endPoint.getIPs()) {
-        address addr = address::from_string(ipStr, ec);
-        if (ec) {
+        network::cidr_t cidr;
+        if (!network::cidr_from_string(ipStr, cidr, false)) {
             LOG(WARNING) << "Invalid endpoint IP: "
                          << ipStr << ": " << ec.message();
         } else {
-            ipAddresses.push_back(addr);
+            ipAddresses.push_back(cidr.first);
         }
     }
     if (hasMac) {
@@ -1786,11 +1834,13 @@ void IntFlowManager::handleEndpointUpdate(const string& uuid) {
                             hasMac, macAddr, virtualDHCPEnabled,
                             hasForwardingInfo, epgVnid, rdId, bdId);
 
+    bool hostAcc = false;
     /* Add ARP responder for veth_host */
     if (uuid.find("veth_host_ac") != std::string::npos) {
+        hostAcc = true;
         for (const string& ipStr : endPoint.getIPs()) {
-            address ipa = address::from_string(ipStr, ec);
-            if (ec) {
+            network::cidr_t cidr;
+            if (!network::cidr_from_string(ipStr, cidr, false)) {
                 LOG(WARNING) << "Invalid endpoint IP: "
                              << ipStr << ": " << ec.message();
                 continue;
@@ -1800,7 +1850,7 @@ void IntFlowManager::handleEndpointUpdate(const string& uuid) {
             }
             FlowBuilder proxyArp;
             proxyArp.priority(41).inPort(ofPort)
-                .ethSrc(macAddr).arpSrc(ipa)
+                .ethSrc(macAddr).arpSrc(cidr.first)
                 .proto(arp::op::REQUEST)
                 .ethDst(packets::MAC_ADDR_BROADCAST)
                 .action()
@@ -1810,7 +1860,7 @@ void IntFlowManager::handleEndpointUpdate(const string& uuid) {
                     .regMove(MFF_ARP_SHA, MFF_ARP_THA)
                     .reg(MFF_ARP_SHA, getRouterMacAddr())
                     .regMove(MFF_ARP_TPA, MFF_ARP_SPA)
-                    .reg(MFF_ARP_TPA, ipa.to_v4().to_ulong())
+                    .reg(MFF_ARP_TPA, cidr.first.to_v4().to_ulong())
                     .output(OFPP_IN_PORT)
                     .parent().build(elPortSec);
         }
@@ -1854,7 +1904,7 @@ void IntFlowManager::handleEndpointUpdate(const string& uuid) {
                              hasMac, macAddr, ipAddresses);
 
         /* Source Table flows; applicable only to local endpoints */
-        flowsEndpointSource(elSrc, endPoint, ofPort,
+        flowsEndpointSource(elSrc, endPoint, ofPort, hostAcc,
                             hasMac, macAddr, unkFloodMode, bcastFloodMode,
                             epgVnid, bdId, fgrpId, rdId);
 
@@ -3245,12 +3295,15 @@ void IntFlowManager::updatePodSvcStatsFlows (const string &uuid,
                 }
 
                 for (const string& epipStr : endPoint.getIPs()) {
+                    network::cidr_t cidr;
+                    if (!network::cidr_from_string(epipStr, cidr, false))
+                        continue;
                     // Dont create EPIP <--> SVCIP flows if EPIP is one of the
                     // next hops of this service.
                     const auto& nhips = sm.getNextHopIPs();
-                    if (nhips.find(epipStr) == nhips.end()) {
+                    if (nhips.find(cidr.first.to_string()) == nhips.end()) {
                         podSvcFlowAddExpr(epUuid+":"+uuid,
-                                          epipStr, sm,
+                                          cidr.first.to_string(), sm,
                                           endPoint.getAttributes(),
                                           as.getAttributes());
                     } else {
@@ -3304,6 +3357,9 @@ void IntFlowManager::updatePodSvcStatsFlows (const string &uuid,
         // cleaned up.
         unordered_set<string> epsvc_uuids;
         for (const string& epipStr : endPoint.getIPs()) {
+             network::cidr_t cidr;
+             if (!network::cidr_from_string(epipStr, cidr, false))
+                 continue;
 
             for (const string& svcUuid : svcUuids) {
                 shared_ptr<const Service> asWrapper
@@ -3328,9 +3384,9 @@ void IntFlowManager::updatePodSvcStatsFlows (const string &uuid,
                     // Dont create EPIP <--> SVCIP flows if EPIP is one of the
                     // next hops of this service.
                     const auto& nhips = sm.getNextHopIPs();
-                    if (nhips.find(epipStr) == nhips.end()) {
+                    if (nhips.find(cidr.first.to_string()) == nhips.end()) {
                         podSvcFlowAddExpr(uuid+":"+svcUuid,
-                                          epipStr, sm,
+                                          cidr.first.to_string(), sm,
                                           endPoint.getAttributes(),
                                           as.getAttributes());
                     } else {

--- a/agent-ovs/ovs/IntFlowManager.cpp
+++ b/agent-ovs/ovs/IntFlowManager.cpp
@@ -104,9 +104,11 @@ static const char* ID_NMSPC_L24CLASS_RULE = ID_NAMESPACES[4];
 static const char* ID_NMSPC_SVCSTATS      = ID_NAMESPACES[5];
 static const char* ID_NMSPC_SERVICE       = ID_NAMESPACES[6];
 
-void IntFlowManager::populateTableDescriptionMap() {
+
+
+void IntFlowManager::populateTableDescriptionMap(
+        SwitchManager::TableDescriptionMap &fwdTblDescr) {
     // Populate descriptions of flow tables
-    SwitchManager::TableDescriptionMap fwdTblDescr;
 #define TABLE_DESC(table_id, table_name, drop_reason) \
         fwdTblDescr.insert( \
                     std::make_pair(table_id, \
@@ -134,7 +136,6 @@ void IntFlowManager::populateTableDescriptionMap() {
     TABLE_DESC(OUT_TABLE_ID, "OUT_TABLE",
             "Derived output port missing/incorrect")
 #undef TABLE_DESC
-    switchManager.setForwardingTableList(fwdTblDescr);
 }
 
 IntFlowManager::IntFlowManager(Agent& agent_,
@@ -156,7 +157,9 @@ IntFlowManager::IntFlowManager(Agent& agent_,
     advertManager(agent, *this), isSyncing(false), stopping(false) {
     // set up flow tables
     switchManager.setMaxFlowTables(NUM_FLOW_TABLES);
-    populateTableDescriptionMap();
+    SwitchManager::TableDescriptionMap fwdTblDescr;
+    populateTableDescriptionMap(fwdTblDescr);
+    switchManager.setForwardingTableList(fwdTblDescr);
 
     memset(routerMac, 0, sizeof(routerMac));
     memset(dhcpMac, 0, sizeof(dhcpMac));

--- a/agent-ovs/ovs/IntFlowManager.cpp
+++ b/agent-ovs/ovs/IntFlowManager.cpp
@@ -2328,7 +2328,8 @@ updateSvcTgtStatsCounters (const uint64_t &cookie,
                                                      updPktCount,
                                                      opSvcTgt.get()->getTxbytes(0),
                                                      opSvcTgt.get()->getTxpackets(0),
-                                                     epAttr);
+                                                     epAttr,
+                                                     epAttr.size()!=0?true:false);
         } else {
             prometheusManager.addNUpdateSvcTargetCounter(svcUuid,
                                                      nhipStr,
@@ -2336,7 +2337,8 @@ updateSvcTgtStatsCounters (const uint64_t &cookie,
                                                      opSvcTgt.get()->getRxpackets(0),
                                                      updByteCount,
                                                      updPktCount,
-                                                     epAttr);
+                                                     epAttr,
+                                                     epAttr.size()!=0?true:false);
         }
 #endif
     }
@@ -2445,11 +2447,13 @@ void IntFlowManager::clearSvcTgtStatsCounters (const std::string& svcUuid,
         updateSvcStatsCounters(true, svcUuid, oldRxPktCount, oldRxByteCount, false);
         updateSvcStatsCounters(false, svcUuid, oldTxPktCount, oldTxByteCount, false);
 #ifdef HAVE_PROMETHEUS_SUPPORT
-        // If the flows dont exist, dont keep the metric for this
+        // If the flows dont exist, reset the counts back to 0
+        // also remove the extra pod specific label annotations
         prometheusManager.addNUpdateSvcTargetCounter(svcUuid,
                                                      nhipStr,
                                                      0, 0, 0, 0,
-                                                     attr_map());
+                                                     attr_map(),
+                                                     true);
 #endif
     }
     mutator.commit();
@@ -2479,12 +2483,14 @@ void IntFlowManager::clearSvcStatsCounters (const std::string& uuid)
             pSvcTarget->unsetTxpackets();
 #ifdef HAVE_PROMETHEUS_SUPPORT
             // If the flows dont exist, reset the counts back to 0
+            // also remove the extra pod specific label annotations
             auto nhip = pSvcTarget->getIp();
             if (nhip)
                 prometheusManager.addNUpdateSvcTargetCounter(uuid,
                                                              nhip.get(),
                                                              0, 0, 0, 0,
-                                                             attr_map());
+                                                             attr_map(),
+                                                             true);
 #endif
         }
         opSvc.get()->unsetRxbytes();

--- a/agent-ovs/ovs/IntFlowManager.cpp
+++ b/agent-ovs/ovs/IntFlowManager.cpp
@@ -2381,36 +2381,42 @@ updatePodSvcStatsCounters (const uint64_t &cookie,
         if (isEpToSvc) {
             auto pEpToSvc = su.get()->resolveGbpeEpToSvcCounter(
                                         agent.getUuid(), idStr);
-            if (!pEpToSvc) {
-                pEpToSvc = su.get()->addGbpeEpToSvcCounter(
-                                        agent.getUuid(), idStr);
-            }
-
-            auto oldPktCount = pEpToSvc.get()->getPackets(0);
-            auto oldByteCount = pEpToSvc.get()->getBytes(0);
-            pEpToSvc.get()->setPackets(oldPktCount + newPktCount)
-                           .setBytes(oldByteCount + newByteCount);
+            // Create mo and update attributes only during cfg update
             if (!newPktCount) {
+                if (!pEpToSvc) {
+                    pEpToSvc = su.get()->addGbpeEpToSvcCounter(
+                                       agent.getUuid(), idStr);
+                }
                 updatePodSvcStatsAttr<EpToSvcCounter>(pEpToSvc.get(),
                                                       epAttr,
                                                       svcAttr);
             }
+
+            if (pEpToSvc) {
+                auto oldPktCount = pEpToSvc.get()->getPackets(0);
+                auto oldByteCount = pEpToSvc.get()->getBytes(0);
+                pEpToSvc.get()->setPackets(oldPktCount + newPktCount)
+                               .setBytes(oldByteCount + newByteCount);
+            }
         } else {
             auto pSvcToEp = su.get()->resolveGbpeSvcToEpCounter(
                                         agent.getUuid(), idStr);
-            if (!pSvcToEp) {
-                pSvcToEp = su.get()->addGbpeSvcToEpCounter(
-                                        agent.getUuid(), idStr);
-            }
-
-            auto oldPktCount = pSvcToEp.get()->getPackets(0);
-            auto oldByteCount = pSvcToEp.get()->getBytes(0);
-            pSvcToEp.get()->setPackets(oldPktCount + newPktCount)
-                           .setBytes(oldByteCount + newByteCount);
+            // Create mo and update attributes only during cfg update
             if (!newPktCount) {
+                if (!pSvcToEp) {
+                    pSvcToEp = su.get()->addGbpeSvcToEpCounter(
+                                        agent.getUuid(), idStr);
+                }
                 updatePodSvcStatsAttr<SvcToEpCounter>(pSvcToEp.get(),
                                                       epAttr,
                                                       svcAttr);
+            }
+
+            if (pSvcToEp) {
+                auto oldPktCount = pSvcToEp.get()->getPackets(0);
+                auto oldByteCount = pSvcToEp.get()->getBytes(0);
+                pSvcToEp.get()->setPackets(oldPktCount + newPktCount)
+                               .setBytes(oldByteCount + newByteCount);
             }
         }
     }

--- a/agent-ovs/ovs/IntFlowManager.cpp
+++ b/agent-ovs/ovs/IntFlowManager.cpp
@@ -2467,7 +2467,7 @@ updateSvcTgtStatsCounters (const uint64_t &cookie,
                                                      opSvcTgt.get()->getNodePortTxpackets(0),
                                                      svcAttr,
                                                      epAttr,
-                                                     epAttr.size()!=0?true:false, true);
+                                                     false, !epAttr.empty(), true);
             } else {
                 prometheusManager.addNUpdateSvcTargetCounter(svcUuid,
                                                      nhipStr,
@@ -2477,7 +2477,7 @@ updateSvcTgtStatsCounters (const uint64_t &cookie,
                                                      opSvcTgt.get()->getTxpackets(0),
                                                      svcAttr,
                                                      epAttr,
-                                                     epAttr.size()!=0?true:false);
+                                                     false, !epAttr.empty());
             }
         } else {
             if (isNodePort) {
@@ -2489,7 +2489,7 @@ updateSvcTgtStatsCounters (const uint64_t &cookie,
                                                      updPktCount,
                                                      svcAttr,
                                                      epAttr,
-                                                     epAttr.size()!=0?true:false, true);
+                                                     false, !epAttr.empty(), true);
             } else {
                 prometheusManager.addNUpdateSvcTargetCounter(svcUuid,
                                                      nhipStr,
@@ -2499,7 +2499,7 @@ updateSvcTgtStatsCounters (const uint64_t &cookie,
                                                      updPktCount,
                                                      svcAttr,
                                                      epAttr,
-                                                     epAttr.size()!=0?true:false);
+                                                     false, !epAttr.empty());
             }
         }
 #endif
@@ -2689,14 +2689,14 @@ void IntFlowManager::clearSvcTgtStatsCounters (const std::string& svcUuid,
                                                      0, 0, 0, 0,
                                                      svcAttr,
                                                      attr_map(),
-                                                     true, true);
+                                                     false, true, true);
         } else {
             prometheusManager.addNUpdateSvcTargetCounter(svcUuid,
                                                      nhipStr,
                                                      0, 0, 0, 0,
                                                      svcAttr,
                                                      attr_map(),
-                                                     true);
+                                                     false, true);
         }
 #endif
     }
@@ -2750,14 +2750,14 @@ void IntFlowManager::clearSvcStatsCounters (const std::string& uuid,
                                                              0, 0, 0, 0,
                                                              svcAttr,
                                                              attr_map(),
-                                                             true, true);
+                                                             false, true, true);
                 } else {
                     prometheusManager.addNUpdateSvcTargetCounter(uuid,
                                                              nhip.get(),
                                                              0, 0, 0, 0,
                                                              svcAttr,
                                                              attr_map(),
-                                                             true);
+                                                             false, true);
                 }
             }
 #endif
@@ -3104,6 +3104,11 @@ void IntFlowManager::updateSvcNodeStatsFlows (const string &uuid,
                                          const Service::ServiceMapping &sm,
                                          const attr_map &svcAttr,
                                          const attr_map &epAttr) -> void {
+
+        if (!sm.getNodePort()) {
+            LOG(TRACE) << "nodeport not valid for svc uuid: " << svc_uuid;
+            return;
+        }
 
         boost::system::error_code ec;
         address nhAddr = address::from_string(nhipStr, ec);

--- a/agent-ovs/ovs/IntFlowManager.cpp
+++ b/agent-ovs/ovs/IntFlowManager.cpp
@@ -2550,14 +2550,33 @@ void IntFlowManager::updateSvcTgtStatsFlows (const string &uuid,
                 const string &svc_uuid) -> void {
         switchManager.clearFlows(flow_uuid, STATS_TABLE_ID);
         clearSvcStatsCounters(svc_uuid);
+
+        // Idgen would have restored the ids during agent restart. If flows for this
+        // service needs to be removed, then free up the restored IDs as well.
+        ServiceManager& srvMgr = agent.getServiceManager();
+        shared_ptr<const Service> asWrapper = srvMgr.getService(svc_uuid);
+        if (asWrapper) {
+            const Service& as = *asWrapper;
+            for (auto const& sm : as.getServiceMappings()) {
+                for (const string& nhip : sm.getNextHopIPs()) {
+                    idGen.erase(ID_NMSPC_SVCSTATS, "antosvc:"+flow_uuid+":"+nhip);
+                    idGen.erase(ID_NMSPC_SVCSTATS, "svctoan:"+flow_uuid+":"+nhip);
+                    if (svc_nh_map.find(svc_uuid) != svc_nh_map.end())
+                        svc_nh_map[svc_uuid].erase(nhip);
+                }
+            }
+        }
+
+        // Above should have freed up all the ids. But during svc delete, asWrapper will be
+        // null. Use svc_nh_map to free up in that case.
         if (svc_nh_map.find(svc_uuid) != svc_nh_map.end()) {
             for (const string& nhip : svc_nh_map[svc_uuid]) {
                 idGen.erase(ID_NMSPC_SVCSTATS, "antosvc:"+flow_uuid+":"+nhip);
                 idGen.erase(ID_NMSPC_SVCSTATS, "svctoan:"+flow_uuid+":"+nhip);
             }
-            svc_nh_map[svc_uuid].clear();
-            svc_nh_map.erase(svc_uuid);
         }
+        svc_nh_map[svc_uuid].clear();
+        svc_nh_map.erase(svc_uuid);
     };
 
     // build this set to detect if any svc-tgt state needs to be removed
@@ -2630,23 +2649,23 @@ void IntFlowManager::updateSvcTgtStatsFlows (const string &uuid,
         matchActionServiceProto(svcToAny, proto, sm, false, false);
 
         if (nhAddr.is_v4()) {
-            anyToSvc.priority(98).ethType(eth::type::IP)
+            anyToSvc.priority(97).ethType(eth::type::IP)
                     .ipDst(nhAddr)
                     .flags(OFPUTIL_FF_SEND_FLOW_REM)
                     .cookie(ovs_htonll(cookieIdIg))
                     .action().go(OUT_TABLE_ID);
-            svcToAny.priority(98).ethType(eth::type::IP)
+            svcToAny.priority(97).ethType(eth::type::IP)
                     .ipSrc(nhAddr)
                     .flags(OFPUTIL_FF_SEND_FLOW_REM)
                     .cookie(ovs_htonll(cookieIdEg))
                     .action().go(OUT_TABLE_ID);
         } else {
-            anyToSvc.priority(98).ethType(eth::type::IPV6)
+            anyToSvc.priority(97).ethType(eth::type::IPV6)
                     .ipDst(nhAddr)
                     .flags(OFPUTIL_FF_SEND_FLOW_REM)
                     .cookie(ovs_htonll(cookieIdIg))
                     .action().go(OUT_TABLE_ID);
-            svcToAny.priority(98).ethType(eth::type::IPV6)
+            svcToAny.priority(97).ethType(eth::type::IPV6)
                     .ipSrc(nhAddr)
                     .flags(OFPUTIL_FF_SEND_FLOW_REM)
                     .cookie(ovs_htonll(cookieIdEg))
@@ -2731,8 +2750,15 @@ void IntFlowManager::updateSvcTgtStatsFlows (const string &uuid,
         // If the EP became local, then stats flows need to be added
         // If new IP is added, then stats flows will be added
         // If an IP is deleted, then stats flows will be deleted
-        for (const string& svcUuid : svcUuids)
+        for (const string& svcUuid : svcUuids) {
             updateSvcTgtStatsFlows(svcUuid, true, true);
+            // If EP IP is added, and happens to be NH of this service, then cookie needs to be updated
+            // If EP IP is deleted, and happens to be NH of this service, then cookie needs to be removed
+            // If EP IP is modified:
+            //  - if it became NH of this service, then cookie needs to be updated
+            //  - if it moved away from being NH of this service, then cookie needs to be removed
+            programServiceSnatDnatFlows(svcUuid);
+        }
     }
 
     for (auto &p : uuid_felist_map)
@@ -3047,6 +3073,238 @@ void IntFlowManager::updatePodSvcStatsFlows (const string &uuid,
         switchManager.writeFlow(p.first, STATS_TABLE_ID, p.second);
 }
 
+void IntFlowManager::programServiceSnatDnatFlows (const string& uuid)
+{
+    LOG(DEBUG) << "Updating snat dnat flows for service " << uuid;
+
+    ServiceManager& srvMgr = agent.getServiceManager();
+    shared_ptr<const Service> asWrapper = srvMgr.getService(uuid);
+
+    if (!asWrapper || !asWrapper->getDomainURI()) {
+        return;
+    }
+    const Service& as = *asWrapper;
+    FlowEntryList serviceRevFlows;
+    FlowEntryList serviceNextHopFlows;
+
+    boost::system::error_code ec;
+
+    uint32_t ofPort = OFPP_NONE;
+    const optional<string>& ofPortName = as.getInterfaceName();
+    if (ofPortName)
+        ofPort = switchManager.getPortMapper().FindPort(ofPortName.get());
+
+    optional<shared_ptr<RoutingDomain > > rd =
+        RoutingDomain::resolve(agent.getFramework(),
+                               as.getDomainURI().get());
+
+    if (rd) {
+        uint8_t smacAddr[6];
+        const uint8_t* macAddr = smacAddr;
+        if (as.getServiceMAC()) {
+            as.getServiceMAC().get().toUIntArray(smacAddr);
+        } else {
+            macAddr = getRouterMacAddr();
+        }
+
+        uint32_t rdId = getId(RoutingDomain::CLASS_ID, as.getDomainURI().get());
+        uint32_t ctMark = idGen.getId(ID_NMSPC_SERVICE, uuid);
+        if (as.getInterfaceName())
+            ctMark |= 1 << 31;
+
+        for (auto const& sm : as.getServiceMappings()) {
+            if (!sm.getServiceIP())
+                continue;
+
+            uint16_t zoneId = -1;
+            if (conntrackEnabled && sm.isConntrackMode()) {
+                zoneId = ctZoneManager.getId(as.getDomainURI()->toString());
+                if (zoneId == static_cast<uint16_t>(-1))
+                    LOG(ERROR) << "Could not allocate connection tracking"
+                               << " zone for "
+                               << as.getDomainURI().get();
+            }
+
+            address serviceAddr =
+                address::from_string(sm.getServiceIP().get(), ec);
+            if (ec) {
+                LOG(WARNING) << "Invalid service IP: "
+                             << sm.getServiceIP().get()
+                             << ": " << ec.message();
+                continue;
+            }
+
+            vector<address> nextHopAddrs;
+            for (const string& ipstr : sm.getNextHopIPs()) {
+                auto nextHopAddr = address::from_string(ipstr, ec);
+                if (ec) {
+                    LOG(WARNING) << "Invalid service next hop IP: "
+                                 << ipstr << ": " << ec.message();
+                } else {
+                    nextHopAddrs.push_back(nextHopAddr);
+                }
+            }
+
+            uint8_t proto = 0;
+            if (sm.getServiceProto()) {
+                const string& protoStr = sm.getServiceProto().get();
+                if ("udp" == protoStr)
+                    proto = 17;
+                else
+                    proto = 6;
+            }
+
+
+            uint16_t link = 0;
+            for (const address& nextHopAddr : nextHopAddrs) {
+                {
+                    FlowBuilder ipMap;
+                    matchDestDom(ipMap, 0, rdId);
+                    matchActionServiceProto(ipMap, proto, sm, true, true);
+                    ipMap.ipDst(serviceAddr);
+
+                    // use the first address as a "default" so that
+                    // there is no transient case where there is no
+                    // match while flows are updated.
+                    if (link == 0) {
+                        ipMap.priority(99);
+                    } else {
+                        ipMap.priority(100)
+                            .reg(7, link);
+                    }
+                    ipMap.action().ipDst(nextHopAddr).decTtl();
+
+                    if (as.getServiceMode() == Service::LOADBALANCER) {
+                        // For LB: save v4 service address to reg8
+                        // Save v6 addr in regs 8 to 11
+                        if (serviceAddr.is_v4()) {
+                            ipMap.action()
+                                .reg(MFF_REG8, serviceAddr.to_v4().to_ulong());
+                        } else {
+                            uint32_t pAddr[4];
+                            in6AddrToLong(serviceAddr, &pAddr[0]);
+                            ipMap.action()
+                                .reg(MFF_REG8, pAddr[0])
+                                .reg(MFF_REG9, pAddr[1])
+                                .reg(MFF_REG10, pAddr[2])
+                                .reg(MFF_REG11, pAddr[3]);
+                        }
+
+                        if (zoneId != static_cast<uint16_t>(-1)) {
+                            uint32_t metav = as.getInterfaceName()
+                                ? flow::meta::FROM_SERVICE_INTERFACE
+                                : 0;
+
+                            ipMap.metadata(metav,
+                                           flow::meta::FROM_SERVICE_INTERFACE);
+
+                            ActionBuilder setMark;
+                            setMark.reg(MFF_CT_MARK, ctMark);
+                            ipMap.action()
+                                .conntrack(ActionBuilder::CT_COMMIT,
+                                           static_cast<mf_field_id>(0),
+                                           zoneId, 0xff, 0, setMark);
+                        }
+
+                        // If a cookie was already allocated by updateSvcTgtStatsFlows(), then
+                        // use it.
+                        const string& ingStr = "antosvc:svc-tgt:"+uuid+":"+nextHopAddr.to_string();
+                        uint32_t cookieIdIg = idGen.getIdNoAlloc(ID_NMSPC_SVCSTATS, ingStr);
+                        if (cookieIdIg != static_cast<uint32_t>(-1)) {
+                            ipMap.cookie(ovs_htonll((uint64_t)cookieIdIg))
+                                 .flags(OFPUTIL_FF_SEND_FLOW_REM);
+                        }
+
+                        ipMap.action()
+                            .metadata(flow::meta::ROUTED, flow::meta::ROUTED)
+                            .go(ROUTE_TABLE_ID);
+                    } else if (as.getServiceMode() == Service::LOCAL_ANYCAST &&
+                               ofPort != OFPP_NONE) {
+                        ipMap.action().output(ofPort);
+                    }
+
+                    ipMap.build(serviceNextHopFlows);
+                }
+                if (as.getServiceMode() == Service::LOADBALANCER) {
+                    // For load balanced services reverse traffic is
+                    // handled with normal policy semantics
+                    if (zoneId != static_cast<uint16_t>(-1)) {
+                        if (encapType == ENCAP_VLAN) {
+                            // traffic from the uplink will originally
+                            // have had a vlan tag that was stripped
+                            // in the source table.  Restore the tag
+                            // before running through the conntrack
+                            // table to ensure we can property rebuild
+                            // the state when the packet comes back.
+                            flowRevMapCt(serviceRevFlows, 101,
+                                         sm, nextHopAddr, rdId, zoneId, proto,
+                                         getTunnelPort(), ENCAP_VLAN);
+                        }
+                        flowRevMapCt(serviceRevFlows, 100,
+                                     sm, nextHopAddr, rdId, zoneId, proto,
+                                     0, ENCAP_NONE);
+                    }
+                    {
+                        FlowBuilder ipRevMap;
+                        matchDestDom(ipRevMap, 0, rdId);
+                        matchActionServiceProto(ipRevMap, proto, sm,
+                                                false, true);
+
+                        // If a cookie was already allocated by updateSvcTgtStatsFlows(), then
+                        // use it.
+                        const string& egrStr = "svctoan:svc-tgt:"+uuid+":"+nextHopAddr.to_string();
+                        uint32_t cookieIdEg = idGen.getIdNoAlloc(ID_NMSPC_SVCSTATS, egrStr);
+                        if (cookieIdEg != static_cast<uint32_t>(-1)) {
+                            ipRevMap.cookie(ovs_htonll((uint64_t)cookieIdEg))
+                                    .flags(OFPUTIL_FF_SEND_FLOW_REM);
+                        }
+                        ipRevMap.priority(100)
+                            .ipSrc(nextHopAddr)
+                            .action()
+                            .ethSrc(macAddr)
+                            .ipSrc(serviceAddr)
+                            .decTtl();
+                        if (zoneId != static_cast<uint16_t>(-1)) {
+                            ipRevMap
+                                .conntrackState(FlowBuilder::CT_TRACKED |
+                                                FlowBuilder::CT_ESTABLISHED,
+                                                FlowBuilder::CT_TRACKED |
+                                                FlowBuilder::CT_ESTABLISHED |
+                                                FlowBuilder::CT_INVALID |
+                                                FlowBuilder::CT_NEW);
+
+                            ipRevMap.ctMark(ctMark);
+                        }
+                        if (!as.getInterfaceName()) {
+                            ipRevMap.action()
+                                .metadata(flow::meta::ROUTED,
+                                          flow::meta::ROUTED)
+                                .go(BRIDGE_TABLE_ID);
+                        } else if (ofPort != OFPP_NONE) {
+                            if (as.getIfaceVlan()) {
+                                ipRevMap.action()
+                                    .pushVlan()
+                                    .setVlanVid(as.getIfaceVlan().get());
+                            }
+                            ipRevMap.action()
+                                .ethDst(getRouterMacAddr())
+                                .output(ofPort);
+                        }
+                        ipRevMap.build(serviceRevFlows);
+                    }
+                }
+
+                link += 1;
+            }
+
+        }
+    }
+
+    switchManager.writeFlow(uuid, SERVICE_REV_TABLE_ID, serviceRevFlows);
+    switchManager.writeFlow(uuid, SERVICE_NEXTHOP_TABLE_ID,
+                            serviceNextHopFlows);
+}
+
 void IntFlowManager::handleServiceUpdate(const string& uuid) {
     LOG(DEBUG) << "Updating service " << uuid;
 
@@ -3068,9 +3326,7 @@ void IntFlowManager::handleServiceUpdate(const string& uuid) {
 
     FlowEntryList secFlows;
     FlowEntryList bridgeFlows;
-    FlowEntryList serviceRevFlows;
     FlowEntryList serviceDstFlows;
-    FlowEntryList serviceNextHopFlows;
 
     boost::system::error_code ec;
 
@@ -3183,131 +3439,6 @@ void IntFlowManager::handleServiceUpdate(const string& uuid) {
                 }
 
                 serviceDest.build(bridgeFlows);
-            }
-
-            uint16_t link = 0;
-            for (const address& nextHopAddr : nextHopAddrs) {
-                {
-                    FlowBuilder ipMap;
-                    matchDestDom(ipMap, 0, rdId);
-                    matchActionServiceProto(ipMap, proto, sm, true, true);
-                    ipMap.ipDst(serviceAddr);
-
-                    // use the first address as a "default" so that
-                    // there is no transient case where there is no
-                    // match while flows are updated.
-                    if (link == 0) {
-                        ipMap.priority(99);
-                    } else {
-                        ipMap.priority(100)
-                            .reg(7, link);
-                    }
-                    ipMap.action().ipDst(nextHopAddr).decTtl();
-
-                    if (as.getServiceMode() == Service::LOADBALANCER) {
-                        // For LB: save v4 service address to reg8
-                        // Save v6 addr in regs 8 to 11
-                        if (serviceAddr.is_v4()) {
-                            ipMap.action()
-                                .reg(MFF_REG8, serviceAddr.to_v4().to_ulong());
-                        } else {
-                            uint32_t pAddr[4];
-                            in6AddrToLong(serviceAddr, &pAddr[0]);
-                            ipMap.action()
-                                .reg(MFF_REG8, pAddr[0])
-                                .reg(MFF_REG9, pAddr[1])
-                                .reg(MFF_REG10, pAddr[2])
-                                .reg(MFF_REG11, pAddr[3]);
-                        }
-
-                        if (zoneId != static_cast<uint16_t>(-1)) {
-                            uint32_t metav = as.getInterfaceName()
-                                ? flow::meta::FROM_SERVICE_INTERFACE
-                                : 0;
-
-                            ipMap.metadata(metav,
-                                           flow::meta::FROM_SERVICE_INTERFACE);
-
-                            ActionBuilder setMark;
-                            setMark.reg(MFF_CT_MARK, ctMark);
-                            ipMap.action()
-                                .conntrack(ActionBuilder::CT_COMMIT,
-                                           static_cast<mf_field_id>(0),
-                                           zoneId, 0xff, 0, setMark);
-                        }
-
-                        ipMap.action()
-                            .metadata(flow::meta::ROUTED, flow::meta::ROUTED)
-                            .go(ROUTE_TABLE_ID);
-                    } else if (as.getServiceMode() == Service::LOCAL_ANYCAST &&
-                               ofPort != OFPP_NONE) {
-                        ipMap.action().output(ofPort);
-                    }
-
-                    ipMap.build(serviceNextHopFlows);
-                }
-                if (as.getServiceMode() == Service::LOADBALANCER) {
-                    // For load balanced services reverse traffic is
-                    // handled with normal policy semantics
-                    if (zoneId != static_cast<uint16_t>(-1)) {
-                        if (encapType == ENCAP_VLAN) {
-                            // traffic from the uplink will originally
-                            // have had a vlan tag that was stripped
-                            // in the source table.  Restore the tag
-                            // before running through the conntrack
-                            // table to ensure we can property rebuild
-                            // the state when the packet comes back.
-                            flowRevMapCt(serviceRevFlows, 101,
-                                         sm, nextHopAddr, rdId, zoneId, proto,
-                                         getTunnelPort(), ENCAP_VLAN);
-                        }
-                        flowRevMapCt(serviceRevFlows, 100,
-                                     sm, nextHopAddr, rdId, zoneId, proto,
-                                     0, ENCAP_NONE);
-                    }
-                    {
-                        FlowBuilder ipRevMap;
-                        matchDestDom(ipRevMap, 0, rdId);
-                        matchActionServiceProto(ipRevMap, proto, sm,
-                                                false, true);
-
-                        ipRevMap.priority(100)
-                            .ipSrc(nextHopAddr)
-                            .action()
-                            .ethSrc(macAddr)
-                            .ipSrc(serviceAddr)
-                            .decTtl();
-                        if (zoneId != static_cast<uint16_t>(-1)) {
-                            ipRevMap
-                                .conntrackState(FlowBuilder::CT_TRACKED |
-                                                FlowBuilder::CT_ESTABLISHED,
-                                                FlowBuilder::CT_TRACKED |
-                                                FlowBuilder::CT_ESTABLISHED |
-                                                FlowBuilder::CT_INVALID |
-                                                FlowBuilder::CT_NEW);
-
-                            ipRevMap.ctMark(ctMark);
-                        }
-                        if (!as.getInterfaceName()) {
-                            ipRevMap.action()
-                                .metadata(flow::meta::ROUTED,
-                                          flow::meta::ROUTED)
-                                .go(BRIDGE_TABLE_ID);
-                        } else if (ofPort != OFPP_NONE) {
-                            if (as.getIfaceVlan()) {
-                                ipRevMap.action()
-                                    .pushVlan()
-                                    .setVlanVid(as.getIfaceVlan().get());
-                            }
-                            ipRevMap.action()
-                                .ethDst(getRouterMacAddr())
-                                .output(ofPort);
-                        }
-                        ipRevMap.build(serviceRevFlows);
-                    }
-                }
-
-                link += 1;
             }
 
             if (ofPort != OFPP_NONE) {
@@ -3463,11 +3594,9 @@ void IntFlowManager::handleServiceUpdate(const string& uuid) {
         }
     }
 
+    programServiceSnatDnatFlows(uuid);
     switchManager.writeFlow(uuid, SEC_TABLE_ID, secFlows);
     switchManager.writeFlow(uuid, BRIDGE_TABLE_ID, bridgeFlows);
-    switchManager.writeFlow(uuid, SERVICE_REV_TABLE_ID, serviceRevFlows);
-    switchManager.writeFlow(uuid, SERVICE_NEXTHOP_TABLE_ID,
-                            serviceNextHopFlows);
     switchManager.writeFlow(uuid, SERVICE_DST_TABLE_ID, serviceDstFlows);
 }
 

--- a/agent-ovs/ovs/IntFlowManager.cpp
+++ b/agent-ovs/ovs/IntFlowManager.cpp
@@ -5285,7 +5285,7 @@ void IntFlowManager::handleRoutingDomainUpdate(const URI& rdURI) {
     LOG(DEBUG) << "Updating routing domain " << rdURI;
 #ifdef HAVE_PROMETHEUS_SUPPORT
     prometheusManager.addNUpdateRDDropCounter(rdURI.toString(),
-                                              true);
+                                              true, 0, 0);
 #endif
 
     FlowEntryList rdRouteFlows;

--- a/agent-ovs/ovs/JsonRpc.cpp
+++ b/agent-ovs/ovs/JsonRpc.cpp
@@ -48,8 +48,6 @@ bool JsonRpc::createNetFlow(const string& brUuid, const string& target, const in
     JsonRpcTransactMessage msg1(OvsdbOperation::INSERT, OvsdbTable::NETFLOW);
     msg1.rows["targets"] = tdSet;
 
-    TupleData iTimeout("", timeout);
-
     tuples.clear();
     tuples.emplace_back("", timeout);
     tdSet = TupleDataSet(tuples);

--- a/agent-ovs/ovs/JsonRpc.cpp
+++ b/agent-ovs/ovs/JsonRpc.cpp
@@ -204,43 +204,6 @@ void JsonRpc::printMirMap(const map<string, mirror>& mirMap) {
     }
 }
 
-void JsonRpc::handleGetBridgeMirrorUuidResp(uint64_t reqId, const Document& payload) {
-    list<string> ids = {"0","rows","0","_uuid","1"};
-    string brUuid;
-    Value val;
-    opflexagent::getValue(payload, ids, val);
-    if (!val.IsNull() && val.IsString()) {
-        LOG(DEBUG) << "bridge uuid " << val.GetString();
-        brUuid = val.GetString();
-    } else {
-        responseReceived = true;
-        return;
-    }
-    // OVS supports only one mirror, expect only one.
-    ids = {"0","rows","0","mirrors","1"};
-    Value val2;
-    opflexagent::getValue(payload, ids, val2);
-    string mirUuid;
-    if (!val2.IsNull() && val2.IsString()) {
-        LOG(DEBUG) << "mirror uuid " << val2.GetString();
-        mirUuid = val2.GetString();
-    } else {
-        LOG(WARNING) << "did not find mirror ID";
-        responseReceived = true;
-        return;
-    }
-    for (auto& elem : mirMap) {
-        if ((elem.second).uuid == mirUuid) {
-            LOG(DEBUG) << "found mirror, adding bridge uuid";
-            (elem.second).brUuid = brUuid;
-            break;
-        }
-    }
-    printMirMap(mirMap);
-    conn->ready.notify_all();
-    responseReceived = true;
-}
-
 bool JsonRpc::updateBridgePorts(tuple<string,set<string>> ports,
         const string& port, bool action) {
     string brPortUuid = get<0>(ports);
@@ -794,13 +757,6 @@ bool JsonRpc::handleCreateMirrorResp(uint64_t reqId, const Document& payload) {
         return false;
     }
     return true;
-}
-
-void JsonRpc::handleAddMirrorToBridgeResp(uint64_t reqId, const Document& payload) {
-}
-
-void JsonRpc::handleAddErspanPortResp(uint64_t reqId, const Document& payload) {
-    responseReceived = true;
 }
 
 bool JsonRpc::deleteMirror(const string& brName) {

--- a/agent-ovs/ovs/OVSRenderer.cpp
+++ b/agent-ovs/ovs/OVSRenderer.cpp
@@ -459,13 +459,15 @@ void OVSRenderer::setProperties(const ptree& properties) {
 
     std::string tnlEpAdvStr =
         properties.get<std::string>(ENDPOINT_TNL_ADV_MODE,
-                                    "rarp-broadcast");
+                                    "garp-rarp-broadcast");
     if (tnlEpAdvStr == "gratuitous-broadcast") {
         tunnelEndpointAdvMode = AdvertManager::EPADV_GRATUITOUS_BROADCAST;
     } else if(tnlEpAdvStr == "disabled") {
         tunnelEndpointAdvMode = AdvertManager::EPADV_DISABLED;
-    } else {
+    } else if(tnlEpAdvStr == "rarp-broadcast") {
         tunnelEndpointAdvMode = AdvertManager::EPADV_RARP_BROADCAST;
+    } else {
+        tunnelEndpointAdvMode = AdvertManager::EPADV_GARP_RARP_BROADCAST;
     }
 
     tunnelEndpointAdvIntvl =

--- a/agent-ovs/ovs/OVSRenderer.cpp
+++ b/agent-ovs/ovs/OVSRenderer.cpp
@@ -34,6 +34,7 @@ static const std::string ID_NMSPC_CONNTRACK("conntrack");
 static const boost::posix_time::milliseconds CLEANUP_INTERVAL(3*60*1000);
 
 #define PACKET_LOGGER_PIDDIR LOCALSTATEDIR"/lib/opflex-agent-ovs/pids"
+#define LOOPBACK "127.0.0.1"
 
 OVSRendererPlugin::OVSRendererPlugin() {
     /* No good way to redirect OVS logs to our logs, suppress them for now */
@@ -80,7 +81,7 @@ OVSRenderer::OVSRenderer(Agent& agent_)
       secGroupStatsEnabled(true), secGroupStatsInterval(0),
       tableDropStatsEnabled(true), tableDropStatsInterval(0),
       spanRenderer(agent_), netflowRenderer(agent_), started(false),
-      dropLogRemotePort(6081), pktLogger(pktLoggerIO, exporterIO) {
+      dropLogRemotePort(6081), dropLogLocalPort(50000), pktLogger(pktLoggerIO, exporterIO) {
 
 }
 
@@ -230,12 +231,6 @@ void OVSRenderer::start() {
                                   this, error));
 
     if(!dropLogIntIface.empty() || !dropLogAccessIface.empty()) {
-        boost::system::error_code ec;
-        boost::asio::ip::address addr = boost::asio::ip::address::from_string(dropLogRemoteIp, ec);
-        if(ec) {
-            LOG(ERROR) << "PacketLogger: Failed to start:" << ec << "invalid address:" <<dropLogRemoteIp;
-            return;
-        }
         // Inform the io_service that we are about to become a daemon. The
         // io_service cleans up any internal resources, such as threads, that may
         // interfere with forking.
@@ -270,20 +265,12 @@ void OVSRenderer::start() {
         bool toSysLog;
         std::tie(log_level, toSysLog, log_file) = logParams;
         initLogging(log_level, toSysLog, log_file);
-        int ns_fd = open(dropLogNs.c_str(), O_RDONLY);
-        if(ns_fd < 0) {
-            LOG(ERROR) << "PacketLogger: Failed to open namespace "
-                       << dropLogNs << ":" << errno;
-            exit(1);
+        boost::system::error_code ec;
+        boost::asio::ip::address addr = boost::asio::ip::address::from_string(LOOPBACK, ec);
+        if(ec) {
+            LOG(ERROR) << "PacketLogger: Failed to convert address " << LOOPBACK;
         }
-
-        int err = setns(ns_fd, CLONE_NEWNET);
-        if(err) {
-            LOG(ERROR) << "PacketLogger: Failed to switch to namespace "
-                       << dropLogNs << ":" << err;
-            exit(1);
-        }
-        pktLogger.setAddress(addr, dropLogRemotePort);
+        pktLogger.setAddress(addr, dropLogLocalPort);
         pktLogger.setNotifSock(getAgent().getPacketEventNotifSock());
         PacketLogHandler::TableDescriptionMap tblDescMap;
         intSwitchManager.getForwardingTableList(tblDescMap);
@@ -291,7 +278,6 @@ void OVSRenderer::start() {
         accessSwitchManager.getForwardingTableList(tblDescMap);
         pktLogger.setAccBridgeTableDescription(tblDescMap);
         if(!pktLogger.startListener()) {
-            LOG(ERROR) << "PacketLogger: Failed to bind socket:" << errno;
             exit(1);
         }
 
@@ -329,6 +315,8 @@ void OVSRenderer::start() {
         client_thread.join();
         signal_thread.join();
         exit(0);
+    } else {
+        LOG(DEBUG) << "DropLog interfaces not configured.Skipping creation";
     }
 
     ovsdbConnection.reset(new OvsdbConnection());
@@ -412,6 +400,7 @@ void OVSRenderer::setProperties(const ptree& properties) {
     static const std::string ENCAP_IFACE("encap-iface");
     static const std::string REMOTE_IP("remote-ip");
     static const std::string REMOTE_PORT("remote-port");
+    static const std::string LOCAL_PORT("local-port");
     static const std::string INT_BR_IFACE("int-br-iface");
     static const std::string ACC_BR_IFACE("access-br-iface");
 
@@ -520,9 +509,9 @@ void OVSRenderer::setProperties(const ptree& properties) {
     if(dropLogEncapGeneve) {
         dropLogIntIface = dropLogEncapGeneve.get().get<std::string>(INT_BR_IFACE, "");
         dropLogAccessIface = dropLogEncapGeneve.get().get<std::string>(ACC_BR_IFACE, "");
-        dropLogRemoteIp = dropLogEncapGeneve.get().get<std::string>(REMOTE_IP, "");
+        dropLogRemoteIp = dropLogEncapGeneve.get().get<std::string>(REMOTE_IP, "192.168.1.2");
         dropLogRemotePort = dropLogEncapGeneve.get().get<uint16_t>(REMOTE_PORT, 6081);
-        dropLogNs = dropLogEncapGeneve.get().get<std::string>(REMOTE_NAMESPACE, "/var/run/netns/DropLog");
+        dropLogLocalPort = dropLogEncapGeneve.get().get<uint16_t>(LOCAL_PORT, 50000);
     }
 
     virtualRouter = properties.get<bool>(VIRTUAL_ROUTER, true);

--- a/agent-ovs/ovs/OVSRenderer.cpp
+++ b/agent-ovs/ovs/OVSRenderer.cpp
@@ -77,7 +77,7 @@ OVSRenderer::OVSRenderer(Agent& agent_)
       virtualDHCP(true), connTrack(true), ctZoneRangeStart(0),
       ctZoneRangeEnd(0), ifaceStatsEnabled(true), ifaceStatsInterval(0),
       contractStatsEnabled(true), contractStatsInterval(0),
-      serviceStatsEnabled(true), serviceStatsInterval(0),
+      serviceStatsFlowDisabled(false), serviceStatsEnabled(true), serviceStatsInterval(0),
       secGroupStatsEnabled(true), secGroupStatsInterval(0),
       tableDropStatsEnabled(true), tableDropStatsInterval(0),
       spanRenderer(agent_), netflowRenderer(agent_), started(false),
@@ -160,7 +160,7 @@ void OVSRenderer::start() {
         accessSwitchManager.registerStateHandler(&accessFlowManager);
         accessSwitchManager.start(accessBridgeName);
     }
-    intFlowManager.start();
+    intFlowManager.start(serviceStatsFlowDisabled);
     intFlowManager.registerModbListeners();
 
     if (accessBridgeName != "") {
@@ -444,6 +444,8 @@ void OVSRenderer::setProperties(const ptree& properties) {
                                                     ".contract.enabled");
     static const std::string STATS_CONTRACT_INTERVAL("statistics"
                                                     ".contract.interval");
+    static const std::string STATS_SERVICE_FLOWDISABLED("statistics"
+                                                        ".service.flow-disabled");
     static const std::string STATS_SERVICE_ENABLED("statistics"
                                                   ".service.enabled");
     static const std::string STATS_SERVICE_INTERVAL("statistics"
@@ -564,6 +566,7 @@ void OVSRenderer::setProperties(const ptree& properties) {
 
     ifaceStatsEnabled = properties.get<bool>(STATS_INTERFACE_ENABLED, true);
     contractStatsEnabled = properties.get<bool>(STATS_CONTRACT_ENABLED, true);
+    serviceStatsFlowDisabled = properties.get<bool>(STATS_SERVICE_FLOWDISABLED, false);
     serviceStatsEnabled = properties.get<bool>(STATS_SERVICE_ENABLED, true);
     secGroupStatsEnabled = properties.get<bool>(STATS_SECGROUP_ENABLED, true);
     ifaceStatsInterval = properties.get<long>(STATS_INTERFACE_INTERVAL, 30000);

--- a/agent-ovs/ovs/OVSRenderer.cpp
+++ b/agent-ovs/ovs/OVSRenderer.cpp
@@ -62,7 +62,7 @@ OVSRenderer::OVSRenderer(Agent& agent_)
       interfaceStatsManager(&agent_, intSwitchManager.getPortMapper(),
                             accessSwitchManager.getPortMapper()),
       contractStatsManager(&agent_, idGen, intSwitchManager),
-      podsvcStatsManager(&agent_, idGen, intSwitchManager,
+      serviceStatsManager(&agent_, idGen, intSwitchManager,
                            intFlowManager),
       secGrpStatsManager(&agent_, idGen, accessSwitchManager),
       tableDropStatsManager(&agent_, idGen, intSwitchManager,
@@ -76,7 +76,7 @@ OVSRenderer::OVSRenderer(Agent& agent_)
       virtualDHCP(true), connTrack(true), ctZoneRangeStart(0),
       ctZoneRangeEnd(0), ifaceStatsEnabled(true), ifaceStatsInterval(0),
       contractStatsEnabled(true), contractStatsInterval(0),
-      podsvcStatsEnabled(true), podsvcStatsInterval(0),
+      serviceStatsEnabled(true), serviceStatsInterval(0),
       secGroupStatsEnabled(true), secGroupStatsInterval(0),
       tableDropStatsEnabled(true), tableDropStatsInterval(0),
       spanRenderer(agent_), netflowRenderer(agent_), started(false),
@@ -193,12 +193,12 @@ void OVSRenderer::start() {
             registerConnection(intSwitchManager.getConnection());
         contractStatsManager.start();
     }
-    if (podsvcStatsEnabled) {
-        podsvcStatsManager.setTimerInterval(podsvcStatsInterval);
-        podsvcStatsManager.setAgentUUID(getAgent().getUuid());
-        podsvcStatsManager.
+    if (serviceStatsEnabled) {
+        serviceStatsManager.setTimerInterval(serviceStatsInterval);
+        serviceStatsManager.setAgentUUID(getAgent().getUuid());
+        serviceStatsManager.
             registerConnection(intSwitchManager.getConnection());
-        podsvcStatsManager.start();
+        serviceStatsManager.start();
     }
     if (secGroupStatsEnabled && accessBridgeName != "") {
         secGrpStatsManager.setTimerInterval(secGroupStatsInterval);
@@ -351,8 +351,8 @@ void OVSRenderer::stop() {
 
     if (ifaceStatsEnabled)
         interfaceStatsManager.stop();
-    if (podsvcStatsEnabled)
-        podsvcStatsManager.stop();
+    if (serviceStatsEnabled)
+        serviceStatsManager.stop();
     if (contractStatsEnabled)
         contractStatsManager.stop();
     if (secGroupStatsEnabled)
@@ -455,10 +455,10 @@ void OVSRenderer::setProperties(const ptree& properties) {
                                                     ".contract.enabled");
     static const std::string STATS_CONTRACT_INTERVAL("statistics"
                                                     ".contract.interval");
-    static const std::string STATS_PODSVC_ENABLED("statistics"
-                                                  ".podsvc.enabled");
-    static const std::string STATS_PODSVC_INTERVAL("statistics"
-                                                   ".podsvc.interval");
+    static const std::string STATS_SERVICE_ENABLED("statistics"
+                                                  ".service.enabled");
+    static const std::string STATS_SERVICE_INTERVAL("statistics"
+                                                   ".service.interval");
     static const std::string STATS_SECGROUP_ENABLED("statistics"
                                                     ".security-group.enabled");
     static const std::string STATS_SECGROUP_INTERVAL("statistics"
@@ -575,15 +575,15 @@ void OVSRenderer::setProperties(const ptree& properties) {
 
     ifaceStatsEnabled = properties.get<bool>(STATS_INTERFACE_ENABLED, true);
     contractStatsEnabled = properties.get<bool>(STATS_CONTRACT_ENABLED, true);
-    podsvcStatsEnabled = properties.get<bool>(STATS_PODSVC_ENABLED, true);
+    serviceStatsEnabled = properties.get<bool>(STATS_SERVICE_ENABLED, true);
     secGroupStatsEnabled = properties.get<bool>(STATS_SECGROUP_ENABLED, true);
     ifaceStatsInterval = properties.get<long>(STATS_INTERFACE_INTERVAL, 30000);
     tableDropStatsEnabled = properties.get<bool>(TABLE_DROP_STATS_ENABLED, true);
 
     contractStatsInterval =
         properties.get<long>(STATS_CONTRACT_INTERVAL, 10000);
-    podsvcStatsInterval =
-        properties.get<long>(STATS_PODSVC_INTERVAL, 10000);
+    serviceStatsInterval =
+        properties.get<long>(STATS_SERVICE_INTERVAL, 10000);
     secGroupStatsInterval =
         properties.get<long>(STATS_SECGROUP_INTERVAL, 10000);
     tableDropStatsInterval =

--- a/agent-ovs/ovs/OvsdbConnection.cpp
+++ b/agent-ovs/ovs/OvsdbConnection.cpp
@@ -72,7 +72,9 @@ void OvsdbConnection::connect_cb(uv_async_t* handle) {
 void OvsdbConnection::stop() {
     uv_close((uv_handle_t*)&connect_async, nullptr);
     uv_close((uv_handle_t*)&send_req_async, nullptr);
-    peer->destroy();
+    if (peer) {
+        peer->destroy();
+    }
     yajr::finiLoop(client_loop);
     threadManager.stopTask("OvsdbConnection");
 }

--- a/agent-ovs/ovs/PacketInHandler.cpp
+++ b/agent-ovs/ovs/PacketInHandler.cpp
@@ -187,7 +187,8 @@ static void send_packet_out(Agent& agent,
 
                 if (ep->getAccessIfaceVlan()) {
                     outActionsSkipVlan = outActions;
-                    send_untagged = true;
+                    if (ep->isAccessAllowUntagged())
+                        send_untagged = true;
                     outActions = [&ep](ActionBuilder& ab) {
                         ab.pushVlan();
                         ab.setVlanVid(ep->getAccessIfaceVlan().get());

--- a/agent-ovs/ovs/PacketLogHandler.cpp
+++ b/agent-ovs/ovs/PacketLogHandler.cpp
@@ -31,6 +31,8 @@ void LocalClient::run() {
     for(;;) {
         if(stopped) {
             boost::system::error_code ec;
+            clientSocket.shutdown(
+		    boost::asio::local::stream_protocol::socket::shutdown_both);
             clientSocket.cancel(ec);
             clientSocket.close(ec);
             break;

--- a/agent-ovs/ovs/PacketLogHandler.cpp
+++ b/agent-ovs/ovs/PacketLogHandler.cpp
@@ -98,6 +98,9 @@ bool PacketLogHandler::startListener()
         return false;
     }
     pktDecoder.configure();
+    if(!socketListener->startListener()) {
+        return false;
+    }
     socketListener->startReceive();
     LOG(INFO) << "PacketLogHandler started!";
     return true;
@@ -136,11 +139,11 @@ void PacketLogHandler::stopExporter()
 
 void UdpServer::handleReceive(const boost::system::error_code& error,
       std::size_t bytes_transferred) {
+
     if (!error || error == boost::asio::error::message_size)
     {
         uint32_t length = (bytes_transferred > 4096) ? 4096: bytes_transferred;
-        server_io.post([=](){this->pktLogger.parseLog(recv_buffer.data(),
-                length);});
+        this->pktLogger.parseLog(recv_buffer.data(), length);
     }
     if(!stopped) {
         startReceive();

--- a/agent-ovs/ovs/PacketLogHandler.cpp
+++ b/agent-ovs/ovs/PacketLogHandler.cpp
@@ -139,7 +139,6 @@ void UdpServer::handleReceive(const boost::system::error_code& error,
     if (!error || error == boost::asio::error::message_size)
     {
         uint32_t length = (bytes_transferred > 4096) ? 4096: bytes_transferred;
-        boost::asio::io_service &server_io(serverSocket.get_io_service());
         server_io.post([=](){this->pktLogger.parseLog(recv_buffer.data(),
                 length);});
     }

--- a/agent-ovs/ovs/PacketLogHandler.cpp
+++ b/agent-ovs/ovs/PacketLogHandler.cpp
@@ -175,6 +175,17 @@ void PacketLogHandler::parseLog(unsigned char *buf , std::size_t length) {
         }
         LOG(ERROR) << str.str();
     } else {
+        /* *
+         * TBD: Need to have a filter to prune with
+         * a generic criterion
+         * */
+        /* Skip logging/events for LLDP packets*/
+        #define LLDP_MAC "01:80:c2:00:00:0e"
+        std::string dstMac;
+        p.packetTuple.getField(2, dstMac);
+        if(dstMac == LLDP_MAC) {
+            return;
+        }
         std::string dropReason;
         getDropReason(p, dropReason);
         p.packetTuple.setField(0, dropReason);

--- a/agent-ovs/ovs/SecGrpStatsManager.cpp
+++ b/agent-ovs/ovs/SecGrpStatsManager.cpp
@@ -143,24 +143,40 @@ updatePolicyStatsCounters(const std::string& l24Classifier,
                 .setTxbytes(newVals2.byte_count.get())
                 .setRxpackets(newVals1.packet_count.get())
                 .setRxbytes(newVals1.byte_count.get());
+#ifdef HAVE_PROMETHEUS_SUPPORT
+            prometheusManager.addNUpdateSGClassifierCounter(l24Classifier,
+                                                            newVals1.byte_count.get(),
+                                                            newVals1.packet_count.get(),
+                                                            newVals2.byte_count.get(),
+                                                            newVals2.packet_count.get());
+#endif
         } else if (newVals1.byte_count) {
             su.get()->addGbpeSecGrpClassifierCounter(getAgentUUID(),
                                                      nextId,
                                                      l24Classifier)
                 ->setRxpackets(newVals1.packet_count.get())
                 .setRxbytes(newVals1.byte_count.get());
+#ifdef HAVE_PROMETHEUS_SUPPORT
+            prometheusManager.addNUpdateSGClassifierCounter(l24Classifier,
+                                                            newVals1.byte_count.get(),
+                                                            newVals1.packet_count.get(),
+                                                            0, 0);
+#endif
         } else if (newVals2.byte_count) {
             su.get()->addGbpeSecGrpClassifierCounter(getAgentUUID(),
                                                      nextId,
                                                      l24Classifier)
                 ->setTxpackets(newVals2.packet_count.get())
                 .setTxbytes(newVals2.byte_count.get());
+#ifdef HAVE_PROMETHEUS_SUPPORT
+            prometheusManager.addNUpdateSGClassifierCounter(l24Classifier,
+                                                            0, 0,
+                                                            newVals2.byte_count.get(),
+                                                            newVals2.packet_count.get());
+#endif
         }
     }
     mutator.commit();
-#ifdef HAVE_PROMETHEUS_SUPPORT
-    prometheusManager.addNUpdateSGClassifierCounter(l24Classifier);
-#endif
 }
 
 void SecGrpStatsManager::objectUpdated(opflex::modb::class_id_t class_id,

--- a/agent-ovs/ovs/TableDropStatsManager.cpp
+++ b/agent-ovs/ovs/TableDropStatsManager.cpp
@@ -336,6 +336,30 @@ void BaseTableDropStatsManager::handleTableDropStats(struct ofputil_flow_stats* 
     }
     PolicyStatsManager::flowCounterState_t &counterState =
             CurrentDropCounterState[fentry->table_id];
+    FlowEntryMatchKey_t flowEntryKey((uint32_t)ovs_ntohll(fentry->cookie),
+            fentry->priority, fentry->match);
+    auto it = counterState.newFlowCounterMap.find(flowEntryKey);
+    if(it != counterState.newFlowCounterMap.end()) {
+       /* This flow just got added and the newcounterMap entry
+        * will move to the oldcounterMap entry following the next call.
+        * to updateNewFlowCounters.Capture the accumulated count
+        * till now so that counter value is consistent for the time that
+        * the datapath is counting similar to what is being done for
+        * RDPolicyDrop counters, but different in that table drop counter
+        * is multi-dimensional
+        */
+        uint64_t packet_count = 0, byte_count =0;
+        PolicyStatsManager::FlowStats_t &counter =
+            TableDropCounterState[fentry->table_id];
+        if(counter.packet_count) {
+            packet_count = counter.packet_count.get();
+            byte_count = counter.byte_count.get();
+        }
+        counter.packet_count = make_optional(true,
+                (packet_count+fentry->packet_count));
+        counter.byte_count = make_optional(true,
+                (byte_count+fentry->byte_count));
+    }
     updateNewFlowCounters((uint32_t)ovs_ntohll(fentry->cookie),
                                           fentry->priority,
                                           (fentry->match),

--- a/agent-ovs/ovs/include/AccessFlowManager.h
+++ b/agent-ovs/ovs/include/AccessFlowManager.h
@@ -101,6 +101,14 @@ public:
                                   uint32_t portNo, bool fromDesc);
 
     /**
+     * Populate TableDescriptionMap for this FlowManager
+     * for use by drop counters.
+     * @param fwdTblDescr returned TableDescriptionMap
+     */
+    static void populateTableDescriptionMap(
+            SwitchManager::TableDescriptionMap &fwdTblDescr);
+
+    /**
      * Run periodic cleanup tasks
      */
     void cleanup();
@@ -150,10 +158,6 @@ private:
     void handlePortStatusUpdate(const std::string& portName, uint32_t portNo);
     void handleSecGrpSetUpdate(const EndpointListener::uri_set_t& secGrps,
                                const std::string& secGrpsId);
-    /**
-     * Populate table description for drop counters
-     */
-    void populateTableDescriptionMap();
 
     Agent& agent;
     SwitchManager& switchManager;

--- a/agent-ovs/ovs/include/AdvertManager.h
+++ b/agent-ovs/ovs/include/AdvertManager.h
@@ -85,7 +85,11 @@ public:
         /**
          * Broadcast RARP endpoint advertisements. Only for TunnelEp
          */
-        EPADV_RARP_BROADCAST
+        EPADV_RARP_BROADCAST,
+        /**
+         * Broadcast RARP and GARP endpoint advertisements. Only for TunnelEp
+         */
+        EPADV_GARP_RARP_BROADCAST
     };
 
     /**
@@ -191,6 +195,18 @@ private:
      * @param uuid the UUID of the service
      */
     void sendServiceAdvs(const std::string& uuid);
+
+    /**
+     * Synchronously send GARP for tunnel endpoints
+     * @param uuid the UUID of the tunnel ep
+     */
+    void sendTunnelEpGarp(const std::string& uuid);
+
+    /**
+     * Synchronously send RARP for tunnel endpoints
+     * @param uuid the UUID of the tunnel ep
+     */
+    void sendTunnelEpRarp(const std::string& uuid);
 
     /**
      * Synchronously send advertisements for tunnel endpoints

--- a/agent-ovs/ovs/include/FlowBuilder.h
+++ b/agent-ovs/ovs/include/FlowBuilder.h
@@ -257,9 +257,10 @@ public:
      * Add a match against the value of a register
      * @param reg the register to match against
      * @param value the value of the register to match
+     * @param mask the mask for the match
      * @return this flow builder for chaining
      */
-    FlowBuilder& reg(uint8_t reg, uint32_t value);
+    FlowBuilder& reg(uint8_t reg, uint32_t value, uint32_t mask = ~0l);
 
     /**
      * Add a match against the value of the flow metadata

--- a/agent-ovs/ovs/include/FlowConstants.h
+++ b/agent-ovs/ovs/include/FlowConstants.h
@@ -169,6 +169,11 @@ const uint64_t POP_VLAN = 0x1;
  */
 const uint64_t PUSH_VLAN = 0x2;
 
+/**
+ * Replicate the packet both untagged followed by tagged
+ */
+const uint64_t UNTAGGED_AND_PUSH_VLAN = 0x3;
+
 } // namespace access
 
 } // namespace meta

--- a/agent-ovs/ovs/include/FlowUtils.h
+++ b/agent-ovs/ovs/include/FlowUtils.h
@@ -119,6 +119,26 @@ void add_classifier_entries(modelgbp::gbpe::L24Classifier& clsfr,
                             /* out */ FlowEntryList& entries);
 
 /**
+ * Create L2 flow entries for the classifier specified and append them
+ * to the provided list.
+ *
+ * @param classifier Classifier object to get matching rules from
+ * @param act an action to take for the flows
+ * @param nextTable the table to send to if the traffic is allowed
+ * @param priority Priority of the entry created
+ * @param flags the flow flags to use
+ * @param cookie Cookie of the entry created
+ * @param svnid VNID of the source endpoint group for the entry
+ * @param dvnid VNID of the destination endpoint group for the entry
+ * @param entries List to append entry to
+ */
+void add_l2classifier_entries(modelgbp::gbpe::L24Classifier& clsfr,
+                              ClassAction act,
+                              uint8_t nextTable, uint16_t priority,
+                              uint32_t flags, uint64_t cookie,
+                              uint32_t svnid, uint32_t dvnid,
+                              /* out */ FlowEntryList& entries);
+/**
  * Add a match entry for the DHCP v4 and v6 request
  *
  * @param fb the flowbuilder

--- a/agent-ovs/ovs/include/IntFlowManager.h
+++ b/agent-ovs/ovs/include/IntFlowManager.h
@@ -514,6 +514,13 @@ public:
         }
         return true;
     }
+    /**
+     * Populate TableDescriptionMap for this FlowManager
+     * for use by drop counters.
+     * @param fwdTblDescr returned TableDescriptionMap
+     */
+    static void populateTableDescriptionMap(
+            SwitchManager::TableDescriptionMap &fwdTblDescr);
 private:
     /**
      * Write flows that are fixed and not related to any policy or
@@ -916,10 +923,6 @@ private:
      * Handle if the droplog port name is read later
      */
     void handleDropLogPortUpdate();
-    /**
-     * Populate table description map for use by drop counters
-     */
-    void populateTableDescriptionMap();
 
 };
 

--- a/agent-ovs/ovs/include/IntFlowManager.h
+++ b/agent-ovs/ovs/include/IntFlowManager.h
@@ -654,9 +654,7 @@ private:
                                    const bool &isEpToSvc,
                                    const string& idStr,
                                    const uint64_t &pkts,
-                                   const uint64_t &bytes,
-                                   const attr_map &ep_attr_map,
-                                   const attr_map &svc_attr_map);
+                                   const uint64_t &bytes);
 
     /*
      * Update svc counter objects

--- a/agent-ovs/ovs/include/IntFlowManager.h
+++ b/agent-ovs/ovs/include/IntFlowManager.h
@@ -583,6 +583,17 @@ private:
                                 const bool &is_add);
 
     /**
+     * Update node<-->svc-tgt flows due to changes in a service/ep.
+     *
+     * @param uuid UUID of the changed service/ep
+     * @param is_svc true if the uuid belongs to svc
+     * @param is_add true if the svc/ep is added
+     */
+    void updateSvcNodeStatsFlows(const std::string &uuid,
+                                 const bool &is_svc,
+                                 const bool &is_add);
+
+    /**
      * Update any<-->svc-tgt flows due to changes in a service/ep.
      *
      * @param uuid UUID of the changed service/ep
@@ -611,10 +622,12 @@ private:
      * @param uuid      The uuid of svc
      * @param attr_map  The attribute map of service
      * @param isExternal  is this update for external or cluster svc
+     * @param isNodePort  Does this service have a nodePort configured
      */
     void clearSvcStatsCounters(const std::string& uuid,
                                const attr_map& attr_map,
-                               bool isExternal);
+                               bool isExternal,
+                               bool isNodePort=false);
 
     /**
      * Clear svc-tgt counters
@@ -623,11 +636,13 @@ private:
      * @param nhip The ip of svc-tgt
      * @param attr_map  The attribute map of service
      * @param isExternal  is this update for external or cluster tgt
+     * @param isNodePort  Does this service have a nodePort configured
      */
     void clearSvcTgtStatsCounters(const std::string& uuid,
                                   const std::string& nhip,
                                   const attr_map& attr_map,
-                                  bool isExternal);
+                                  bool isExternal,
+                                  bool isNodePort=false);
 
     /**
      * Clear podsvc counter objects
@@ -663,7 +678,8 @@ private:
                                 const string& uuid,
                                 const uint64_t &pkts,
                                 const uint64_t &bytes,
-                                const bool &add);
+                                const bool &add,
+                                const bool &isNodePort=false);
 
     /*
      * Update podsvc counter attributes

--- a/agent-ovs/ovs/include/IntFlowManager.h
+++ b/agent-ovs/ovs/include/IntFlowManager.h
@@ -78,8 +78,9 @@ public:
 
     /**
      * Module start
+     * @param serviceStatsFlowDisabled toggle service stats flow creation based on agent config
      */
-    void start();
+    void start(bool serviceStatsFlowDisabled=false);
 
     /**
      * Installs listeners for receiving updates to MODB state.
@@ -839,6 +840,7 @@ private:
     std::string dropLogIface;
     boost::asio::ip::address dropLogDst;
     uint16_t dropLogRemotePort;
+    bool serviceStatsFlowDisabled;
 
     /* Map containing ingress and egress cookie: Flows generated out
      * of same pod<-->svc uuid will use these cookies */

--- a/agent-ovs/ovs/include/IntFlowManager.h
+++ b/agent-ovs/ovs/include/IntFlowManager.h
@@ -572,6 +572,17 @@ private:
                              const bool &is_add);
 
     /**
+     * Update ext<-->svc-tgt flows due to changes in a service/ep
+     *
+     * @param uuid UUID of the changed service/ep
+     * @param is_svc true if the uuid belongs to svc
+     * @param is_add true if the svc/ep is added
+     */
+    void updateSvcExtStatsFlows(const std::string &uuid,
+                                const bool &is_svc,
+                                const bool &is_add);
+
+    /**
      * Update any<-->svc-tgt flows due to changes in a service/ep.
      *
      * @param uuid UUID of the changed service/ep
@@ -599,9 +610,11 @@ private:
      *
      * @param uuid      The uuid of svc
      * @param attr_map  The attribute map of service
+     * @param isExternal  is this update for external or cluster svc
      */
     void clearSvcStatsCounters(const std::string& uuid,
-                               const attr_map& attr_map);
+                               const attr_map& attr_map,
+                               bool isExternal);
 
     /**
      * Clear svc-tgt counters
@@ -609,10 +622,12 @@ private:
      * @param uuid The uuid of svc
      * @param nhip The ip of svc-tgt
      * @param attr_map  The attribute map of service
+     * @param isExternal  is this update for external or cluster tgt
      */
     void clearSvcTgtStatsCounters(const std::string& uuid,
                                   const std::string& nhip,
-                                  const attr_map& attr_map);
+                                  const attr_map& attr_map,
+                                  bool isExternal);
 
     /**
      * Clear podsvc counter objects

--- a/agent-ovs/ovs/include/IntFlowManager.h
+++ b/agent-ovs/ovs/include/IntFlowManager.h
@@ -585,21 +585,26 @@ private:
                                 const bool &is_svc,
                                 const bool &is_add);
 
+    typedef std::unordered_map<std::string, std::string> attr_map;
     /**
      * Clear svc counter and children stats
      *
-     * @param uuid The uuid of svc
+     * @param uuid      The uuid of svc
+     * @param attr_map  The attribute map of service
      */
-    void clearSvcStatsCounters(const std::string& uuid);
+    void clearSvcStatsCounters(const std::string& uuid,
+                               const attr_map& attr_map);
 
     /**
      * Clear svc-tgt counters
      *
      * @param uuid The uuid of svc
      * @param nhip The ip of svc-tgt
+     * @param attr_map  The attribute map of service
      */
     void clearSvcTgtStatsCounters(const std::string& uuid,
-                                  const std::string& nhip);
+                                  const std::string& nhip,
+                                  const attr_map& attr_map);
 
     /**
      * Clear podsvc counter objects
@@ -611,12 +616,12 @@ private:
     /*
      * Update svctgt counter objects
      */
-    typedef std::unordered_map<std::string, std::string> attr_map;
     void updateSvcTgtStatsCounters(const uint64_t &cookie,
                                    const bool &isAnyToSvc,
                                    const string& idStr,
                                    const uint64_t &pkts,
                                    const uint64_t &bytes,
+                                   const attr_map &svc_attr_map,
                                    const attr_map &ep_attr_map);
 
     /*

--- a/agent-ovs/ovs/include/IntFlowManager.h
+++ b/agent-ovs/ovs/include/IntFlowManager.h
@@ -545,6 +545,14 @@ private:
     void handleServiceUpdate(const std::string& uuid);
 
     /**
+     * Compare and update snat & dnat flow tables due to changes in a
+     * service.
+     *
+     * @param uuid UUID of the changed service
+     */
+    void programServiceSnatDnatFlows(const std::string& uuid);
+
+    /**
      * Update service stats flows for metric collection
      *
      * @param uuid UUID of the changed service/ep

--- a/agent-ovs/ovs/include/JsonRpc.h
+++ b/agent-ovs/ovs/include/JsonRpc.h
@@ -364,21 +364,6 @@ public:
      */
     bool isConnected();
 
-/*! macro to declare handlers */
-#define DECLARE_HANDLER(F) \
-        /** \
-         * F \
-         * @param[in] reqId request ID \
-         * @param[in] payload body of the response \
-         */ \
-        void F(uint64_t reqId, const rapidjson::Document& payload);
-    /*! declaration for  handleGetBridgeMirrorUuidResp */
-    DECLARE_HANDLER(handleGetBridgeMirrorUuidResp);
-    /*! declaration for handleAddMirrorToBridgeResp */
-    DECLARE_HANDLER(handleAddMirrorToBridgeResp);
-    /*! declaration for handleAddErspanPortResp */
-    DECLARE_HANDLER(handleAddErspanPortResp);
-
     /**
      * get rpc connection pointer
      * @return pointer to OVSDB connection

--- a/agent-ovs/ovs/include/JsonRpcTransactMessage.h
+++ b/agent-ovs/ovs/include/JsonRpcTransactMessage.h
@@ -56,13 +56,13 @@ public:
      * @param key_ the key string
      * @param val value
      */
-    TupleData(const string& key_, bool val) : key(key_), type(Dtype::STRING), iVal(-1), bVal(val) {}
+    TupleData(const string& key_, bool val) : key(key_), type(Dtype::BOOL), iVal(-1), bVal(val) {}
     /**
      * constructor
      * @param key_ the key string
      * @param val value
      */
-    TupleData(const string& key_, int val) : key(key_), type(Dtype::STRING), iVal(val), bVal(false) {}
+    TupleData(const string& key_, int val) : key(key_), type(Dtype::INTEGER), iVal(val), bVal(false) {}
 
     /**
      * Copy constructor

--- a/agent-ovs/ovs/include/NetFlowRenderer.h
+++ b/agent-ovs/ovs/include/NetFlowRenderer.h
@@ -25,8 +25,8 @@ namespace opflexagent {
  * class to render netflow export config on a virtual switch
  */
 class NetFlowRenderer : public NetFlowListener,
-                     private JsonRpcRenderer,
-                     private boost::noncopyable {
+                        public JsonRpcRenderer,
+                        private boost::noncopyable {
 
 public:
     /**

--- a/agent-ovs/ovs/include/OVSRenderer.h
+++ b/agent-ovs/ovs/include/OVSRenderer.h
@@ -141,6 +141,11 @@ private:
      */
     void onCleanupTimer(const boost::system::error_code& ec);
     std::unique_ptr<boost::asio::deadline_timer> cleanupTimer;
+
+    /**
+     * Start packet logger
+     */
+    void startPacketLogger();
 };
 
 /**

--- a/agent-ovs/ovs/include/OVSRenderer.h
+++ b/agent-ovs/ovs/include/OVSRenderer.h
@@ -17,7 +17,7 @@
 #include "PortMapper.h"
 #include "InterfaceStatsManager.h"
 #include "ContractStatsManager.h"
-#include "PodSvcStatsManager.h"
+#include "ServiceStatsManager.h"
 #include "SecGrpStatsManager.h"
 #include "TableDropStatsManager.h"
 #include <opflexagent/TunnelEpManager.h>
@@ -86,7 +86,7 @@ private:
 
     InterfaceStatsManager interfaceStatsManager;
     ContractStatsManager contractStatsManager;
-    PodSvcStatsManager podsvcStatsManager;
+    ServiceStatsManager serviceStatsManager;
     SecGrpStatsManager secGrpStatsManager;
     TableDropStatsManager tableDropStatsManager;
 
@@ -117,8 +117,8 @@ private:
     long ifaceStatsInterval;
     bool contractStatsEnabled;
     long contractStatsInterval;
-    bool podsvcStatsEnabled;
-    long podsvcStatsInterval;
+    bool serviceStatsEnabled;
+    long serviceStatsInterval;
     bool secGroupStatsEnabled;
     long secGroupStatsInterval;
     bool tableDropStatsEnabled;

--- a/agent-ovs/ovs/include/OVSRenderer.h
+++ b/agent-ovs/ovs/include/OVSRenderer.h
@@ -117,6 +117,7 @@ private:
     long ifaceStatsInterval;
     bool contractStatsEnabled;
     long contractStatsInterval;
+    bool serviceStatsFlowDisabled;
     bool serviceStatsEnabled;
     long serviceStatsInterval;
     bool secGroupStatsEnabled;

--- a/agent-ovs/ovs/include/OVSRenderer.h
+++ b/agent-ovs/ovs/include/OVSRenderer.h
@@ -129,8 +129,8 @@ private:
     NetFlowRenderer netflowRenderer;
 
     bool started;
-    std::string dropLogIntIface, dropLogAccessIface, dropLogRemoteIp, dropLogNs;
-    uint16_t dropLogRemotePort;
+    std::string dropLogIntIface, dropLogAccessIface, dropLogRemoteIp;
+    uint16_t dropLogRemotePort, dropLogLocalPort;
     boost::asio::io_service pktLoggerIO;
     boost::asio::io_service exporterIO;
     PacketLogHandler pktLogger;

--- a/agent-ovs/ovs/include/PacketDecoder.h
+++ b/agent-ovs/ovs/include/PacketDecoder.h
@@ -74,6 +74,17 @@ public:
         fields[index].second = value;
     }
     /**
+     * get a member in the tuple by the index of the member
+     * @param index index of the member
+     * @param value returned value of the member
+     * */
+    void getField(unsigned index, std::string &value) {
+        if(index > fields.size()) {
+            return;
+        }
+        value = fields[index].second;
+    }
+    /**
      * serialize this packet tuple into a json stream
      * @param writer JSON encoder
      * @return whether serialization was successful

--- a/agent-ovs/ovs/include/PacketLogHandler.h
+++ b/agent-ovs/ovs/include/PacketLogHandler.h
@@ -54,7 +54,7 @@ public:
      */
     bool startListener() {
         boost::system::error_code ec;
-	serverSocket.open(localEndpoint.protocol());
+        serverSocket.open(localEndpoint.protocol());
         boost::asio::socket_base::reuse_address option(true);
         serverSocket.set_option(boost::asio::socket_base::reuse_address(true),
 			ec);
@@ -84,6 +84,7 @@ public:
     void stop() {
         boost::system::error_code ec;
         stopped = true;
+        serverSocket.shutdown(boost::asio::ip::udp::socket::shutdown_both);
         serverSocket.cancel(ec);
         serverSocket.close(ec);
     }

--- a/agent-ovs/ovs/include/PacketLogHandler.h
+++ b/agent-ovs/ovs/include/PacketLogHandler.h
@@ -38,14 +38,14 @@ public:
     /**
      * Constructor for UDP listener
      * @param logHandler reference to the parent LogHandler
-     * @param io_service reference to IO service to handle UDP
+     * @param io_service_ reference to IO service to handle UDP
      * @param addr IP address to listen on
      * @param port listener UDP port
      */
     UdpServer(PacketLogHandler &logHandler,
-            boost::asio::io_service& io_service,
+            boost::asio::io_service& io_service_,
                boost::asio::ip::address &addr, uint16_t port)
-    : pktLogger(logHandler), serverSocket(io_service,
+    : pktLogger(logHandler), server_io(io_service_), serverSocket(io_service_,
             boost::asio::ip::udp::endpoint(addr, port)),
             stopped(false) {
         serverSocket.set_option(boost::asio::socket_base::reuse_address(true));
@@ -76,6 +76,7 @@ private:
     void handleReceive(const boost::system::error_code& error,
       std::size_t bytes_transferred);
     PacketLogHandler &pktLogger;
+    boost::asio::io_service &server_io;
     boost::asio::ip::udp::socket serverSocket;
     boost::asio::ip::udp::endpoint remoteEndpoint;
     boost::array<unsigned char, 4096> recv_buffer;

--- a/agent-ovs/ovs/include/ServiceStatsManager.h
+++ b/agent-ovs/ovs/include/ServiceStatsManager.h
@@ -118,6 +118,12 @@ private:
     // Flow state of all service flows in stats table
     flowCounterState_t statsState;
 
+    // Flow state of all service flows in svh table
+    flowCounterState_t svhState;
+
+    // Flow state of all service flows in svr table
+    flowCounterState_t svrState;
+
     /**
      * Get aggregated stats counters from for service flows
      */

--- a/agent-ovs/ovs/include/ServiceStatsManager.h
+++ b/agent-ovs/ovs/include/ServiceStatsManager.h
@@ -1,6 +1,6 @@
 /* -*- C++ -*-; c-basic-offset: 4; indent-tabs-mode: nil */
 /*
- * Include file for pod <--> svc stats manager
+ * Include file for service stats manager
  *
  * Copyright (c) 2020 Cisco Systems, Inc. and others.  All rights reserved.
  *
@@ -13,8 +13,8 @@
 #include "PolicyStatsManager.h"
 
 #pragma once
-#ifndef OPFLEXAGENT_PodSvcStatsManager_H
-#define OPFLEXAGENT_PodSvcStatsManager_H
+#ifndef OPFLEXAGENT_ServiceStatsManager_H
+#define OPFLEXAGENT_ServiceStatsManager_H
 
 namespace opflexagent {
 
@@ -24,7 +24,7 @@ class Agent;
  * Periodically query an OpenFlow switch for policy counters and stats
  * and distribute them as needed to other components for reporting.
  */
-class PodSvcStatsManager : public PolicyStatsManager {
+class ServiceStatsManager : public PolicyStatsManager {
 public:
     /**
      * Instantiate a new policy stats manager that will use the
@@ -38,7 +38,7 @@ public:
      * @param timer_interval the interval for the stats timer in
      * milliseconds
      */
-    PodSvcStatsManager(Agent* agent, IdGenerator& idGen,
+    ServiceStatsManager(Agent* agent, IdGenerator& idGen,
                          SwitchManager& switchManager,
                          IntFlowManager& intFlowManager,
                          long timer_interval = 30000);
@@ -46,7 +46,7 @@ public:
     /**
      * Destroy the policy stats manager and clean up all state
      */
-    virtual ~PodSvcStatsManager();
+    virtual ~ServiceStatsManager();
 
     /**
      * Start the policy stats manager
@@ -79,13 +79,13 @@ public:
 
 private:
     /**
-     * Type used as a key for Pod-Svc counter maps
+     * Type used as a key for service counter maps
      */
-    struct PodSvcFlowMatchKey_t {
+    struct ServiceFlowMatchKey_t {
         /**
-         * Trivial constructor for pod<-->svc match key
+         * Trivial constructor for service match key
          */
-        PodSvcFlowMatchKey_t(uint32_t k1) {
+        ServiceFlowMatchKey_t(uint32_t k1) {
             cookie = k1;
         }
 
@@ -97,47 +97,47 @@ private:
         /**
          * equality operator
          */
-        bool operator==(const PodSvcFlowMatchKey_t &other) const;
+        bool operator==(const ServiceFlowMatchKey_t &other) const;
     };
 
     /**
-     * Hasher for PodSvcFlowMatchKey_t
+     * Hasher for ServiceFlowMatchKey_t
      */
-    struct PodSvcKeyHasher {
+    struct ServiceKeyHasher {
         /**
          * Hash for FlowMatch Key
          */
-        size_t operator()(const PodSvcFlowMatchKey_t& k) const noexcept;
+        size_t operator()(const ServiceFlowMatchKey_t& k) const noexcept;
     };
 
-    /** map flow to Pod-Svc info and counters */
-    typedef std::unordered_map<PodSvcFlowMatchKey_t, 
+    /** map flow to service info and counters */
+    typedef std::unordered_map<ServiceFlowMatchKey_t,
                                FlowStats_t,
-                               PodSvcKeyHasher> PodSvcCounterMap_t;
+                               ServiceKeyHasher> ServiceCounterMap_t;
 
-    // Flow state of all pod<-->svc flows in stats table
+    // Flow state of all service flows in stats table
     flowCounterState_t statsState;
 
     /**
-     * Get aggregated stats counters from for Pod<-->Svc flows
+     * Get aggregated stats counters from for service flows
      */
     void on_timer_base(const boost::system::error_code& ec,
                        flowCounterState_t& counterState,
-                       PodSvcCounterMap_t& newClassCountersMap);
+                       ServiceCounterMap_t& newClassCountersMap);
 
     /**
-     * Generate/update the pod<-->svc stats objects for from the counter maps
+     * Generate/update the service stats objects for from the counter maps
      */
-    void updatePodSvcStatsObjects(PodSvcCounterMap_t *counters);
+    void updateServiceStatsObjects(ServiceCounterMap_t *counters);
 
     /**
      * The integration bridge flow manager
      */
     IntFlowManager& intFlowManager;
 
-    friend class PodSvcStatsManagerFixture;
+    friend class ServiceStatsManagerFixture;
 };
 
 } /* namespace opflexagent */
 
-#endif /* OPFLEXAGENT_PodSvcStatsManager_H */
+#endif /* OPFLEXAGENT_ServiceStatsManager_H */

--- a/agent-ovs/ovs/include/TableDropStatsManager.h
+++ b/agent-ovs/ovs/include/TableDropStatsManager.h
@@ -77,6 +77,7 @@ public:
 
     void handleTableDropStats(struct ofputil_flow_stats* fentry) override;
 
+
 private:
     //Drop Flow Counter States per table
     std::unordered_map<int,
@@ -224,6 +225,22 @@ public:
         if(accessConnection) {
             accTableDropStatsMgr.registerConnection(accessConnection);
         }
+    }
+
+    /**
+     * TestRoutine: Get the IntegrationTableDropStats manager.
+     * @return  IntTableDropStatsManager
+     */
+    PolicyStatsManager& getIntTableDropStatsMgr() {
+        return intTableDropStatsMgr;
+    }
+
+    /**
+     * TestRoutine: Get the AccessTableDropStats manager.
+     * @return  AccessTableDropStatsManager
+     */
+    PolicyStatsManager& getAccTableDropStatsMgr() {
+        return accTableDropStatsMgr;
     }
 private:
     IntTableDropStatsManager intTableDropStatsMgr;

--- a/agent-ovs/ovs/include/TableDropStatsManager.h
+++ b/agent-ovs/ovs/include/TableDropStatsManager.h
@@ -227,24 +227,10 @@ public:
         }
     }
 
-    /**
-     * TestRoutine: Get the IntegrationTableDropStats manager.
-     * @return  IntTableDropStatsManager
-     */
-    PolicyStatsManager& getIntTableDropStatsMgr() {
-        return intTableDropStatsMgr;
-    }
-
-    /**
-     * TestRoutine: Get the AccessTableDropStats manager.
-     * @return  AccessTableDropStatsManager
-     */
-    PolicyStatsManager& getAccTableDropStatsMgr() {
-        return accTableDropStatsMgr;
-    }
 private:
     IntTableDropStatsManager intTableDropStatsMgr;
     AccessTableDropStatsManager accTableDropStatsMgr;
+    friend class TableDropStatsManagerFixture;
 };
 
 } /* namespace opflexagent */

--- a/agent-ovs/ovs/test/AccessFlowManager_test.cpp
+++ b/agent-ovs/ovs/test/AccessFlowManager_test.cpp
@@ -568,7 +568,7 @@ uint16_t AccessFlowManagerFixture::initExpSecGrp2(uint32_t setId) {
          .isCtState("-new+est-rel+rpl-inv+trk").tcp().reg(SEPG, setId)
          .actions().go(OUT).done());
     ADDF(Bldr(SEND_FLOW_REM).table(IN_POL).priority(prio - 128).cookie(ruleId)
-         .isCtState("-new-est+rel-inv+trk").tcp().reg(SEPG, setId)
+         .isCtState("-new-est+rel+rpl-inv+trk").ip().reg(SEPG, setId)
          .actions().go(OUT).done());
     ADDF(Bldr(SEND_FLOW_REM).table(IN_POL).priority(prio - 128)
          .isCtState("-trk").tcp().reg(SEPG, setId)

--- a/agent-ovs/ovs/test/FlowManagerFixture.cpp
+++ b/agent-ovs/ovs/test/FlowManagerFixture.cpp
@@ -113,7 +113,7 @@ void diffTables(Agent& agent,
 static string rstr[] = {
     "NXM_NX_REG0[]", "NXM_NX_REG0[0..11]", "NXM_NX_REG2[]", "NXM_NX_REG4[]",
     "NXM_NX_REG5[]", "NXM_NX_REG5[0..11]", "NXM_NX_REG6[]", "NXM_NX_REG7[]",
-    "NXM_NX_REG8[]", "NXM_NX_REG9[]", "NXM_NX_REG10[]", "NXM_NX_REG11[]",
+    "NXM_NX_REG8[]", "NXM_NX_REG9[]", "NXM_NX_REG10[]", "NXM_NX_REG11[]", "NXM_NX_REG12[]",
     "NXM_NX_TUN_ID[0..31]", "NXM_NX_TUN_IPV4_SRC[]", "NXM_NX_TUN_IPV4_DST[]",
     "OXM_OF_VLAN_VID[]", "NXM_OF_ETH_SRC[]", "NXM_OF_ETH_DST[]",
     "NXM_OF_ARP_OP[]", "NXM_NX_ARP_SHA[]", "NXM_NX_ARP_THA[]",
@@ -122,7 +122,7 @@ static string rstr[] = {
 };
 static string rstr1[] =
     { "reg0", "reg0", "reg2", "reg4", "reg5", "reg5", "reg6", "reg7",
-      "reg8", "reg9", "reg10", "reg11",
+      "reg8", "reg9", "reg10", "reg11", "reg12",
       "", "", "", "", "", "", "" ,"", "", "", "", ""};
 
 Bldr::Bldr() :
@@ -155,6 +155,11 @@ std::string Bldr::done() {
 }
 Bldr& Bldr::reg(REG r, uint32_t v) {
     m(rstr1[r], str(v, true));
+    return *this;
+}
+
+Bldr& Bldr::reg(REG r, const string& v) {
+    m(rstr1[r], v);
     return *this;
 }
 

--- a/agent-ovs/ovs/test/IntFlowManager_test.cpp
+++ b/agent-ovs/ovs/test/IntFlowManager_test.cpp
@@ -1477,6 +1477,7 @@ void BaseIntFlowManagerFixture::loadBalancedServiceTest() {
     sm1.addNextHopIP("169.254.169.2");
     sm1.setServicePort(53);
     sm1.setNextHopPort(5353);
+    sm1.setNodePort(33000);
     as1.addServiceMapping(sm1);
 
     Service::ServiceMapping sm2;
@@ -1485,6 +1486,7 @@ void BaseIntFlowManagerFixture::loadBalancedServiceTest() {
     sm2.addNextHopIP("2001:db8::2");
     sm2.addNextHopIP("fe80::a9:fe:a9:2");
     sm2.setServicePort(80);
+    sm1.setNodePort(33001);
     as1.addServiceMapping(sm2);
 
     as1.clearServiceMappings();
@@ -1564,11 +1566,13 @@ void BaseIntFlowManagerFixture::loadBalancedServiceTest() {
     as1.addAttribute("name", "coredns");
     as1.addAttribute("scope", "ext");
     as1.addAttribute("namespace", "default");
+    as1.setServiceType(Service::LOAD_BALANCER);
 
     as2.clearAttributes();
     as2.addAttribute("name", "redis-master");
     as2.addAttribute("scope", "ext");
     as2.addAttribute("namespace", "kube-system");
+    as2.setServiceType(Service::LOAD_BALANCER);
 
     servSrc.updateService(as1);
     servSrc.updateService(as2);

--- a/agent-ovs/ovs/test/IntFlowManager_test.cpp
+++ b/agent-ovs/ovs/test/IntFlowManager_test.cpp
@@ -2793,6 +2793,20 @@ void BaseIntFlowManagerFixture::initExpPodServiceStats (const string& svc_ip,
     };
 
     for (const string& ep_ip : ep->getIPs()) {
+        bool skip_flow = false;
+        for (auto const& sm : as.getServiceMappings()) {
+            // Dont create EPIP <--> SVCIP flows if EPIP is one of the
+            // next hops of this service.
+            const auto& nhips = sm.getNextHopIPs();
+            if (nhips.find(ep_ip) != nhips.end()) {
+                skip_flow = true;
+                break;
+            }
+        }
+
+        if (skip_flow)
+            continue;
+
         address ep_ipa = address::from_string(ep_ip);
         uint64_t ep_to_svc_cookie=0, svc_to_ep_cookie=0;
         intFlowManager.getPodSvcUuidCookie(epSvcUuid,true,ep_to_svc_cookie);

--- a/agent-ovs/ovs/test/IntFlowManager_test.cpp
+++ b/agent-ovs/ovs/test/IntFlowManager_test.cpp
@@ -2935,7 +2935,15 @@ void BaseIntFlowManagerFixture::initExpLBService(Service &as1,
                    flow::meta::POLICY_APPLIED |
                    flow::meta::FROM_SERVICE_INTERFACE)
              .go(BR).done());
-
+        ADDF(Bldr().table(SEC).priority(90).arp().in(17).isVlan(4003)
+             .isEthDst(bmac).isArpOp(1)
+             .actions()
+             .popVlan().load(SEPG, 4003).load(RD, 1)
+             .meta(flow::meta::POLICY_APPLIED |
+                   flow::meta::FROM_SERVICE_INTERFACE,
+                   flow::meta::POLICY_APPLIED |
+                   flow::meta::FROM_SERVICE_INTERFACE)
+             .go(BR).done());
         ADDF(Bldr().table(BR).priority(52).arp()
              .reg(RD, 1).in(17)
              .isEthDst(bmac).isTpa("1.1.1.1")

--- a/agent-ovs/ovs/test/MockRpcConnection.cpp
+++ b/agent-ovs/ovs/test/MockRpcConnection.cpp
@@ -12,8 +12,14 @@
 namespace opflexagent {
 
 void ResponseDict::init() {
-    uint64_t j=1000;
-    for (unsigned int i=0 ; i < no_of_msgs; i++, j++) {
+    uint64_t j = 1001;
+    for (unsigned int i = 0 ; i < no_of_span_msgs; i++, j++) {
+        d[i].GetAllocator().Clear();
+        d[i].Parse(response[i].c_str());
+        dict.emplace(j, i);
+    }
+    j = 2001;
+    for (unsigned int i = no_of_span_msgs ; i < (no_of_span_msgs + no_of_netflow_msgs); i++, j++) {
         d[i].GetAllocator().Clear();
         d[i].Parse(response[i].c_str());
         dict.emplace(j, i);
@@ -33,7 +39,7 @@ void MockRpcConnection::sendTransaction(const uint64_t& reqId, const list<JsonRp
     ResponseDict& rDict = ResponseDict::Instance();
     auto itr = rDict.dict.find(reqId);
     if (itr != rDict.dict.end()) {
-        trans->handleTransaction(1, rDict.d[itr->second]);
+        trans->handleTransaction(reqId, rDict.d[itr->second]);
     } else {
         LOG(DEBUG) << "No response found for req " << reqId;
     }

--- a/agent-ovs/ovs/test/NetFlowRenderer_test.cpp
+++ b/agent-ovs/ovs/test/NetFlowRenderer_test.cpp
@@ -43,13 +43,17 @@ static bool verifyCreateDestroy(const shared_ptr<NetFlowRenderer>& nfr) {
     string bridgeUuid;
     nfr->jRpc->getBridgeUuid("br-int", bridgeUuid);
 
-    bool result = nfr->jRpc->createIpfix(bridgeUuid, "5.5.5.5", 500);
+    bool result = nfr->jRpc->createNetFlow(bridgeUuid, "5.5.5.6", 10, true);
+    result = result && nfr->jRpc->deleteNetFlow(bridgeUuid);
+
+    nfr->jRpc->setNextId(2001);
+    result = result && nfr->jRpc->createIpfix(bridgeUuid, "5.5.5.5", 500);
     result = result && nfr->jRpc->deleteIpfix(bridgeUuid);
     return result;
 }
 
 BOOST_FIXTURE_TEST_CASE( verify_createdestroy, NetFlowRendererFixture ) {
-    WAIT_FOR(verifyCreateDestroy(nfr), 500);
+    WAIT_FOR(verifyCreateDestroy(nfr), 1);
 }
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/agent-ovs/ovs/test/NetFlowRenderer_test.cpp
+++ b/agent-ovs/ovs/test/NetFlowRenderer_test.cpp
@@ -1,0 +1,56 @@
+/*
+ * Test suite for class NetFlowRenderer
+ *
+ * Copyright (c) 2020 Cisco Systems, Inc. and others.  All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ */
+
+#include <boost/test/unit_test.hpp>
+
+#include <opflexagent/logging.h>
+#include <opflexagent/test/BaseFixture.h>
+#include <NetFlowRenderer.h>
+#include "MockJsonRpc.h"
+
+namespace opflexagent {
+
+using namespace std;
+using namespace rapidjson;
+
+BOOST_AUTO_TEST_SUITE(NetFlowRenderer_test)
+
+class NetFlowRendererFixture : public BaseFixture {
+public:
+    NetFlowRendererFixture() : BaseFixture() {
+        nfr = make_shared<NetFlowRenderer>(agent);
+        initLogging("debug", false, "");
+        conn.reset(new MockRpcConnection());
+        nfr->start("br-int", conn.get());
+        nfr->connect();
+    }
+
+    virtual ~NetFlowRendererFixture() {};
+
+    shared_ptr<NetFlowRenderer> nfr;
+    unique_ptr<OvsdbConnection> conn;
+};
+
+static bool verifyCreateDestroy(const shared_ptr<NetFlowRenderer>& nfr) {
+    nfr->jRpc->setNextId(2000);
+    string bridgeUuid;
+    nfr->jRpc->getBridgeUuid("br-int", bridgeUuid);
+
+    bool result = nfr->jRpc->createIpfix(bridgeUuid, "5.5.5.5", 500);
+    result = result && nfr->jRpc->deleteIpfix(bridgeUuid);
+    return result;
+}
+
+BOOST_FIXTURE_TEST_CASE( verify_createdestroy, NetFlowRendererFixture ) {
+    WAIT_FOR(verifyCreateDestroy(nfr), 500);
+}
+BOOST_AUTO_TEST_SUITE_END()
+
+}

--- a/agent-ovs/ovs/test/ServiceStatsManager_test.cpp
+++ b/agent-ovs/ovs/test/ServiceStatsManager_test.cpp
@@ -344,7 +344,7 @@ ServiceStatsManagerFixture::testFlowStatsSvcTgt (MockConnection& portConn,
         if (nhAddr.is_v4()) {
             FlowBuilder().proto(17).tpDst(5353)
                      .priority(97).ethType(eth::type::IP)
-                     .ipDst(nhAddr)
+                     .ipDst(nhAddr).reg(12, 0, 1<<31)
                      .flags(OFPUTIL_FF_SEND_FLOW_REM)
                      .cookie(ovs_htonll(uint64_t(anytosvcCk)))
                      .action().go(IntFlowManager::OUT_TABLE_ID)
@@ -352,7 +352,7 @@ ServiceStatsManagerFixture::testFlowStatsSvcTgt (MockConnection& portConn,
 
             FlowBuilder().proto(17).tpSrc(5353)
                      .priority(97).ethType(eth::type::IP)
-                     .ipSrc(nhAddr)
+                     .ipSrc(nhAddr).reg(12, 0, 1<<31)
                      .flags(OFPUTIL_FF_SEND_FLOW_REM)
                      .cookie(ovs_htonll(uint64_t(svctoanyCk)))
                      .action().go(IntFlowManager::OUT_TABLE_ID)
@@ -360,7 +360,7 @@ ServiceStatsManagerFixture::testFlowStatsSvcTgt (MockConnection& portConn,
         } else {
             FlowBuilder().proto(6).tpDst(80)
                      .priority(97).ethType(eth::type::IPV6)
-                     .ipDst(nhAddr)
+                     .ipDst(nhAddr).reg(12, 0, 1<<31)
                      .flags(OFPUTIL_FF_SEND_FLOW_REM)
                      .cookie(ovs_htonll(uint64_t(anytosvcCk)))
                      .action().go(IntFlowManager::OUT_TABLE_ID)
@@ -368,7 +368,7 @@ ServiceStatsManagerFixture::testFlowStatsSvcTgt (MockConnection& portConn,
 
             FlowBuilder().proto(6).tpSrc(80)
                      .priority(97).ethType(eth::type::IPV6)
-                     .ipSrc(nhAddr)
+                     .ipSrc(nhAddr).reg(12, 0, 1<<31)
                      .flags(OFPUTIL_FF_SEND_FLOW_REM)
                      .cookie(ovs_htonll(uint64_t(svctoanyCk)))
                      .action().go(IntFlowManager::OUT_TABLE_ID)
@@ -606,7 +606,7 @@ ServiceStatsManagerFixture::testFlowRemovedSvcTgt (MockConnection& portConn,
         if (isAnyToSvc) {
             FlowBuilder().proto(17).tpDst(5353)
                      .priority(97).ethType(eth::type::IP)
-                     .ipDst(nhAddr)
+                     .ipDst(nhAddr).reg(12, 0, 1<<31)
                      .flags(OFPUTIL_FF_SEND_FLOW_REM)
                      .cookie(ovs_htonll(uint64_t(anytosvcCk)))
                      .action().go(IntFlowManager::OUT_TABLE_ID)
@@ -614,7 +614,7 @@ ServiceStatsManagerFixture::testFlowRemovedSvcTgt (MockConnection& portConn,
         } else {
             FlowBuilder().proto(17).tpSrc(5353)
                      .priority(97).ethType(eth::type::IP)
-                     .ipSrc(nhAddr)
+                     .ipSrc(nhAddr).reg(12, 0, 1<<31)
                      .flags(OFPUTIL_FF_SEND_FLOW_REM)
                      .cookie(ovs_htonll(uint64_t(svctoanyCk)))
                      .action().go(IntFlowManager::OUT_TABLE_ID)

--- a/agent-ovs/ovs/test/ServiceStatsManager_test.cpp
+++ b/agent-ovs/ovs/test/ServiceStatsManager_test.cpp
@@ -161,6 +161,7 @@ void ServiceStatsManagerFixture::createServices (void)
     sm1.addNextHopIP("169.254.169.2");
     sm1.setServicePort(53);
     sm1.setNextHopPort(5353);
+    sm1.setNodePort(32000);
     as.addServiceMapping(sm1);
 
     sm2.setServiceIP("fe80::a9:fe:a9:fe");
@@ -168,6 +169,7 @@ void ServiceStatsManagerFixture::createServices (void)
     sm2.addNextHopIP("2001:db8::2");
     sm2.addNextHopIP("fe80::a9:fe:a9:2");
     sm2.setServicePort(80);
+    sm1.setNodePort(32001);
     as.addServiceMapping(sm2);
 
     as.addAttribute("name", "coredns");

--- a/agent-ovs/ovs/test/ServiceStatsManager_test.cpp
+++ b/agent-ovs/ovs/test/ServiceStatsManager_test.cpp
@@ -807,13 +807,15 @@ void ServiceStatsManagerFixture::checkSvcTgtPromMetrics (uint64_t pkts,
     pos = output.find(s_tx_pkts);
     BOOST_CHECK_NE(pos, std::string::npos);
 
-    const string& st_rx_bytes = "opflex_svc_target_rx_bytes{ip=\"" + ip + "\"} "
+    const string& s_ann = "\",svc_name=\"coredns\",svc_namespace=\"kube-system\"" \
+                          ",svc_scope=\"cluster\"} ";
+    const string& st_rx_bytes = "opflex_svc_target_rx_bytes{ip=\"" + ip + s_ann
                             + boost::lexical_cast<std::string>(bytes) + ".000000";
-    const string& st_rx_pkts = "opflex_svc_target_rx_packets{ip=\"" + ip + "\"} "
+    const string& st_rx_pkts = "opflex_svc_target_rx_packets{ip=\"" + ip + s_ann
                             + boost::lexical_cast<std::string>(pkts) + ".000000";
-    const string& st_tx_bytes = "opflex_svc_target_tx_bytes{ip=\"" + ip + "\"} "
+    const string& st_tx_bytes = "opflex_svc_target_tx_bytes{ip=\"" + ip + s_ann
                             + boost::lexical_cast<std::string>(bytes) + ".000000";
-    const string& st_tx_pkts = "opflex_svc_target_tx_packets{ip=\"" + ip + "\"} "
+    const string& st_tx_pkts = "opflex_svc_target_tx_packets{ip=\"" + ip + s_ann
                             + boost::lexical_cast<std::string>(pkts) + ".000000";
     pos = output.find(st_rx_bytes);
     BOOST_CHECK_NE(pos, std::string::npos);

--- a/agent-ovs/ovs/test/ServiceStatsManager_test.cpp
+++ b/agent-ovs/ovs/test/ServiceStatsManager_test.cpp
@@ -343,7 +343,7 @@ ServiceStatsManagerFixture::testFlowStatsSvcTgt (MockConnection& portConn,
         [&] (address nhAddr) -> void {
         if (nhAddr.is_v4()) {
             FlowBuilder().proto(17).tpDst(5353)
-                     .priority(98).ethType(eth::type::IP)
+                     .priority(97).ethType(eth::type::IP)
                      .ipDst(nhAddr)
                      .flags(OFPUTIL_FF_SEND_FLOW_REM)
                      .cookie(ovs_htonll(uint64_t(anytosvcCk)))
@@ -351,7 +351,7 @@ ServiceStatsManagerFixture::testFlowStatsSvcTgt (MockConnection& portConn,
                      .parent().build(entryList);
 
             FlowBuilder().proto(17).tpSrc(5353)
-                     .priority(98).ethType(eth::type::IP)
+                     .priority(97).ethType(eth::type::IP)
                      .ipSrc(nhAddr)
                      .flags(OFPUTIL_FF_SEND_FLOW_REM)
                      .cookie(ovs_htonll(uint64_t(svctoanyCk)))
@@ -359,7 +359,7 @@ ServiceStatsManagerFixture::testFlowStatsSvcTgt (MockConnection& portConn,
                      .parent().build(entryList);
         } else {
             FlowBuilder().proto(6).tpDst(80)
-                     .priority(98).ethType(eth::type::IPV6)
+                     .priority(97).ethType(eth::type::IPV6)
                      .ipDst(nhAddr)
                      .flags(OFPUTIL_FF_SEND_FLOW_REM)
                      .cookie(ovs_htonll(uint64_t(anytosvcCk)))
@@ -367,7 +367,7 @@ ServiceStatsManagerFixture::testFlowStatsSvcTgt (MockConnection& portConn,
                      .parent().build(entryList);
 
             FlowBuilder().proto(6).tpSrc(80)
-                     .priority(98).ethType(eth::type::IPV6)
+                     .priority(97).ethType(eth::type::IPV6)
                      .ipSrc(nhAddr)
                      .flags(OFPUTIL_FF_SEND_FLOW_REM)
                      .cookie(ovs_htonll(uint64_t(svctoanyCk)))
@@ -605,7 +605,7 @@ ServiceStatsManagerFixture::testFlowRemovedSvcTgt (MockConnection& portConn,
         [&] (bool isAnyToSvc) -> void {
         if (isAnyToSvc) {
             FlowBuilder().proto(17).tpDst(5353)
-                     .priority(98).ethType(eth::type::IP)
+                     .priority(97).ethType(eth::type::IP)
                      .ipDst(nhAddr)
                      .flags(OFPUTIL_FF_SEND_FLOW_REM)
                      .cookie(ovs_htonll(uint64_t(anytosvcCk)))
@@ -613,7 +613,7 @@ ServiceStatsManagerFixture::testFlowRemovedSvcTgt (MockConnection& portConn,
                      .parent().build(entryList1);
         } else {
             FlowBuilder().proto(17).tpSrc(5353)
-                     .priority(98).ethType(eth::type::IP)
+                     .priority(97).ethType(eth::type::IP)
                      .ipSrc(nhAddr)
                      .flags(OFPUTIL_FF_SEND_FLOW_REM)
                      .cookie(ovs_htonll(uint64_t(svctoanyCk)))

--- a/agent-ovs/ovs/test/ServiceStatsManager_test.cpp
+++ b/agent-ovs/ovs/test/ServiceStatsManager_test.cpp
@@ -111,7 +111,6 @@ public:
                      bool isOld, bool isFlowStateReAdd);
 
 #ifdef HAVE_PROMETHEUS_SUPPORT
-    const string cmd = "curl --proxy \"\" --compressed --silent http://127.0.0.1:9612/metrics 2>&1;";
     void checkSvcTgtPromMetrics(uint64_t pkts, uint64_t bytes, const string& ip, bool isNodePort=false);
     void checkPodSvcPromMetrics(uint64_t pkts, uint64_t bytes);
 #endif

--- a/agent-ovs/ovs/test/TableDropStatsManager_test.cpp
+++ b/agent-ovs/ovs/test/TableDropStatsManager_test.cpp
@@ -12,6 +12,7 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/assign/list_of.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/optional.hpp>
 
 #include <opflexagent/test/ModbFixture.h>
 #include "ovs-ofputil.h"
@@ -141,7 +142,9 @@ void TableDropStatsManagerFixture::verifyDropFlowStats (
                                     PolicyStatsManager &statsManager) {
     optional<shared_ptr<PolicyStatUniverse>> su =
                 PolicyStatUniverse::resolve(agent.getFramework());
-    optional<shared_ptr<TableDropCounter>> tableDropCounter;
+    optional<shared_ptr<TableDropCounter>> tableDropCounter
+        = boost::make_optional<shared_ptr<TableDropCounter>>(false,
+                shared_ptr<TableDropCounter>(nullptr));
     if (su) {
         tableDropCounter = su.get()->resolveGbpeTableDropCounter(
                                         agent.getUuid(),

--- a/agent-ovs/ovs/test/TableDropStatsManager_test.cpp
+++ b/agent-ovs/ovs/test/TableDropStatsManager_test.cpp
@@ -222,8 +222,8 @@ void TableDropStatsManagerFixture::testOneStaticDropFlow (
         SwitchManager &swMgr,
         bool refresh_aged_flow=false)
 {
-    uint64_t expected_pkt_count = INITIAL_PACKET_COUNT,
-            expected_byte_count = INITIAL_PACKET_COUNT * PACKET_SIZE;
+    uint64_t expected_pkt_count = INITIAL_PACKET_COUNT*2,
+            expected_byte_count = INITIAL_PACKET_COUNT*2*PACKET_SIZE;
     FlowEntryList dropLogFlows;
     if(portConn.getSwitchName()=="int_conn") {
         createIntBridgeDropFlowList(table_id,

--- a/agent-ovs/ovs/test/TableDropStatsManager_test.cpp
+++ b/agent-ovs/ovs/test/TableDropStatsManager_test.cpp
@@ -1,0 +1,274 @@
+/*
+ * Test suite for class TableDropStatsManager.
+ *
+ * Copyright (c) 2020 Cisco Systems, Inc. and others.  All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ */
+
+#include <sstream>
+#include <boost/test/unit_test.hpp>
+#include <boost/assign/list_of.hpp>
+#include <boost/lexical_cast.hpp>
+
+#include <opflexagent/test/ModbFixture.h>
+#include "ovs-ofputil.h"
+#include "AccessFlowManager.h"
+#include "IntFlowManager.h"
+#include "TableDropStatsManager.h"
+#include "TableState.h"
+#include "ActionBuilder.h"
+#include "RangeMask.h"
+#include "FlowConstants.h"
+#include "PolicyStatsManagerFixture.h"
+#include "eth.h"
+#include "ovs-ofputil.h"
+
+extern "C" {
+#include <openvswitch/ofp-parse.h>
+#include <openvswitch/ofp-print.h>
+}
+
+using boost::optional;
+
+using std::shared_ptr;
+using std::string;
+using opflex::modb::URI;
+using namespace modelgbp::gbp;
+using namespace modelgbp::gbpe;
+using modelgbp::observer::PolicyStatUniverse;
+
+namespace opflexagent {
+
+class TableDropStatsManagerFixture : public PolicyStatsManagerFixture {
+
+public:
+    TableDropStatsManagerFixture() : PolicyStatsManagerFixture(),
+                                  intBridge(),
+                                  accBridge(opflex_elem_t::INVALID_MODE,
+                                            false),
+                                  tableDropStatsManager(&agent, idGen,
+                                            intBridge.switchManager,
+                                            accBridge.switchManager, 2000000) {
+        intBridge.switchManager.setMaxFlowTables(IntFlowManager::NUM_FLOW_TABLES);
+        accBridge.switchManager.setMaxFlowTables(AccessFlowManager::NUM_FLOW_TABLES);
+        tableDropStatsManager.setAgentUUID(agent.getUuid());
+    }
+    virtual ~TableDropStatsManagerFixture() {
+        intBridge.stop();
+        accBridge.stop();
+    }
+
+    PolicyStatsManagerFixture intBridge, accBridge;
+    TableDropStatsManager tableDropStatsManager;
+
+    void createIntBridgeDropFlowList(uint32_t table_id,
+             FlowEntryList& entryList);
+    void createAccBridgeDropFlowList(uint32_t table_id,
+             FlowEntryList& entryList);
+    void testOneStaticDropFlow(MockConnection& portConn,
+                               uint32_t table_id,
+                               PolicyStatsManager &statsManager,
+                               SwitchManager &swMgr);
+    void verifyDropFlowStats(uint64_t exp_packet_count,
+                             uint64_t exp_byte_count,
+                             uint32_t table_id,
+                             MockConnection& portConn,
+                             PolicyStatsManager &statsManager);
+
+};
+
+void TableDropStatsManagerFixture::verifyDropFlowStats (
+                                    uint64_t exp_packet_count,
+                                    uint64_t exp_byte_count,
+                                    uint32_t table_id,
+                                    MockConnection& portConn,
+                                    PolicyStatsManager &statsManager) {
+    optional<shared_ptr<PolicyStatUniverse>> su =
+                PolicyStatUniverse::resolve(agent.getFramework());
+    optional<shared_ptr<TableDropCounter>> tableDropCounter;
+    if (su) {
+        tableDropCounter = su.get()->resolveGbpeTableDropCounter(
+                                        agent.getUuid(),
+                                        portConn.getSwitchName(),
+                                        table_id);
+        WAIT_FOR_DO_ONFAIL(
+                   (tableDropCounter && tableDropCounter.get()
+                        && (tableDropCounter.get()->getPackets().get()
+                                == exp_packet_count)
+                        && (tableDropCounter.get()->getBytes().get()
+                                == exp_byte_count)),
+                   500, // usleep(1000) * 500 = 500ms
+                   tableDropCounter = su.get()->resolveGbpeTableDropCounter(
+                                            agent.getUuid(),
+                                            portConn.getSwitchName(),
+                                            table_id),
+                   if (tableDropCounter && tableDropCounter.get()) {
+                       BOOST_CHECK_EQUAL(
+                               tableDropCounter.get()->getPackets().get(),
+                               exp_packet_count);
+                       BOOST_CHECK_EQUAL(
+                               tableDropCounter.get()->getBytes().get(),
+                               exp_byte_count);
+                   } else {
+                       LOG(DEBUG) << "TableDropCounter mo for "
+                                  << portConn.getSwitchName()
+                                  << "-" << table_id
+                                  << " isn't present";
+                   });
+    }
+}
+
+void TableDropStatsManagerFixture::createAccBridgeDropFlowList(
+        uint32_t table_id,
+        FlowEntryList& entryList ) {
+    FlowBuilder().priority(0).cookie(flow::cookie::TABLE_DROP_FLOW)
+            .flags(OFPUTIL_FF_SEND_FLOW_REM)
+            .action().dropLog(table_id)
+            .go(AccessFlowManager::EXP_DROP_TABLE_ID)
+            .parent().build(entryList);
+}
+
+void TableDropStatsManagerFixture::createIntBridgeDropFlowList(
+        uint32_t table_id,
+        FlowEntryList& entryList ) {
+    if(table_id == IntFlowManager::SEC_TABLE_ID) {
+        FlowBuilder().priority(25).cookie(flow::cookie::TABLE_DROP_FLOW)
+                .flags(OFPUTIL_FF_SEND_FLOW_REM)
+                .ethType(eth::type::ARP)
+                .action().dropLog(IntFlowManager::SEC_TABLE_ID)
+                .go(IntFlowManager::EXP_DROP_TABLE_ID).parent()
+                .build(entryList);
+        FlowBuilder().priority(25).cookie(flow::cookie::TABLE_DROP_FLOW)
+                .flags(OFPUTIL_FF_SEND_FLOW_REM)
+                .ethType(eth::type::IP)
+                .action().dropLog(IntFlowManager::SEC_TABLE_ID)
+                .go(IntFlowManager::EXP_DROP_TABLE_ID).parent()
+                .build(entryList);
+        FlowBuilder().priority(25).cookie(flow::cookie::TABLE_DROP_FLOW)
+                .flags(OFPUTIL_FF_SEND_FLOW_REM)
+                .ethType(eth::type::IPV6)
+                .action().dropLog(IntFlowManager::SEC_TABLE_ID)
+                .go(IntFlowManager::EXP_DROP_TABLE_ID).parent()
+                .build(entryList);
+    }
+    FlowBuilder().priority(0).cookie(flow::cookie::TABLE_DROP_FLOW)
+            .flags(OFPUTIL_FF_SEND_FLOW_REM)
+            .action().dropLog(table_id)
+            .go(IntFlowManager::EXP_DROP_TABLE_ID)
+            .parent().build(entryList);
+
+}
+
+void TableDropStatsManagerFixture::testOneStaticDropFlow (
+        MockConnection& portConn,
+        uint32_t table_id,
+        PolicyStatsManager &statsManager,
+	SwitchManager &swMgr)
+{
+    uint64_t expected_pkt_count = INITIAL_PACKET_COUNT,
+            expected_byte_count = INITIAL_PACKET_COUNT * PACKET_SIZE;
+    FlowEntryList dropLogFlows;
+    if(portConn.getSwitchName()=="int_conn") {
+        createIntBridgeDropFlowList(table_id,
+                dropLogFlows);
+        if(table_id == IntFlowManager::SEC_TABLE_ID){
+            expected_pkt_count *= 4;
+            expected_byte_count *=4;
+        }
+    } else {
+        createAccBridgeDropFlowList(table_id,
+                        dropLogFlows);
+    }
+    FlowEntryList entryListCopy(dropLogFlows);
+    swMgr.writeFlow("DropLogStatic", table_id, entryListCopy);
+    // Call on_timer function to process the flow entries received from
+    // switchManager.
+    boost::system::error_code ec;
+    ec = make_error_code(boost::system::errc::success);
+    statsManager.on_timer(ec);
+    LOG(DEBUG) << "Called on_timer";
+    // create first flow stats reply message
+    struct ofpbuf *res_msg =
+        makeFlowStatReplyMessage_2(&portConn,
+                                   INITIAL_PACKET_COUNT,
+                                   table_id,
+                                   dropLogFlows);
+    LOG(DEBUG) << "1 makeFlowStatReplyMessage created";
+    BOOST_REQUIRE(res_msg!=0);
+    ofp_header *msgHdr = (ofp_header *)res_msg->data;
+    statsManager.testInjectTxnId(msgHdr->xid);
+
+    // send first flow stats reply message
+    statsManager.Handle(&portConn,
+                         OFPTYPE_FLOW_STATS_REPLY, res_msg);
+    LOG(DEBUG) << "1 FlowStatsReplyMessage handled";
+    ofpbuf_delete(res_msg);
+
+    ec = make_error_code(boost::system::errc::success);
+    statsManager.on_timer(ec);
+    LOG(DEBUG) << "Called on_timer";
+
+    // create second flow stats reply message
+    res_msg =
+        makeFlowStatReplyMessage_2(&portConn,
+                                   INITIAL_PACKET_COUNT*2,
+                                   table_id,
+                                   dropLogFlows);
+    LOG(DEBUG) << "2 makeFlowStatReplyMessage created";
+    BOOST_REQUIRE(res_msg!=0);
+    msgHdr = (ofp_header *)res_msg->data;
+    statsManager.testInjectTxnId(msgHdr->xid);
+
+    // send second flow stats reply message
+    statsManager.Handle(&portConn,
+                         OFPTYPE_FLOW_STATS_REPLY, res_msg);
+    LOG(DEBUG) << "2 FlowStatsReplyMessage handled";
+    ofpbuf_delete(res_msg);
+
+    ec = make_error_code(boost::system::errc::success);
+    statsManager.on_timer(ec);
+    LOG(DEBUG) << "Called on_timer";
+
+    verifyDropFlowStats(expected_pkt_count,
+                        expected_byte_count,
+                        table_id, portConn, statsManager);
+    LOG(DEBUG) << "FlowStatsReplyMessage verification successful";
+
+}
+
+BOOST_AUTO_TEST_SUITE(TableDropStatsManager_test)
+
+BOOST_FIXTURE_TEST_CASE(testStaticDropFlowsInt, TableDropStatsManagerFixture) {
+    MockConnection accPortConn(TEST_CONN_TYPE_ACC);
+    MockConnection intPortConn(TEST_CONN_TYPE_INT);
+    tableDropStatsManager.registerConnection(&intPortConn, &accPortConn);
+    tableDropStatsManager.start();
+    for(int i=IntFlowManager::SEC_TABLE_ID ;
+            i < IntFlowManager::EXP_DROP_TABLE_ID ; i++) {
+        testOneStaticDropFlow(intPortConn, i,
+            tableDropStatsManager.getIntTableDropStatsMgr(),
+            intBridge.switchManager);
+    }
+    tableDropStatsManager.stop();
+}
+
+BOOST_FIXTURE_TEST_CASE(testStaticDropFlowsAcc, TableDropStatsManagerFixture) {
+    MockConnection accPortConn(TEST_CONN_TYPE_ACC);
+    MockConnection intPortConn(TEST_CONN_TYPE_INT);
+    tableDropStatsManager.registerConnection(&intPortConn, &accPortConn);
+    tableDropStatsManager.start();
+    for(int i = AccessFlowManager::GROUP_MAP_TABLE_ID;
+            i < AccessFlowManager::EXP_DROP_TABLE_ID; i++) {
+        testOneStaticDropFlow(accPortConn, i,
+            tableDropStatsManager.getAccTableDropStatsMgr(),
+            accBridge.switchManager);
+    }
+    tableDropStatsManager.stop();
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}

--- a/agent-ovs/ovs/test/TableDropStatsManager_test.cpp
+++ b/agent-ovs/ovs/test/TableDropStatsManager_test.cpp
@@ -107,7 +107,6 @@ public:
                              PolicyStatsManager &statsManager);
 
 #ifdef HAVE_PROMETHEUS_SUPPORT
-    const string cmd = "curl --proxy \"\" --compressed --silent http://127.0.0.1:9612/metrics 2>&1;";
     void checkPrometheusCounters(uint64_t exp_packet_count,
                                  uint64_t exp_byte_count,
                                  const std::string &bridgeName,

--- a/agent-ovs/ovs/test/include/FlowManagerFixture.h
+++ b/agent-ovs/ovs/test/include/FlowManagerFixture.h
@@ -99,7 +99,7 @@ void diffTables(Agent& agent,
 
 enum REG {
     SEPG, SEPG12, DEPG, BD, FD, FD12, RD, OUTPORT,
-    SVCADDR1, SVCADDR2, SVCADDR3, SVCADDR4, TUNID, TUNSRC, TUNDST,
+    SVCADDR1, SVCADDR2, SVCADDR3, SVCADDR4, CTMARK, TUNID, TUNSRC, TUNDST,
     VLAN, ETHSRC, ETHDST, ARPOP, ARPSHA, ARPTHA, ARPSPA, ARPTPA, METADATA,
     PKT_MARK
 };
@@ -131,6 +131,7 @@ public:
     Bldr& tunId(uint32_t id) { m("tun_id", str(id, true)); return *this; }
     Bldr& in(uint32_t p) { m("in_port", str(p)); return *this; }
     Bldr& reg(REG r, uint32_t v);
+    Bldr& reg(REG r, const std::string& v);
     Bldr& isEthSrc(const std::string& s) { m("dl_src", s); return *this; }
     Bldr& isEthDst(const std::string& s) { m("dl_dst", s); return *this; }
     Bldr& ip() { m("ip"); return *this; }

--- a/agent-ovs/ovs/test/include/FlowManagerFixture.h
+++ b/agent-ovs/ovs/test/include/FlowManagerFixture.h
@@ -203,6 +203,7 @@ public:
         m("metadata", str(a, true) + "/0xff"); return *this;
     }
     Bldr& isPolicyApplied() { m("metadata", "0x100/0x100"); return *this; }
+    Bldr& isToHostAccess() { m("metadata", "0x8/0xff"); return *this; }
     Bldr& isFromServiceIface(bool yes = true) {
         m() << "metadata=" << (yes ? "0x200" : "0") << "/0x200";
         return *this;

--- a/agent-ovs/ovs/test/include/FlowManagerFixture.h
+++ b/agent-ovs/ovs/test/include/FlowManagerFixture.h
@@ -18,6 +18,8 @@
 #include "PacketInHandler.h"
 #include <opflexagent/logging.h>
 
+#include "IntFlowManager.h"
+#include "AccessFlowManager.h"
 #include <vector>
 #include <thread>
 #include <list>
@@ -26,11 +28,18 @@
 namespace opflexagent {
 
 class FlowManagerFixture : public ModbFixture {
-    typedef opflex::ofcore::OFConstants::OpflexElementMode opflex_elem_t;
 public:
-    FlowManagerFixture(opflex_elem_t mode = opflex_elem_t::INVALID_MODE)
+    FlowManagerFixture(opflex_elem_t mode = opflex_elem_t::INVALID_MODE,
+            bool intBridgeTableDesc = true)
         : ModbFixture(mode), ctZoneManager(idGen),
         switchManager(agent, exec, reader, portmapper) {
+        SwitchManager::TableDescriptionMap fwdTblDescr;
+        if(intBridgeTableDesc) {
+            IntFlowManager::populateTableDescriptionMap(fwdTblDescr);
+        } else {
+            AccessFlowManager::populateTableDescriptionMap(fwdTblDescr);
+        }
+        switchManager.setForwardingTableList(fwdTblDescr);
         switchManager.setSyncDelayOnConnect(0);
         ctZoneManager.setCtZoneRange(1, 65534);
         ctZoneManager.init("conntrack");

--- a/agent-ovs/ovs/test/include/FlowManagerFixture.h
+++ b/agent-ovs/ovs/test/include/FlowManagerFixture.h
@@ -29,17 +29,9 @@ namespace opflexagent {
 
 class FlowManagerFixture : public ModbFixture {
 public:
-    FlowManagerFixture(opflex_elem_t mode = opflex_elem_t::INVALID_MODE,
-            bool intBridgeTableDesc = true)
+    FlowManagerFixture(opflex_elem_t mode = opflex_elem_t::INVALID_MODE)
         : ModbFixture(mode), ctZoneManager(idGen),
         switchManager(agent, exec, reader, portmapper) {
-        SwitchManager::TableDescriptionMap fwdTblDescr;
-        if(intBridgeTableDesc) {
-            IntFlowManager::populateTableDescriptionMap(fwdTblDescr);
-        } else {
-            AccessFlowManager::populateTableDescriptionMap(fwdTblDescr);
-        }
-        switchManager.setForwardingTableList(fwdTblDescr);
         switchManager.setSyncDelayOnConnect(0);
         ctZoneManager.setCtZoneRange(1, 65534);
         ctZoneManager.init("conntrack");

--- a/agent-ovs/ovs/test/include/MockRpcConnection.h
+++ b/agent-ovs/ovs/test/include/MockRpcConnection.h
@@ -88,15 +88,24 @@ public:
      * map of request response pairs
      */
     map<uint64_t, int> dict;
+
     /**
-     * number of responses to send
+     * number of span responses to send
      */
-    static const unsigned int no_of_msgs = 13;
+    static const unsigned int no_of_span_msgs = 13;
+
+    /**
+     * number of netflow responses to send
+     */
+    static const unsigned int no_of_netflow_msgs = 3;
+
     /**
      * rapidjson Document object array
      */
-    Document d[no_of_msgs];
+    Document d[no_of_span_msgs + no_of_netflow_msgs];
 private:
+
+    /* SPAN request/responses start */
 
     //string request1 {"[\"Open_vSwitch\",{\"where\":[],\"table\":\"Mirror\",\"op\":\"select\"}]"};
     string response1 {"[{\"rows\":[{\"statistics\":[\"map\",[[\"tx_bytes\",0],[\"tx_packets\",0]]],\
@@ -231,9 +240,37 @@ private:
             */
     string response13 {"[{\"uuid\":[\"uuid\",\"ad0810fb-fa38-4dd0-b0b3-6a98985dd2bc\"]},{\"count\":1}]"};
 
-    string response[no_of_msgs] = {response1, response2, response3, response4, response5,
+    /* SPAN request/responses end */
+
+    /* NetFlow request/responses start */
+
+    /*
+    string netflowRequest1 {"[\"Open_vSwitch\",{\"where\":[[\"name\",\"==\",\"br-int\"]],\"table\":\
+            \"Bridge\",\"op\":\"select\",\"columns\":[\"_uuid\"]}]"};
+            */
+    string netflowResponse1 {"[{\"rows\":[{\"_uuid\":[\"uuid\",\"7cb323d7-0215-406d-ae1d-679b72e1f6aa\"]}]}]"};
+
+    /*
+     string netflowRequest2 {"Open_vSwitch",{"uuid-name":"row5ceec9e1-c8a4-496a-a265-1e98ec2986d1","table":"NetFlow",
+                             "op":"insert","row":{"active_timeout":180,"add_id_to_interface":false,"targets":"172.28.184.20:2055"}},
+                             {"where":[["_uuid","==",["uuid","18368680-b320-458f-927c-3e8e87a75a7a"]]],"table":"Bridge",
+                             "op":"update","row":{"netflow":["named-uuid","row5ceec9e1-c8a4-496a-a265-1e98ec2986d1"]}}]}
+    */
+    string netflowResponse2{"[{\"uuid\":[\"uuid\",\"8efc3cdd-5504-4943-90a7-06aa15fac286\"]},{\"count\":1}]"};
+
+    /*
+     string netflowRequest3 {"id":["transact",1],"method":"transact","params":["Open_vSwitch",
+                             {"where":[["name","==","br-int"]],"table":"Bridge","op":"update",
+                             "row":{"netflow":["set",[]]}}]}
+    */
+    string netflowResponse3{"[{\"count\":1}]"};
+
+
+    /* NetFlow request/responses end */
+
+    string response[no_of_span_msgs + no_of_netflow_msgs] = {response1, response2, response3, response4, response5,
             response6, response7, response8, response9, response10, response11, response12,
-            response13 };
+            response13, netflowResponse1, netflowResponse2, netflowResponse3 };
 
 };
 

--- a/agent-ovs/ovs/test/include/PolicyStatsManagerFixture.h
+++ b/agent-ovs/ovs/test/include/PolicyStatsManagerFixture.h
@@ -70,6 +70,12 @@ public:
 
 class PolicyStatsManagerFixture : public FlowManagerFixture {
 public:
+    PolicyStatsManagerFixture (
+            opflex_elem_t mode = opflex_elem_t::INVALID_MODE,
+            bool intBridgeTableDesc = true ): FlowManagerFixture (
+                    mode, intBridgeTableDesc) {
+    };
+
     void verifyFlowStats(shared_ptr<L24Classifier> classifier,
                          uint32_t packet_count,
                          uint32_t byte_count,uint32_t table_id,

--- a/agent-ovs/ovs/test/include/PolicyStatsManagerFixture.h
+++ b/agent-ovs/ovs/test/include/PolicyStatsManagerFixture.h
@@ -71,9 +71,8 @@ public:
 class PolicyStatsManagerFixture : public FlowManagerFixture {
 public:
     PolicyStatsManagerFixture (
-            opflex_elem_t mode = opflex_elem_t::INVALID_MODE,
-            bool intBridgeTableDesc = true ): FlowManagerFixture (
-                    mode, intBridgeTableDesc) {
+            opflex_elem_t mode = opflex_elem_t::INVALID_MODE):
+            FlowManagerFixture (mode) {
     };
 
     void verifyFlowStats(shared_ptr<L24Classifier> classifier,

--- a/agent-ovs/plugin-renderer-openvswitch.conf.in
+++ b/agent-ovs/plugin-renderer-openvswitch.conf.in
@@ -63,9 +63,9 @@
         //               // The IP address used for the destination IP in
         //               // the encapsulated traffic.
         //               "remote-ip": "192.168.1.2",
-        //               // Full path of the network namespace in which the
-        //               // packet logger runs. DropLog is the network namespace name
-        //               "namespace": "/var/run/netns/DropLog"
+        //               // Geneve packets destined to the remote-ip will be
+        //               // redirected to this port locally
+        //               "local-port": 50000
         //         }
         //     },
         //

--- a/agent-ovs/plugin-renderer-openvswitch.conf.in
+++ b/agent-ovs/plugin-renderer-openvswitch.conf.in
@@ -123,8 +123,9 @@
         //             // gratuitous-broadcast: Send gratuitous arp
         //             //   broadcast requests
         //             // rarp-broadcast: Send rarp broadcast requests
-        //             // Default: rarp-broadcast
-        //             "tunnel-endpoint-mode": "rarp-broadcast",
+        //             // garp-rarp-broadcast: Send garp and rarp broadcast requests
+        //             // Default: garp-rarp-broadcast
+        //             "tunnel-endpoint-mode": "garp-rarp-broadcast",
         //             // tunnel endpoint advertisement interval in seconds
         //             // Default: 300 s
         //             "tunnel-endpoint-interval": 300

--- a/agent-ovs/rpm/90-opflex-agent-sysctl.conf
+++ b/agent-ovs/rpm/90-opflex-agent-sysctl.conf
@@ -1,2 +1,6 @@
 # Increase max IGMP memberships to allow VXLAN scaling
+# Increase socket buffer size to be able to support more IGMP joins
 net.ipv4.igmp_max_memberships=16535
+net.core.optmem_max=1310720
+net.core.wmem_max=1310720
+net.core.rmem_max=1310720

--- a/genie/MODEL/EXTENSIONS/GBP/extensions.mdl
+++ b/genie/MODEL/EXTENSIONS/GBP/extensions.mdl
@@ -457,6 +457,18 @@ module[gbpe]
 
         # number of bytes sent from the service
         member[txbytes; type=scalar/UInt64]
+
+        # number of packets received by the nodePort service
+        member[nodePortRxpackets; type=scalar/UInt64]
+
+        # number of bytes received by the nodePort service
+        member[nodePortRxbytes; type=scalar/UInt64]
+
+        # number of packets sent from the nodePort service
+        member[nodePortTxpackets; type=scalar/UInt64]
+
+        # number of bytes sent from the nodePort service
+        member[nodePortTxbytes; type=scalar/UInt64]
     }
 
     # Counter for showing target Rx and Tx statistics per service. Traffic must
@@ -500,6 +512,18 @@ module[gbpe]
 
         # number of bytes sent from the service target
         member[txbytes; type=scalar/UInt64]
+
+        # number of packets received by the nodePort service target
+        member[nodePortRxpackets; type=scalar/UInt64]
+
+        # number of bytes received by the nodePort service target
+        member[nodePortRxbytes; type=scalar/UInt64]
+
+        # number of packets sent from the nodePort service target
+        member[nodePortTxpackets; type=scalar/UInt64]
+
+        # number of bytes sent from the nodePort service target
+        member[nodePortTxbytes; type=scalar/UInt64]
     }
 
     class[SecGrpClassifierCounter;

--- a/genie/MODEL/SPECIFIC/EPR/inventory.mdl
+++ b/genie/MODEL/SPECIFIC/EPR/inventory.mdl
@@ -161,8 +161,15 @@ module[inv]
             }
         }
 
-        # An IP address
+        # An IP address or subnet
         member[ip; type=address/IP]
+        # Prefix length for if IP address is a subnet
+        member[prefixLen; type=scalar/UInt8]
+        # In case of subnet the next-hop IP address
+        member[nextHopIP; type=address/IP]
+        # In case of subnet the next-hop MAC
+        member[nextHopMac; type=address/MAC]
+
     }
 
     class[IpMapping;
@@ -417,7 +424,7 @@ module[inv]
         }
     }
 
-    # an endpoint with network identifiers
+    # an endpoint with network identifiers or a remote subnet
     class[RemoteInventoryEp;
           super=inv/InventoryEp;
           concrete;

--- a/genie/MODEL/SPECIFIC/SVC/mapping.mdl
+++ b/genie/MODEL/SPECIFIC/SVC/mapping.mdl
@@ -29,6 +29,9 @@ module[svc]
         # Nexthop's L4 port
         member[nexthopPort; type=l4/Port]
 
+        # NodePort value
+        member[nodePort; type=l4/Port]
+
         contained
         {
             parent[class=svc/Service]

--- a/genie/MODEL/SPECIFIC/SVC/service.mdl
+++ b/genie/MODEL/SPECIFIC/SVC/service.mdl
@@ -7,6 +7,14 @@ module[svc]
         const[name=anycast; value=2]
     }
 
+    type[ServiceType; super=scalar/Enum8]
+    {
+        const[name=unknown; value=0]
+        const[name=clusterIp; value=1]
+        const[name=nodePort; value=2]
+        const[name=loadBalancer; value=3]
+    }
+
     # class to represent services present in the svc universe.
     class[Service;
           concrete;
@@ -17,6 +25,10 @@ module[svc]
 
         # mode of service - can be LB or anycast
         member[mode; type=svc/ServiceMode]
+
+        # Type of service set by host agent
+        # can be ClusterIP, NodePort, LoadBalancer, externalName (future)
+        member[type; type=svc/ServiceType]
 
         # service domain's URI
         member[dom; type=reference/URI]

--- a/genie/src/main/java/org/opendaylight/opflex/genie/content/format/agent/build/automake/cpp/FAutomakeDef.java
+++ b/genie/src/main/java/org/opendaylight/opflex/genie/content/format/agent/build/automake/cpp/FAutomakeDef.java
@@ -127,14 +127,18 @@ public class FAutomakeDef
         out.println();
         out.println(ainIndent,"doc/html: $(metadata_include_HEADERS) " + 
                     moddirs.toString() + "doc/Doxyfile");
+        out.println(ainIndent,"if HAVE_DOXYGEN");
             out.println(ainIndent + 1,"cd doc && ${DOXYGEN} Doxyfile");
+        out.println(ainIndent,"endif");
         out.println(ainIndent,"doc: doc/html");
         out.println(ainIndent,"install-data-local: doc");
             out.println(ainIndent + 1,"@$(NORMAL_INSTALL)");
+        out.println(ainIndent,"if HAVE_DOXYGEN");
             out.println(ainIndent + 1, "test -z \"${DESTDIR}/${docdir}/html\" || $(mkdir_p) \"${DESTDIR}/${docdir}/html\"");
             out.println(ainIndent + 1, "for i in `ls $(srcdir)/doc/html`; do \\");
                 out.println(ainIndent + 2, "$(INSTALL) -m 0644 $(srcdir)/doc/html/$$i \"${DESTDIR}/${docdir}/html\"; \\");
             out.println(ainIndent + 1, "done");
+        out.println(ainIndent,"endif");
         out.println(ainIndent,"uninstall-local:");
             out.println(ainIndent + 1,"@$(NORMAL_UNINSTALL)");
             out.println(ainIndent + 1,"rm -rf \"${DESTDIR}/${docdir}/html\"");

--- a/libopflex/Makefile.am
+++ b/libopflex/Makefile.am
@@ -144,17 +144,23 @@ if HAVE_DOXYGEN
 endif
 
 doc/html: $(modb_include_HEADERS) $(modb_mo_include_HEADERS) $(core_include_HEADERS)  $(logging_include_HEADERS) $(c_include_HEADERS) $(rpc_include_HEADERS) $(gbp_include_HEADERS) $(util_include_HEADERS) $(yajr_include_HEADERS) $(yajr_internal_include_HEADERS) $(yajr_rpc_include_HEADERS) $(yajr_transport_include_HEADERS) doc/Doxyfile
+if HAVE_DOXYGEN
 	cd doc && ${DOXYGEN} Doxyfile
+endif
 doc: doc/html
 doc/html-internal: clean-doc-internal $(modb_include_HEADERS) $(modb_mo_include_HEADERS) $(core_include_HEADERS)  $(logging_include_HEADERS) $(c_include_HEADERS) $(rpc_include_HEADERS) $(gbp_include_HEADERS) $(util_include_HEADERS) $(yajr_include_HEADERS) $(yajr_internal_include_HEADERS) $(yajr_rpc_include_HEADERS) $(yajr_transport_include_HEADERS) doc/Doxyfile-internal
+if HAVE_DOXYGEN
 	cd doc && ${DOXYGEN} Doxyfile-internal
+endif
 doc-internal: doc/html-internal
 install-data-local: doc
 	@$(NORMAL_INSTALL)
+if HAVE_DOXYGEN
 	test -z "${DESTDIR}/${docdir}/html" || $(mkdir_p) "${DESTDIR}/${docdir}/html"
 	for i in `ls $(top_builddir)/doc/html`; do \
 	  $(INSTALL) -m 0644 $(top_builddir)/doc/html/$$i "${DESTDIR}/${docdir}/html"; \
 	done
+endif
 uninstall-local: 
 	@$(NORMAL_UNINSTALL)
 	rm -rf "${DESTDIR}/${docdir}/html"

--- a/libopflex/engine/OpflexClientConnection.cpp
+++ b/libopflex/engine/OpflexClientConnection.cpp
@@ -147,11 +147,11 @@ void OpflexClientConnection::on_state_change(Peer * p, void * data,
         conn->ready = false;
         uv_timer_stop(conn->handshake_timer);
         uv_timer_start(conn->handshake_timer,
-                       on_handshake_timer, 30000, 0);
+                       on_handshake_timer, conn->getHandshakeTimeout(), 0);
 
         if (conn->pool->clientCtx.get())
             ZeroCopyOpenSSL::attachTransport(p, conn->pool->clientCtx.get());
-        p->startKeepAlive(5000, 15000, 60000);
+        p->startKeepAlive(10000, 15000, 60000);
 
         conn->pool->updatePeerStatus(conn->hostname, conn->port,
                                      PeerStatusListener::CONNECTED);

--- a/libopflex/engine/OpflexPEHandler.cpp
+++ b/libopflex/engine/OpflexPEHandler.cpp
@@ -123,6 +123,11 @@ private:
     string mac;
 };
 
+OpflexPEHandler::OpflexPEHandler(OpflexConnection* conn, Processor* processor_)
+    : OpflexHandler(conn), processor(processor_) {
+    conn->setHandshakeTimeout(processor_->getHandshakeTimeout());
+}
+
 void OpflexPEHandler::connected() {
     setState(CONNECTED);
 

--- a/libopflex/engine/OpflexServerConnection.cpp
+++ b/libopflex/engine/OpflexServerConnection.cpp
@@ -118,7 +118,7 @@ void OpflexServerConnection::on_state_change(yajr::Peer * p, void * data,
             ZeroCopyOpenSSL::Ctx* serverCtx = conn->listener->serverCtx.get();
             if (serverCtx)
                 ZeroCopyOpenSSL::attachTransport(p, serverCtx);
-            p->startKeepAlive();
+            p->startKeepAlive(10000, 15000, 45000);
 
             conn->handler->connected();
         }

--- a/libopflex/engine/include/opflex/engine/Processor.h
+++ b/libopflex/engine/include/opflex/engine/Processor.h
@@ -191,6 +191,20 @@ public:
     void setPrrTimerDuration(const uint64_t duration);
 
     /**
+     * Get the peer handshake timeout
+     */
+    uint32_t getHandshakeTimeout() const {
+        return peerHandshakeTimeout;
+    }
+
+    /**
+     * Set the peer handshake timeout
+     */
+    void setHandshakeTimeout(const uint32_t timeout) {
+        peerHandshakeTimeout = timeout;
+    }
+
+    /**
      * Set the prr timer duration in secs
      */
     uint64_t getPrrTimerDuration() { return prrTimerDuration; }
@@ -491,8 +505,10 @@ private:
     /**
      * prr timer duration in secs
      */
-    static const uint64_t DEFAULT_PRR_TIMER_DURATION = 5400;
+    static const uint64_t DEFAULT_PRR_TIMER_DURATION = 7200;
     uint64_t prrTimerDuration = DEFAULT_PRR_TIMER_DURATION;
+
+    uint32_t peerHandshakeTimeout = 45000;
 
     /**
      *  policy refresh timer duration in msecs

--- a/libopflex/engine/include/opflex/engine/internal/OpflexConnection.h
+++ b/libopflex/engine/include/opflex/engine/internal/OpflexConnection.h
@@ -141,6 +141,22 @@ public:
      */
     void processWriteQueue();
 
+    /**
+     * Get the peer handshake timeout (in ms)
+     * @return timeout
+     */
+    uint32_t getHandshakeTimeout() {
+        return handshakeTimeout;
+    }
+
+    /**
+     * Set the peer handshake timeout (in ms)
+     * @param timeout timeout
+     */
+    void setHandshakeTimeout(uint32_t timeout) {
+        handshakeTimeout = timeout;
+    }
+
 protected:
     /**
      * The handler for the connection
@@ -158,7 +174,6 @@ protected:
      */
     virtual yajr::Peer* getPeer() = 0;
 
-protected:
     /**
      * Clean up write queue
      */
@@ -172,6 +187,7 @@ private:
     typedef std::list<write_queue_item_t> write_queue_t;
     write_queue_t write_queue;
     uv_mutex_t queue_mutex;
+    uint32_t handshakeTimeout;
 
     void doWrite(OpflexMessage* message);
 

--- a/libopflex/engine/include/opflex/engine/internal/OpflexPEHandler.h
+++ b/libopflex/engine/include/opflex/engine/internal/OpflexPEHandler.h
@@ -38,8 +38,7 @@ public:
      * Construct a new opflex PE handler associated with the given
      * connection
      */
-    OpflexPEHandler(OpflexConnection* conn, Processor* processor_)
-        : OpflexHandler(conn), processor(processor_) {}
+    OpflexPEHandler(OpflexConnection* conn, Processor* processor_);
 
     /**
      * Destroy the handler

--- a/libopflex/engine/test/MOSerialize_test.cpp
+++ b/libopflex/engine/test/MOSerialize_test.cpp
@@ -73,7 +73,7 @@ BOOST_FIXTURE_TEST_CASE( mo_serialize , BaseFixture ) {
     writer.EndArray();
 
     writer.String("prr");
-    writer.Uint(5400);
+    writer.Uint(7200);
     writer.EndObject();
 
     writer.String("id");
@@ -88,7 +88,7 @@ BOOST_FIXTURE_TEST_CASE( mo_serialize , BaseFixture ) {
     BOOST_CHECK(result.IsObject());
     const Value& prr = result["prr"];
     BOOST_CHECK(prr.IsUint());
-    BOOST_CHECK_EQUAL(5400, prr.GetInt());
+    BOOST_CHECK_EQUAL(7200, prr.GetInt());
 
     const Value& policy = result["policy"];
     BOOST_CHECK(policy.IsArray());
@@ -227,7 +227,7 @@ BOOST_FIXTURE_TEST_CASE( mo_deserialize , BaseFixture ) {
         "{\"result\":{\"policy\":[{\"subject\":\"class1\",\"uri\""
         ":\"/\",\"properties\":[{\"name\":\"prop2\",\"data\":[\"te"
         "st1\",\"test2\"]},{\"name\":\"prop1\",\"data\":42}],\"chi"
-        "ldren\":[\"/class2/-84\"]}],\"prr\":5400},\"id\":42}";
+        "ldren\":[\"/class2/-84\"]}],\"prr\":7200},\"id\":42}";
     Document d3;
     d3.Parse(buffer3);
     const Value& result3 = d3["result"];

--- a/libopflex/include/opflex/ofcore/OFFramework.h
+++ b/libopflex/include/opflex/ofcore/OFFramework.h
@@ -736,6 +736,12 @@ public:
     void setPrrTimerDuration(const uint64_t duration);
 
     /**
+     * Set the peer handshake timeout
+     * @param timeout peer handshake timeout in milliseconds
+     */
+     void setHandshakeTimeout(const uint32_t timeout);
+
+    /**
      * Start the framework.  This will start all the framework threads
      * and attempt to connect to configured OpFlex peers.
      */

--- a/libopflex/ofcore/OFFramework.cpp
+++ b/libopflex/ofcore/OFFramework.cpp
@@ -113,6 +113,10 @@ void OFFramework::setPrrTimerDuration(const uint64_t duration) {
     pimpl->processor.setPrrTimerDuration(duration);
 }
 
+void OFFramework::setHandshakeTimeout(const uint32_t timeout) {
+    pimpl->processor.setHandshakeTimeout(timeout);
+}
+
 void OFFramework::start() {
     LOG(DEBUG) << "Starting OpFlex Framework";
     pimpl->started = true;


### PR DESCRIPTION
- mcast: Found that some of the events happen just after the test fails. Increasing retry count.
- routingDomainUnenforcedMode: test fails if policy manager updates group_map after intflowmanager.egDomUpd() gets called. Registering listener updates from policy manager to fix ordering issues. EPG updates will be trigged by policy manager updates now.
- remoteInventoryMode: same fix as routingDomainUnenforced