### PR TITLE
Integrating PrometheusManager with opflex-server

### DIFF
--- a/agent-ovs/Makefile.am
+++ b/agent-ovs/Makefile.am
@@ -222,7 +222,7 @@ libopflex_agent_la_SOURCES = \
 	lib/SnatSource.cpp \
 	lib/FSPacketDropLogConfigSource.cpp
 if ENABLE_PROMETHEUS
-libopflex_agent_la_SOURCES += lib/PrometheusManager.cpp
+libopflex_agent_la_SOURCES += lib/AgentPrometheusManager.cpp
 endif
 
 libopflex_agent_la_LDFLAGS = -shared -version-info ${VERSION_INFO}
@@ -543,6 +543,9 @@ opflex_server_SOURCES = \
 	cmd/test/include/Policies.h \
 	cmd/test/Policies.cpp \
 	cmd/test/opflex_server.cpp
+if ENABLE_PROMETHEUS
+opflex_server_SOURCES += cmd/test/ServerPrometheusManager.cpp
+endif
 if ENABLE_GRPC
 %.grpc.pb.cc %.grpc.pb.h %.pb.cc %.pb.h: %.proto
 	protoc --cpp_out=. $^
@@ -565,6 +568,10 @@ opflex_server_LDADD = \
 	$(BOOST_FILESYSTEM_LIB) \
 	$(BOOST_SYSTEM_LIB) \
 	libopflex_agent.la
+if ENABLE_PROMETHEUS
+opflex_server_LDADD += $(PROMETHEUS_CORE_LIBS)
+opflex_server_LDADD += $(PROMETHEUS_PULL_LIBS)
+endif
 if ENABLE_GRPC
 opflex_server_LDADD += $(GRPC_LIBS) $(PROTOBUF_LIBS) -lgrpc++_reflection
 endif

--- a/agent-ovs/cmd/test/ServerPrometheusManager.cpp
+++ b/agent-ovs/cmd/test/ServerPrometheusManager.cpp
@@ -1,0 +1,65 @@
+/* -*- C++ -*-; c-basic-offset: 4; indent-tabs-mode: nil */
+/*
+ * Implementation for ServerPrometheusManager class.
+ *
+ * Copyright (c) 2020-2021 Cisco Systems, Inc. and others.  All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ */
+
+#include <opflexagent/PrometheusManager.h>
+
+namespace opflexagent {
+
+using std::make_shared;
+using namespace prometheus::detail;
+
+// construct ServerPrometheusManager for opflex server
+ServerPrometheusManager::ServerPrometheusManager ()
+                                 : PrometheusManager() {}
+
+// Start of ServerPrometheusManager instance
+void ServerPrometheusManager::start (bool exposeLocalHostOnly)
+{
+    disabled = false;
+    LOG(DEBUG) << "starting prometheus manager,"
+               << " exposeLHOnly: " << exposeLocalHostOnly;
+    /**
+     * create an http server running on port 9632
+     * Note: The third argument is the total worker thread count. Prometheus
+     * follows boss-worker thread model. 1 boss thread will get created to
+     * intercept HTTP requests. The requests will then be serviced by free
+     * worker threads. We are using 1 worker thread to service the requests.
+     * Note: Port #9632 has been reserved for opflex server here:
+     * https://github.com/prometheus/prometheus/wiki/Default-port-allocations
+     */
+    registry_ptr = make_shared<Registry>();
+    if (exposeLocalHostOnly)
+        exposer_ptr = unique_ptr<Exposer>(new Exposer{"127.0.0.1:9632", "/metrics", 1});
+    else
+        exposer_ptr = unique_ptr<Exposer>(new Exposer{"9632", "/metrics", 1});
+
+    // ask the exposer to scrape the registry on incoming scrapes
+    exposer_ptr->RegisterCollectable(registry_ptr);
+}
+
+// Stop of AgentPrometheusManager instance
+void ServerPrometheusManager::stop ()
+{
+    RETURN_IF_DISABLED
+    disabled = true;
+    LOG(DEBUG) << "stopping prometheus manager";
+
+    gauge_check.clear();
+    counter_check.clear();
+
+    exposer_ptr.reset();
+    exposer_ptr = nullptr;
+
+    registry_ptr.reset();
+    registry_ptr = nullptr;
+}
+
+} /* namespace opflexagent */

--- a/agent-ovs/cmd/test/opflex_server.cpp
+++ b/agent-ovs/cmd/test/opflex_server.cpp
@@ -36,6 +36,9 @@
 #ifdef HAVE_GRPC_SUPPORT
 #include "GbpClient.h"
 #endif
+#ifdef HAVE_PROMETHEUS_SUPPORT
+#include <opflexagent/PrometheusManager.h>
+#endif
 
 using std::string;
 using std::make_pair;
@@ -70,6 +73,10 @@ int main(int argc, char** argv) {
             ("sample", po::value<string>()->default_value(""),
              "Output a sample policy to the given file then exit")
             ("daemon", "Run the opflex server as a daemon")
+#ifdef HAVE_PROMETHEUS_SUPPORT
+            ("disable-prometheus", "Disable exporting metrics to prometheus")
+            ("enable-prometheus-localhost", "Export prometheus port only on localhost")
+#endif
             ("policy,p", po::value<string>()->default_value(""),
              "Read the specified policy file to seed the MODB")
             ("ssl_castore", po::value<string>()->default_value("/etc/ssl/certs/"),
@@ -97,6 +104,10 @@ int main(int argc, char** argv) {
     }
 
     bool daemon = false;
+#ifdef HAVE_PROMETHEUS_SUPPORT
+    bool enable_prometheus = true;
+    bool enable_localhost_only = false;
+#endif
     std::string log_file;
     std::string level_str;
     std::string policy_file;
@@ -130,6 +141,12 @@ int main(int argc, char** argv) {
         if (vm.count("daemon")) {
             daemon = true;
         }
+#ifdef HAVE_PROMETHEUS_SUPPORT
+        if (vm.count("disable-prometheus"))
+            enable_prometheus = false;
+        if (vm.count("enable-prometheus-localhost"))
+            enable_localhost_only = true;
+#endif
         log_file = vm["log"].as<string>();
         level_str = vm["level"].as<string>();
         policy_file = vm["policy"].as<string>();
@@ -210,9 +227,15 @@ int main(int argc, char** argv) {
                                modelgbp::getMetadata(),
                                prr_interval_secs);
 #ifdef HAVE_GRPC_SUPPORT
-	LOG(INFO) << "Connecting to gbp-server at address: "
+	      LOG(INFO) << "Connecting to gbp-server at address: "
                   << grpc_address;
         GbpClient client(grpc_address, server);
+#endif
+
+#ifdef HAVE_PROMETHEUS_SUPPORT
+        ServerPrometheusManager prometheusManager;
+        if (enable_prometheus)
+            prometheusManager.start(enable_localhost_only);
 #endif
 
         if (policy_file != "") {
@@ -276,6 +299,12 @@ int main(int argc, char** argv) {
             }
         }
 cleanup:
+#ifdef HAVE_PROMETHEUS_SUPPORT
+        prometheusManager.stop();
+#endif
+#ifdef HAVE_GRPC_SUPPORT
+        client.Stop();
+#endif
         server.stop();
     } catch (const std::exception& e) {
         LOG(ERROR) << "Fatal error: " << e.what();

--- a/agent-ovs/lib/Agent.cpp
+++ b/agent-ovs/lib/Agent.cpp
@@ -587,7 +587,7 @@ void Agent::start() {
 #ifdef HAVE_PROMETHEUS_SUPPORT
     if (prometheusEnabled) {
         prometheusManager.start(prometheusExposeLocalHostOnly,
-                                prometheusExposeEpSvcNan);
+                          prometheusExposeEpSvcNan);
     } else {
         LOG(DEBUG) << "prometheus not enabled";
     }

--- a/agent-ovs/lib/EndpointManager.cpp
+++ b/agent-ovs/lib/EndpointManager.cpp
@@ -62,7 +62,7 @@ static const string NULL_MAC_ADDR("00:00:00:00:00:00");
 EndpointManager::EndpointManager(Agent& agent_,
                                  opflex::ofcore::OFFramework& framework_,
                                  PolicyManager& policyManager_,
-                                 PrometheusManager& prometheusManager_)
+                                 AgentPrometheusManager& prometheusManager_)
     : agent(agent_), framework(framework_), policyManager(policyManager_),
       prometheusManager(prometheusManager_), epgMappingListener(*this) {
 

--- a/agent-ovs/lib/FSEndpointSource.cpp
+++ b/agent-ovs/lib/FSEndpointSource.cpp
@@ -275,7 +275,7 @@ void FSEndpointSource::updated(const fs::path& filePath) {
         auto acc_intf = newep.getAccessInterface();
         if (acc_intf) {
             newep.setAttributeHash(
-                PrometheusManager::calcHashEpAttributes(
+                AgentPrometheusManager::calcHashEpAttributes(
                                             acc_intf.get(),
                                             newep.getAttributes(),
                                             manager->getAgent().getPrometheusEpAttributes()));

--- a/agent-ovs/lib/ModelEndpointSource.cpp
+++ b/agent-ovs/lib/ModelEndpointSource.cpp
@@ -170,7 +170,7 @@ void ModelEndpointSource::objectUpdated (opflex::modb::class_id_t class_id,
             auto acc_intf = newep.getAccessInterface();
             if (acc_intf) {
                 newep.setAttributeHash(
-                    PrometheusManager::calcHashEpAttributes(
+                    AgentPrometheusManager::calcHashEpAttributes(
                                             acc_intf.get(),
                                             newep.getAttributes(),
                                             manager->getAgent().getPrometheusEpAttributes()));

--- a/agent-ovs/lib/ServiceManager.cpp
+++ b/agent-ovs/lib/ServiceManager.cpp
@@ -33,7 +33,7 @@ using boost::optional;
 #ifdef HAVE_PROMETHEUS_SUPPORT
 ServiceManager::ServiceManager (Agent& agent_,
                                 opflex::ofcore::OFFramework& framework_,
-                                PrometheusManager& prometheusManager_)
+                                AgentPrometheusManager& prometheusManager_)
     : agent(agent_), framework(framework_),
       prometheusManager(prometheusManager_) {
 }

--- a/agent-ovs/lib/include/opflexagent/Agent.h
+++ b/agent-ovs/lib/include/opflexagent/Agent.h
@@ -132,7 +132,7 @@ public:
     /**
      * Get the prometheus manager object for this agent
      */
-    PrometheusManager& getPrometheusManager() { return prometheusManager; }
+    AgentPrometheusManager& getPrometheusManager() { return prometheusManager; }
 #endif
 
     /**
@@ -330,7 +330,7 @@ private:
 
     opflex::ofcore::OFFramework& framework;
 #ifdef HAVE_PROMETHEUS_SUPPORT
-    PrometheusManager prometheusManager;
+    AgentPrometheusManager prometheusManager;
 #endif
     PolicyManager policyManager;
     EndpointManager endpointManager;

--- a/agent-ovs/lib/include/opflexagent/EndpointManager.h
+++ b/agent-ovs/lib/include/opflexagent/EndpointManager.h
@@ -126,7 +126,7 @@ public:
     EndpointManager(Agent& agent,
                     opflex::ofcore::OFFramework& framework,
                     PolicyManager& policyManager,
-                    PrometheusManager& prometheusManager);
+                    AgentPrometheusManager& prometheusManager);
 #else
     EndpointManager(Agent& agent,
                     opflex::ofcore::OFFramework& framework,
@@ -396,7 +396,7 @@ private:
     opflex::ofcore::OFFramework& framework;
     PolicyManager& policyManager;
 #ifdef HAVE_PROMETHEUS_SUPPORT
-    PrometheusManager& prometheusManager;
+    AgentPrometheusManager& prometheusManager;
 #endif
 
     class EndpointState {

--- a/agent-ovs/lib/include/opflexagent/ServiceManager.h
+++ b/agent-ovs/lib/include/opflexagent/ServiceManager.h
@@ -48,7 +48,7 @@ public:
 #ifdef HAVE_PROMETHEUS_SUPPORT
     ServiceManager(Agent& agent_,
                    opflex::ofcore::OFFramework& framework_,
-                   PrometheusManager& prometheusManager_);
+                   AgentPrometheusManager& prometheusManager_);
 #else
     ServiceManager(Agent& agent,
                    opflex::ofcore::OFFramework& framework);
@@ -167,7 +167,7 @@ private:
 
 #ifdef HAVE_PROMETHEUS_SUPPORT
     // reference to prometheus manager
-    PrometheusManager& prometheusManager;
+    AgentPrometheusManager& prometheusManager;
 #endif
 
     class ServiceState {

--- a/agent-ovs/ovs/TableDropStatsManager.cpp
+++ b/agent-ovs/ovs/TableDropStatsManager.cpp
@@ -102,7 +102,7 @@ void BaseTableDropStatsManager::start(bool register_listener) {
        }
        mutator.commit();
 #ifdef HAVE_PROMETHEUS_SUPPORT
-       PrometheusManager &prometheusManager = agent->getPrometheusManager();
+       AgentPrometheusManager &prometheusManager = agent->getPrometheusManager();
        prometheusManager.addTableDropGauge(connection->getSwitchName(),
                                             tbl_it.second.first);
 #endif
@@ -123,7 +123,7 @@ void BaseTableDropStatsManager::stop(bool unregister_listener) {
                << connection->getSwitchName()
                << " Table Drop stats manager";
 #ifdef HAVE_PROMETHEUS_SUPPORT
-    PrometheusManager &prometheusManager = agent->getPrometheusManager();
+    AgentPrometheusManager &prometheusManager = agent->getPrometheusManager();
     for (const auto& tbl_it: tableDescMap) {
         prometheusManager.removeTableDropGauge(
                 connection->getSwitchName(),
@@ -306,7 +306,7 @@ void BaseTableDropStatsManager::on_timer(const boost::system::error_code& ec) {
         }
         mutator.commit();
 #ifdef HAVE_PROMETHEUS_SUPPORT
-        PrometheusManager &prometheusManager = agent->getPrometheusManager();
+        AgentPrometheusManager &prometheusManager = agent->getPrometheusManager();
         prometheusManager.updateTableDropGauge(connection->getSwitchName(),
                                                 tbl_it.second.first,
                                                 byte_count,

--- a/agent-ovs/ovs/include/IntFlowManager.h
+++ b/agent-ovs/ovs/include/IntFlowManager.h
@@ -839,7 +839,7 @@ private:
     CtZoneManager& ctZoneManager;
     TunnelEpManager& tunnelEpManager;
 #ifdef HAVE_PROMETHEUS_SUPPORT
-    PrometheusManager& prometheusManager;
+    AgentPrometheusManager& prometheusManager;
 #endif
     TaskQueue taskQueue;
 

--- a/agent-ovs/ovs/include/PolicyStatsManager.h
+++ b/agent-ovs/ovs/include/PolicyStatsManager.h
@@ -352,7 +352,7 @@ protected:
     /**
      * The prometheus manager that exports stats to prometheus server
      */
-    PrometheusManager& prometheusManager;
+    AgentPrometheusManager& prometheusManager;
 #endif
 
     /**


### PR DESCRIPTION
- refactored existing PrometheusManager implementation so that agent and server implementations are kept separate
- Commonalities are kept in "PrometheusManager"
- exposing on port 9632 from opflex-server
- added config knobs to disable prometheus and expose only on localhost
- tested manually

TODO:
- this is first cut. metrics to be added
- uts to be added

Signed-off-by: Gautam Venkataramanan <gautam.chennai@gmail.com>