### PR TITLE
Avoid unnecessarily writing OVSDB payload into a buffer

### DIFF
--- a/agent-ovs/ovs/OvsdbConnection.cpp
+++ b/agent-ovs/ovs/OvsdbConnection.cpp
@@ -72,9 +72,9 @@ void OvsdbConnection::stop() {
     threadManager.stopTask("OvsdbConnection");
 }
 
- void OvsdbConnection::on_state_change(yajr::Peer * p, void * data,
-                     yajr::StateChange::To stateChange,
-                     int error) {
+void OvsdbConnection::on_state_change(yajr::Peer * p, void * data,
+                                      yajr::StateChange::To stateChange,
+                                      int error) {
     auto* conn = (OvsdbConnection*)data;
     switch (stateChange) {
         case yajr::StateChange::CONNECT: {
@@ -228,9 +228,6 @@ bool processRowUpdate(const Value& value, OvsdbRowDetails& rowDetails) {
 }
 
 void OvsdbConnection::handleMonitor(uint64_t reqId, const Document& payload) {
-    StringBuffer buffer;
-    Writer<StringBuffer> writer(buffer);
-    payload.Accept(writer);
     if (payload.IsObject()) {
         OvsdbTableDetails tableState;
         if (payload.HasMember(OvsdbMessage::toString(OvsdbTable::BRIDGE))) {
@@ -349,9 +346,6 @@ void OvsdbConnection::handleMonitorError(uint64_t reqId, const Document& payload
 }
 
 void OvsdbConnection::handleUpdate(const Document& payload) {
-    StringBuffer buffer;
-    Writer<StringBuffer> writer(buffer);
-    payload.Accept(writer);
     if (payload.IsArray()) {
         if (payload[0].IsString()) {
             if (payload[1].IsObject()) {
@@ -476,14 +470,8 @@ void OvsdbConnection::handleUpdate(const Document& payload) {
                         }
                     }
                 }
-            } else {
-                LOG(WARNING) << "second elem is not an array";
             }
-        } else {
-            LOG(WARNING) << "first element in array is not a string";
         }
-    } else {
-        LOG(WARNING) << "Payload is not an array";
     }
 }
 

--- a/agent-ovs/ovs/test/OvsdbConnection_test.cpp
+++ b/agent-ovs/ovs/test/OvsdbConnection_test.cpp
@@ -60,56 +60,46 @@ BOOST_FIXTURE_TEST_CASE( verify_connect, OvsdbConnectionFixture ) {
     payload.GetAllocator().Clear();
     payload.Parse(bridgeMonitorResponse.c_str());
     conn->handleMonitor(1, payload);
-
     payload.GetAllocator().Clear();
     payload.Parse(bridgeMonitorUpdate.c_str());
     conn->handleUpdate(payload);
 
     payload.GetAllocator().Clear();
     payload.Parse(portMonitorResponse.c_str());
-    conn->handleMonitor(1, payload);
-    conn->handleUpdate(payload);
-
+    conn->handleMonitor(2, payload);
     payload.GetAllocator().Clear();
     payload.Parse(portMonitorUpdate.c_str());
     conn->handleUpdate(payload);
 
     payload.GetAllocator().Clear();
     payload.Parse(interfaceMonitorResponse.c_str());
-    conn->handleMonitor(1, payload);
-    conn->handleUpdate(payload);
-
+    conn->handleMonitor(3, payload);
     payload.GetAllocator().Clear();
     payload.Parse(interfaceMonitorUpdate.c_str());
     conn->handleUpdate(payload);
 
     payload.GetAllocator().Clear();
     payload.Parse(mirrorMonitorResponse.c_str());
-    conn->handleMonitor(1, payload);
-    conn->handleUpdate(payload);
-
+    conn->handleMonitor(4, payload);
     payload.GetAllocator().Clear();
     payload.Parse(mirrorMonitorUpdate.c_str());
     conn->handleUpdate(payload);
 
     payload.GetAllocator().Clear();
     payload.Parse(netflowMonitorResponse.c_str());
-    conn->handleMonitor(1, payload);
-    conn->handleUpdate(payload);
-
+    conn->handleMonitor(5, payload);
     payload.GetAllocator().Clear();
     payload.Parse(netflowMonitorUpdate.c_str());
     conn->handleUpdate(payload);
 
     payload.GetAllocator().Clear();
     payload.Parse(ipfixMonitorResponse.c_str());
-    conn->handleMonitor(1, payload);
-    conn->handleUpdate(payload);
-
+    conn->handleMonitor(6, payload);
     payload.GetAllocator().Clear();
     payload.Parse(ipfixMonitorUpdate.c_str());
     conn->handleUpdate(payload);
 
+    conn->stop();
 }
 BOOST_AUTO_TEST_SUITE_END()
 


### PR DESCRIPTION
Avoid unnecessarily writing OVSDB payload into a buffer

Remove mocked calls to handleUpdate with incorrect payload

Signed-off-by: Tom Flynn <tom.flynn@gmail.com>