### PR TITLE
Fix to catch and exit travis with error code

### DIFF
--- a/.travis/asan-build.sh
+++ b/.travis/asan-build.sh
@@ -3,15 +3,24 @@
 set -o errtrace
 set -x
 
+trap 'catch $? $LINENO' ERR
+
+catch() {
+  echo "Error $1 occurred on $2"
+}
+
 pushd libopflex
+set -e
 ./autogen.sh
 ./configure --enable-asan &> /dev/null
 make -j2
-make check
 sudo make install
+set +e
+make check
 find . -name test-suite.log|xargs cat
 popd
 
+set -e
 pushd genie
 mvn compile exec:java &> /dev/null
 pushd target/libmodelgbp
@@ -28,6 +37,10 @@ pushd agent-ovs
 ./configure --enable-asan &> /dev/null
 make -j2
 sudo make install
+set +e
 make check
+result=$?
 find . -name test-suite.log|xargs cat
 popd
+
+exit $result

--- a/.travis/ubsan-build.sh
+++ b/.travis/ubsan-build.sh
@@ -3,15 +3,24 @@
 set -o errtrace
 set -x
 
+trap 'catch $? $LINENO' ERR
+
+catch() {
+  echo "Error $1 occurred on $2"
+}
+
 pushd libopflex
+set -e
 ./autogen.sh
 ./configure --enable-ubsan &> /dev/null
 make -j2
-make check
 sudo make install
+set +e
+make check
 find . -name test-suite.log|xargs cat
 popd
 
+set -e
 pushd genie
 mvn compile exec:java &> /dev/null
 pushd target/libmodelgbp
@@ -28,6 +37,10 @@ pushd agent-ovs
 ./configure --enable-ubsan &> /dev/null
 make -j2
 sudo make install
+set +e
 make check
+result=$?
 find . -name test-suite.log|xargs cat
 popd
+
+exit $result


### PR DESCRIPTION
- Trap ERR to pinpoint failed line in the script
- Exit travis in case of build errors using "set -e".
- Cache return code of agent's make check and exit with that.

Signed-off-by: Gautam Venkataramanan <gautam.chennai@gmail.com>