### PR TITLE
Fix for large values of policy unresolved counts

### DIFF
--- a/libopflex/engine/OpflexClientConnection.cpp
+++ b/libopflex/engine/OpflexClientConnection.cpp
@@ -45,6 +45,7 @@ OpflexClientConnection::OpflexClientConnection(HandlerFactory& handlerFactory,
 }
 
 OpflexClientConnection::~OpflexClientConnection() {
+    pool->clearPendingItems(this);
 }
 
 const string& OpflexClientConnection::getName() {

--- a/libopflex/engine/include/opflex/engine/Processor.h
+++ b/libopflex/engine/include/opflex/engine/Processor.h
@@ -308,7 +308,7 @@ private:
         NEW,
         /** a local item that's been updated */
         UPDATED,
-        /** a local item that's been send to the server */
+        /** a local item that's been sent to the server */
         IN_SYNC,
         /** A remote item that does not get resolved */
         REMOTE,

--- a/libopflex/engine/include/opflex/engine/internal/OpflexPool.h
+++ b/libopflex/engine/include/opflex/engine/internal/OpflexPool.h
@@ -216,6 +216,11 @@ public:
     void removePendingItem(OpflexClientConnection* conn, const std::string& uri);
 
     /**
+     * Clear the pending policies per connection
+     */
+    void clearPendingItems(OpflexClientConnection* conn);
+
+    /**
      * Register the given peer status listener to get updates on the
      * health of the connection pool and on individual connections.
      *


### PR DESCRIPTION
Whenever a connection is destroyed, we need to clear the pending resolutions for that connection. Without this, unresolved counts and pending resolutions can get out of sync.

Signed-off-by: Gautam Venkataramanan <gautam.chennai@gmail.com>