### PR TITLE
Add src mac for snat bounce

### DIFF
--- a/agent-ovs/ovs/IntFlowManager.cpp
+++ b/agent-ovs/ovs/IntFlowManager.cpp
@@ -4628,6 +4628,7 @@ void IntFlowManager::handleSnatUpdate(const string& snatUuid) {
                             maskedFlow.action().go(SNAT_REV_TABLE_ID);
                         } else {
                             maskedFlow.action().ethDst(dmac)
+                                               .ethSrc(ifcMac)
                                                .output(OFPP_IN_PORT);
                         }
                         maskedFlow.build(toSnatFlows);


### PR DESCRIPTION
- Not having source mac is causing the leaf to get a packet
  with its own mac as src-mac that is causing it to move the
  EP
- this sends a well known mac of the snat-ifc as src mac

Signed-off-by: Madhu Challa <challa@gmail.com>