### PR TITLE
Temporarily revert move to C++14 for opflex_agent

### DIFF
--- a/agent-ovs/Makefile.am
+++ b/agent-ovs/Makefile.am
@@ -294,7 +294,7 @@ if RENDERER_OVS
 	$(OVS_ADDL_CFLAGS) \
 	$(libopenvswitch_CFLAGS) \
 	$(libofproto_CFLAGS) \
-	-std=gnu++14
+	-std=gnu++11
 if ENABLE_TSAN
   librenderer_openvswitch_la_CXXFLAGS += -fsanitize=thread
 endif

--- a/agent-ovs/configure.ac
+++ b/agent-ovs/configure.ac
@@ -79,7 +79,7 @@ AC_PROG_INSTALL
 AM_PROG_AS
 AC_LANG([C])
 AC_LANG([C++])
-AX_CXX_COMPILE_STDCXX([14], [ext], [mandatory])
+AX_CXX_COMPILE_STDCXX([11], [ext], [mandatory])
 
 # check for doxygen
 AC_CHECK_PROGS(DOXYGEN,doxygen,none)


### PR DESCRIPTION
 Temporarily revert move to C++14 for opflex_agent

Ran into some RPM build issues that need to be
resolved before moving forward with this change

Signed-off-by: Tom Flynn <tom.flynn@gmail.com>