### PR TITLE
Send unicast GARPs additionally to each opflex peer

### DIFF
--- a/agent-ovs/ovs/include/AdvertManager.h
+++ b/agent-ovs/ovs/include/AdvertManager.h
@@ -199,8 +199,9 @@ private:
     /**
      * Synchronously send GARP for tunnel endpoints
      * @param uuid the UUID of the tunnel ep
+     * @param unicast_mode send unicast/broadcast GARPs
      */
-    void sendTunnelEpGarp(const std::string& uuid);
+    void sendTunnelEpGarp(const std::string& uuid, bool unicast_mode=false);
 
     /**
      * Synchronously send RARP for tunnel endpoints
@@ -214,6 +215,16 @@ private:
      * @param uuid the UUID of the tunnel ep
      */
     void sendTunnelEpAdvs(const std::string& uuid);
+
+    /**
+     * Get the Mac address from the ARP entry of the given IP address
+     *
+     * @param ipAddr IPv4 address of the peer.
+     * @param iface interface on which peer is reachable.
+     * @param mac output MAC address of the given peer.
+     * @return whether successful
+     */
+    int getArpMac(const string& ipAddr, const string& iface, string &mac);
 
     /**
      * Timer callback for gratuitious endpoint advertisements

--- a/libopflex/engine/OpflexPool.cpp
+++ b/libopflex/engine/OpflexPool.cpp
@@ -477,6 +477,12 @@ void OpflexPool::getOpflexPeerStats(std::unordered_map<string, OF_SHARED_PTR<OFS
     }
 }
 
+void OpflexPool::getOpflexPeers(std::vector<std::string>& peers) {
+    util::RecursiveLockGuard guard(&conn_mutex, &conn_mutex_key);
+    BOOST_FOREACH(conn_map_t::value_type& v, connections) {
+        peers.emplace_back(v.first.first);
+    }
+}
 
 } /* namespace internal */
 } /* namespace engine */

--- a/libopflex/engine/include/opflex/engine/internal/OpflexPool.h
+++ b/libopflex/engine/include/opflex/engine/internal/OpflexPool.h
@@ -349,6 +349,12 @@ public:
      */
     void getOpflexPeerStats(std::unordered_map<std::string, OF_SHARED_PTR<OFStats>>& stats);
 
+    /**
+     * Retrieve OpFlex peers
+     *
+     * @param peers vector of peer IP address
+     */
+    void getOpflexPeers(std::vector<std::string>& peers);
 private:
     HandlerFactory& factory;
     util::ThreadManager& threadManager;

--- a/libopflex/include/opflex/ofcore/OFFramework.h
+++ b/libopflex/include/opflex/ofcore/OFFramework.h
@@ -900,6 +900,13 @@ public:
     void getOpflexPeerStats(std::unordered_map<std::string, OF_SHARED_PTR<OFStats>>& stats);
 
     /**
+     * Retrieve OpFlex peers
+     *
+     * @param peers vector of IP addresses
+     */
+    void getOpflexPeers(std::vector<std::string>& peers);
+
+    /**
      * Enable/Disable reporting of observable changes to registered observers
      *
      * @param class_id Observable class ID

--- a/libopflex/ofcore/OFFramework.cpp
+++ b/libopflex/ofcore/OFFramework.cpp
@@ -277,6 +277,11 @@ void OFFramework::clearTLMutator() {
     uv_key_set(&pimpl->mutator_key, NULL);
 }
 
+void OFFramework::getOpflexPeers(std::vector<std::string>& peers) {
+    engine::internal::OpflexPool& pool = pimpl->processor.getPool();
+    pool.getOpflexPeers(peers);
+}
+
 void OFFramework::getOpflexPeerStats(std::unordered_map<string, OF_SHARED_PTR<OFStats>>& stats) {
     engine::internal::OpflexPool& pool = pimpl->processor.getPool();
     pool.getOpflexPeerStats(stats);


### PR DESCRIPTION
GARP broadcast does not reach both opflex peers if GARP flood is disabled.
Unicast GARPs to each opflex peer, so both peers can refresh their ARP

Signed-off-by: Kiran Shastri <shastrinator@gmail.com>