### PR TITLE
Protecting pool's tunnel mac update with mutex

### DIFF
--- a/libopflex/engine/include/opflex/engine/internal/OpflexPool.h
+++ b/libopflex/engine/include/opflex/engine/internal/OpflexPool.h
@@ -335,10 +335,12 @@ public:
     }
 
     void setTunnelMac(const opflex::modb::MAC &mac) {
+        const std::lock_guard<std::mutex> lock(tunnel_mac_mutex);
         tunnelMac = mac;
     }
 
     opflex::modb::MAC getTunnelMac() {
+        const std::lock_guard<std::mutex> lock(tunnel_mac_mutex);
         return tunnelMac;
     }
 
@@ -396,6 +398,7 @@ private:
     boost::asio::ip::address_v4 ipv4_proxy;
     boost::asio::ip::address_v4 ipv6_proxy;
     boost::asio::ip::address_v4 mac_proxy;
+    std::mutex tunnel_mac_mutex;
     opflex::modb::MAC tunnelMac;
 
     uv_loop_t* client_loop;


### PR DESCRIPTION
355 WARNING: ThreadSanitizer: data race (pid=8183)
356   Write of size 8 at 0x7b7800000548 by thread T11 (mutexes: write M1342):
357     #0 opflex::engine::internal::OpflexPool::setTunnelMac(opflex::modb::MAC const&) include/opflex/engine/internal/OpflexPool.h:338 (libopflex.so.0+0x115151)
358     #1 opflex::engine::Processor::setTunnelMac(opflex::modb::MAC const&) /home/noiro/work/opflex/libopflex/engine/Processor.cpp:584 (libopflex.so.0+0x115151)
359     #2 opflex::ofcore::OFFramework::setTunnelMac(opflex::modb::MAC const&) /home/noiro/work/opflex/libopflex/ofcore/OFFramework.cpp:103 (libopflex.so.0+0x18dcca)
360     #3 opflexagent::Agent::setUplinkMac(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) lib/Agent.cpp:795 (libopflex_agent.so.0+0x253e33)
361     #4 opflexagent::TunnelEpManager::on_timer(boost::system::error_code const&) lib/TunnelEpManager.cpp:281 (libopflex_agent.so.0+0x22c49f)
362     #5 boost::asio::detail::wait_handler<boost::_bi::bind_t<void, boost::_mfi::mf1<void, opflexagent::TunnelEpManager, boost::system::error_code const&>, boost::_bi::list2<boost::_bi::value<opflexagent::T
363     #6 boost::asio::detail::task_io_service_operation::complete(boost::asio::detail::task_io_service&, boost::system::error_code const&, unsigned long) /usr/include/boost/asio/detail/task_io_service_opera
364     #7 boost::asio::detail::task_io_service::do_run_one(boost::asio::detail::scoped_lock<boost::asio::detail::posix_mutex>&, boost::asio::detail::task_io_service_thread_info&, boost::system::error_code co
365     #8 boost::asio::detail::task_io_service::run(boost::system::error_code&) /usr/include/boost/asio/detail/impl/task_io_service.ipp:149 (libopflex.so.0+0x16b982)
366     #9 boost::asio::io_service::run() /usr/include/boost/asio/impl/io_service.ipp:59 (libopflex_agent.so.0+0x256259)
367     #10 operator() lib/Agent.cpp:606 (libopflex_agent.so.0+0x256259)
368     #11 __invoke_impl<void, opflexagent::Agent::start()::<lambda()> > /usr/include/c++/9/bits/invoke.h:60 (libopflex_agent.so.0+0x256259)
369     #12 __invoke<opflexagent::Agent::start()::<lambda()> > /usr/include/c++/9/bits/invoke.h:95 (libopflex_agent.so.0+0x256259)
370     #13 _M_invoke<0> /usr/include/c++/9/thread:244 (libopflex_agent.so.0+0x256259)
371     #14 operator() /usr/include/c++/9/thread:251 (libopflex_agent.so.0+0x256259)
372     #15 _M_run /usr/include/c++/9/thread:195 (libopflex_agent.so.0+0x256259)
373     #16 <null> <null> (libstdc++.so.6+0xd086f)
374
375   Previous read of size 8 at 0x7b7800000548 by thread T4:
376     #0 opflex::engine::internal::OpflexPool::getTunnelMac() include/opflex/engine/internal/OpflexPool.h:342 (libopflex.so.0+0x1457d5)
377     #1 opflex::engine::internal::OpflexPEHandler::connected() /home/noiro/work/opflex/libopflex/engine/OpflexPEHandler.cpp:139 (libopflex.so.0+0x1457d5)
378     #2 opflex::engine::internal::OpflexClientConnection::on_state_change(yajr::Peer*, void*, yajr::StateChange::To, int) /home/noiro/work/opflex/libopflex/engine/OpflexClientConnection.cpp:158 (libopflex.
379     #3 yajr::comms::internal::CommunicationPeer::onConnect() /home/noiro/work/opflex/libopflex/comms/CommunicationPeer.cpp:116 (libopflex.so.0+0xe2aac)
380     #4 yajr::comms::internal::on_active_connection(uv_connect_s*, int) /home/noiro/work/opflex/libopflex/comms/active_connection.cpp:185 (libopflex.so.0+0xb5d00)
381     #5 <null> <null> (libuv.so.1+0x162c3)
382     #6 <null> <null> (libtsan.so.0+0x2aba6)

Signed-off-by: Gautam Venkataramanan <gautam.chennai@gmail.com>