### PR TITLE
Add order/direction to SG rule

### DIFF
--- a/genie/MODEL/SPECIFIC/GBP/COMMON/secgroup.mdl
+++ b/genie/MODEL/SPECIFIC/GBP/COMMON/secgroup.mdl
@@ -54,5 +54,7 @@ module[gbp]
                 cardinality=many;
                 ]
         }
+        member[order; type=scalar/UInt32]
+        member[direction; type=gbp/Direction]
     }
 }


### PR DESCRIPTION
Add order/direction to SG rule

We already have order/direction for contract rules...not sure why we didn't add them to security groups as well
This change is needed for some upcoming work. agent changes to make use of the new fields to follow

Signed-off-by: Tom Flynn <tom.flynn@gmail.com>