### PR TITLE
fix for tsan issues in opflex-server and clean prometheus before execv

### DIFF
--- a/agent-ovs/cmd/test/ServerPrometheusManager.cpp
+++ b/agent-ovs/cmd/test/ServerPrometheusManager.cpp
@@ -45,7 +45,7 @@ void ServerPrometheusManager::start (bool exposeLocalHostOnly)
     exposer_ptr->RegisterCollectable(registry_ptr);
 }
 
-// Stop of AgentPrometheusManager instance
+// Stop of ServerPrometheusManager instance
 void ServerPrometheusManager::stop ()
 {
     RETURN_IF_DISABLED

--- a/agent-ovs/cmd/test/include/GbpClient.h
+++ b/agent-ovs/cmd/test/include/GbpClient.h
@@ -19,6 +19,7 @@
 #include <string>
 #include <thread>
 #include <chrono>
+#include <mutex>
 
 #ifdef RAPIDJSON_HAS_STDSTRING
 #undef RAPIDJSON_HAS_STDSTRING
@@ -47,8 +48,9 @@ private:
     void JsonDocAdd(rapidjson::Document& d, const gbpserver::GBPObject& gbp);
     std::thread thread_;
     opflex::test::GbpOpflexServer& server_;
-    bool stopping;
+    std::atomic<bool> stopping;
     GbpClientImpl* client_;
+    std::mutex client_mutex;
 };
 
 } /* namespace opflexagent */

--- a/agent-ovs/cmd/test/opflex_server.cpp
+++ b/agent-ovs/cmd/test/opflex_server.cpp
@@ -227,7 +227,7 @@ int main(int argc, char** argv) {
                                modelgbp::getMetadata(),
                                prr_interval_secs);
 #ifdef HAVE_GRPC_SUPPORT
-	      LOG(INFO) << "Connecting to gbp-server at address: "
+        LOG(INFO) << "Connecting to gbp-server at address: "
                   << grpc_address;
         GbpClient client(grpc_address, server);
 #endif
@@ -283,6 +283,9 @@ int main(int argc, char** argv) {
 
                 if ((event->mask & IN_CLOSE_WRITE) && event->len > 0) {
                     LOG(INFO) << "Policy/Config dir modified : " << pf_dir;
+#ifdef HAVE_PROMETHEUS_SUPPORT
+                    prometheusManager.stop();
+#endif
 #ifdef HAVE_GRPC_SUPPORT
                     client.Stop();
 #endif


### PR DESCRIPTION
- Cleaning up prometheus before execv
- addressing typo and indentation
- addressing couple of data races when policy path dir changes

Issue 1: protecting client_ access
WARNING: ThreadSanitizer: data race (pid=13435)
  Read of size 8 at 0x7ffd9def3db8 by main thread:
    #0 opflexagent::GbpClient::Stop() cmd/test/GbpClient.cpp:214 (opflex_server+0xe4a9e)
    #1 main cmd/test/opflex_server.cpp:290 (opflex_server+0x945e7)

  Previous write of size 8 at 0x7ffd9def3db8 by thread T1:
    #0 opflexagent::GbpClient::Start(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) cmd/test/GbpClient.cpp:206 (opflex_server+0xe4e0d)

Issue 2: atomic bool
WARNING: ThreadSanitizer: data race (pid=1993)
  Read of size 1 at 0x7ffd965bd3e0 by thread T1:
    #0 opflexagent::GbpClient::Start(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) cmd/test/GbpClient.cpp:200 (opflex_server+0xe4f26)

  Previous write of size 1 at 0x7ffd965bd3e0 by main thread:
    #0 opflexagent::GbpClient::Stop() cmd/test/GbpClient.cpp:213 (opflex_server+0xe4a7b)
    #1 main cmd/test/opflex_server.cpp:287 (opflex_server+0x945db)

Signed-off-by: Gautam Venkataramanan <gautam.chennai@gmail.com>