### PR TITLE
Require c++11 support to build libopflex, c++14 for agent-ovs

### DIFF
--- a/agent-ovs/Makefile.am
+++ b/agent-ovs/Makefile.am
@@ -293,7 +293,8 @@ if RENDERER_OVS
 	$(libmodelgbp_CFLAGS) \
 	$(OVS_ADDL_CFLAGS) \
 	$(libopenvswitch_CFLAGS) \
-	$(libofproto_CFLAGS)
+	$(libofproto_CFLAGS) \
+	-std=gnu++14
 if ENABLE_TSAN
   librenderer_openvswitch_la_CXXFLAGS += -fsanitize=thread
 endif

--- a/agent-ovs/configure.ac
+++ b/agent-ovs/configure.ac
@@ -79,7 +79,7 @@ AC_PROG_INSTALL
 AM_PROG_AS
 AC_LANG([C])
 AC_LANG([C++])
-AX_CXX_COMPILE_STDCXX([11], [ext], [mandatory])
+AX_CXX_COMPILE_STDCXX([14], [ext], [mandatory])
 
 # check for doxygen
 AC_CHECK_PROGS(DOXYGEN,doxygen,none)

--- a/agent-ovs/ovs/include/ovs-shim.h
+++ b/agent-ovs/ovs/include/ovs-shim.h
@@ -245,12 +245,6 @@ extern "C" {
             int regId, const void* regValue, const void* mask);
 
     /**
-     * Get the value of the output reg action
-     */
-    uint32_t get_output_reg_value(const struct ofpact* ofpacts,
-                                  size_t ofpacts_len);
-
-    /**
      * malloc a dp_packet
      */
     struct dp_packet* alloc_dpp();

--- a/agent-ovs/ovs/ovs-shim.c
+++ b/agent-ovs/ovs/ovs-shim.c
@@ -369,22 +369,6 @@ void act_macvlan_learn(struct ofpbuf* ofpacts,
     ofpact_finish_LEARN(ofpacts, &learn);
 }
 
-uint32_t get_output_reg_value(const struct ofpact* ofpacts,
-                              size_t ofpacts_len) {
-    const struct ofpact* a;
-    OFPACT_FOR_EACH (a, ofpacts, ofpacts_len) {
-        if (a->type == OFPACT_SET_FIELD) {
-            struct ofpact_set_field* sf = ofpact_get_SET_FIELD(a);
-            const struct mf_field *mf = sf->field;
-            if (mf->id == MFF_REG7) {
-                return ntohl(*((ovs_be32*)&sf->value));
-                break;
-            }
-        }
-    }
-    return OFPP_NONE;
-}
-
 struct dp_packet* alloc_dpp() {
     return (struct dp_packet*)malloc(sizeof(struct dp_packet));
 }

--- a/libopflex/Makefile.am
+++ b/libopflex/Makefile.am
@@ -12,7 +12,7 @@
 
 ACLOCAL_AMFLAGS = -I m4
 
-AM_CPPFLAGS = -Wall -Werror
+AM_CPPFLAGS = -Wall -Werror -std=c++11
 
 if ENABLE_TSAN
   AM_CPPFLAGS += -fsanitize=thread

--- a/libopflex/comms/Makefile.am
+++ b/libopflex/comms/Makefile.am
@@ -21,6 +21,7 @@ noinst_LTLIBRARIES += libcomms.la
 AM_CPPFLAGS  =
 AM_CPPFLAGS += -Wall
 AM_CPPFLAGS += -Werror
+AM_CPPFLAGS += -std=c++11
 AM_CPPFLAGS += $(BOOST_CPPFLAGS)
 AM_CPPFLAGS += -I$(top_builddir)
 AM_CPPFLAGS += -I$(srcdir)/include

--- a/libopflex/configure.ac
+++ b/libopflex/configure.ac
@@ -129,7 +129,7 @@ AC_PROG_CXX
 AC_PROG_INSTALL
 AM_PROG_AS
 AC_LANG([C++])
-AX_CXX_COMPILE_STDCXX([11], [noext], [optional])
+AX_CXX_COMPILE_STDCXX([11], [ext], [mandatory])
 
 dnl check for compiler flags
 AX_CHECK_COMPILE_FLAG([-Wno-multichar],

--- a/libopflex/cwrapper/Makefile.am
+++ b/libopflex/cwrapper/Makefile.am
@@ -15,6 +15,7 @@ SUBDIRS = . test
 AM_CPPFLAGS = $(BOOST_CPPFLAGS) \
         -Wall \
         -Werror \
+        -std=c++11 \
         -I$(srcdir)/include -I$(top_srcdir)/include
 
 if ENABLE_TSAN

--- a/libopflex/cwrapper/test/Makefile.am
+++ b/libopflex/cwrapper/test/Makefile.am
@@ -13,6 +13,7 @@
 AM_CPPFLAGS = $(BOOST_CPPFLAGS) -DBOOST_TEST_DYN_LINK \
 	-Wall \
 	-Werror \
+	-std=c++11 \
 	-I$(top_srcdir)/include \
 	-I$(top_srcdir)/comms/include \
 	-I$(top_srcdir)/engine/include \

--- a/libopflex/engine/Makefile.am
+++ b/libopflex/engine/Makefile.am
@@ -15,6 +15,7 @@ SUBDIRS = . test
 AM_CPPFLAGS = $(BOOST_CPPFLAGS) \
         -Wall \
         -Werror \
+        -std=c++11 \
         -I$(srcdir)/include -I$(top_srcdir)/include \
 	-I$(top_srcdir)/modb/include \
 	-I$(top_srcdir)/logging/include \

--- a/libopflex/engine/OpflexPool.cpp
+++ b/libopflex/engine/OpflexPool.cpp
@@ -394,12 +394,7 @@ void incrementMsgCounter(OpflexClientConnection* conn, OpflexMessage* msg)
 size_t OpflexPool::sendToRole(OpflexMessage* message,
                            OFConstants::OpflexRole role,
                            bool sync, const std::string& uri) {
-#ifdef HAVE_CXX11
     std::unique_ptr<OpflexMessage> messagep(message);
-#else
-    std::auto_ptr<OpflexMessage> messagep(message);
-#endif
-
     if (!active) return 0;
     std::vector<OpflexClientConnection*> conns;
 

--- a/libopflex/engine/include/opflex/engine/internal/OpflexListener.h
+++ b/libopflex/engine/include/opflex/engine/internal/OpflexListener.h
@@ -185,11 +185,7 @@ private:
     std::string socketName;
     uint16_t port;
 
-#ifdef HAVE_CXX11
     std::unique_ptr<yajr::transport::ZeroCopyOpenSSL::Ctx> serverCtx;
-#else
-    std::auto_ptr<yajr::transport::ZeroCopyOpenSSL::Ctx> serverCtx;
-#endif
 
     std::string name;
     std::string domain;

--- a/libopflex/engine/include/opflex/engine/internal/OpflexPool.h
+++ b/libopflex/engine/include/opflex/engine/internal/OpflexPool.h
@@ -362,11 +362,7 @@ private:
     /** location string for this policy element */
     boost::optional<std::string> location;
 
-#ifdef HAVE_CXX11
     std::unique_ptr<yajr::transport::ZeroCopyOpenSSL::Ctx> clientCtx;
-#else
-    std::auto_ptr<yajr::transport::ZeroCopyOpenSSL::Ctx> clientCtx;
-#endif
 
     uv_mutex_t conn_mutex;
     uv_key_t conn_mutex_key;

--- a/libopflex/engine/test/Makefile.am
+++ b/libopflex/engine/test/Makefile.am
@@ -13,6 +13,7 @@
 AM_CPPFLAGS = $(BOOST_CPPFLAGS) -DBOOST_TEST_DYN_LINK \
 	-Wall \
 	-Werror \
+	-std=c++11 \
 	-DSRCDIR="\"$(abs_top_srcdir)\"" \
 	-I$(srcdir)/../include \
 	-I$(top_srcdir)/include \

--- a/libopflex/logging/Makefile.am
+++ b/libopflex/logging/Makefile.am
@@ -16,6 +16,7 @@ noinst_LTLIBRARIES += liblogging.la
 AM_CPPFLAGS = \
 	-Wall \
 	-Werror \
+	-std=c++11 \
 	-I$(srcdir)/include \
 	-I$(top_srcdir)/include
 

--- a/libopflex/modb/Makefile.am
+++ b/libopflex/modb/Makefile.am
@@ -15,6 +15,7 @@ SUBDIRS = . test
 AM_CPPFLAGS = $(BOOST_CPPFLAGS) \
         -Wall \
         -Werror \
+        -std=c++11 \
         -I$(srcdir)/include -I$(top_srcdir)/include \
 	-I$(top_srcdir)/logging/include \
 	-I$(top_srcdir)/util/include

--- a/libopflex/modb/test/Makefile.am
+++ b/libopflex/modb/test/Makefile.am
@@ -13,6 +13,7 @@
 AM_CPPFLAGS = $(BOOST_CPPFLAGS) -DBOOST_TEST_DYN_LINK \
 	-Wall \
 	-Werror \
+	-std=c++11 \
 	-I$(srcdir)/../include \
 	-I$(top_srcdir)/include \
 	-I$(top_srcdir)/util/include

--- a/libopflex/ofcore/Makefile.am
+++ b/libopflex/ofcore/Makefile.am
@@ -15,6 +15,7 @@ SUBDIRS = . test
 AM_CPPFLAGS = $(BOOST_CPPFLAGS) \
         -Wall \
         -Werror \
+        -std=c++11 \
         -I$(srcdir)/include -I$(top_srcdir)/include \
 	-I$(top_srcdir)/modb/include \
 	-I$(top_srcdir)/util/include \

--- a/libopflex/ofcore/test/Makefile.am
+++ b/libopflex/ofcore/test/Makefile.am
@@ -13,6 +13,7 @@
 AM_CPPFLAGS = $(BOOST_CPPFLAGS) -DBOOST_TEST_DYN_LINK \
 	-Wall \
 	-Werror \
+	-std=c++11 \
 	-I$(top_srcdir)/include \
 	-I$(top_srcdir)/util/include \
 	-I$(top_srcdir)/comms/include \

--- a/libopflex/util/Makefile.am
+++ b/libopflex/util/Makefile.am
@@ -10,7 +10,7 @@
 #
 # Process this file with automake to produce a Makefile.in
 
-AM_CPPFLAGS = $(BOOST_CPPFLAGS) -Wall -Werror \
+AM_CPPFLAGS = $(BOOST_CPPFLAGS) -Wall -Werror -std=c++11 \
         -I$(srcdir)/include -I$(top_srcdir)/include
 
 if ENABLE_TSAN


### PR DESCRIPTION
Require c++11 support to build libopflex
Require c++14 support to build agent-ovs

Remove some of the #ifdefs used to support older versions
Remove some unused code in ovs-shim

Signed-off-by: Tom Flynn <tom.flynn@gmail.com>