### PR TITLE
Addressing coverity and clang-tidy issues

### DIFF
--- a/agent-ovs/ovs/test/include/MockRpcConnection.h
+++ b/agent-ovs/ovs/test/include/MockRpcConnection.h
@@ -59,7 +59,7 @@ public:
      * only be called if it's called from the uv loop thread.
      */
     virtual void sendMessage(JsonRpcMessage* message, bool sync = false) {
-        boost::scoped_ptr<JsonRpcMessage> messagep(message);
+        std::unique_ptr<JsonRpcMessage> messagep(message);
         opflex::jsonrpc::PayloadWrapper wrapper(message);
         yajr::internal::GenericStringQueue<rapidjson::UTF8<> > sq;
         ::yajr::rpc::SendHandler writer;

--- a/libopflex/comms/ListeningPeer.cpp
+++ b/libopflex/comms/ListeningPeer.cpp
@@ -24,22 +24,18 @@ void ListeningPeer::destroy(bool now) {
 
     assert(!destroying_);
     if (destroying_) {
-        LOG(WARNING)
-            << this
-            << " Double destroy() detected"
-        ;
-
+        LOG(WARNING) << this << " Double destroy() detected" ;
         return;
     }
 
-    destroying_ = 1;
+    destroying_ = true;
 
     if (down()) {
         return;
     }
 
     if (connected_) {
-        connected_ = 0;
+        connected_ = false;
         if (!uv_is_closing(getHandle())) {
             uv_close(getHandle(), on_close);
         }

--- a/libopflex/comms/passive_listener.cpp
+++ b/libopflex/comms/passive_listener.cpp
@@ -77,7 +77,6 @@
     }
 
     int rc;
-
     if ((rc = peer->setAddrFromIpAndPort(ip_address, port))) {
         LOG(WARNING)
             << "addr_from_ip_and_port: ["
@@ -85,7 +84,6 @@
             << "] "
             << uv_strerror(rc)
         ;
-        assert(0);
         peer->destroy();
         return NULL;
     }
@@ -184,7 +182,7 @@ void ::yajr::comms::internal::ListeningTcpPeer::retry() {
 
     status_ = Peer::kPS_LISTENING;
     insert(internal::Peer::LoopData::LISTENING);
-    connected_ = 1;
+    connected_ = true;
 
     return;
 
@@ -252,7 +250,7 @@ void ::yajr::comms::internal::ListeningUnixPeer::retry() {
 
     status_ = Peer::kPS_LISTENING;
     insert(internal::Peer::LoopData::LISTENING);
-    connected_ = 1;
+    connected_ = true;
 
     return;
 
@@ -283,19 +281,13 @@ void on_passive_connection(uv_stream_t * server_handle, int status)
     ListeningPeer * listener = Peer::get<ListeningPeer>(server_handle);
 
     if (status) {
-        LOG(ERROR)
-            << listener
-            << "on_passive_connection: ["
-            << uv_err_name(status)
-            << "] "
-            << uv_strerror(status)
-        ;
+        LOG(ERROR) << listener << "on_passive_connection: ["
+            << uv_err_name(status) << "] " << uv_strerror(status);
 
         /* there could also be legitimate reasons for this, but we still have to
          * encounter them
          */
         assert(0);
-
         return;
     }
 

--- a/libopflex/comms/peer.cpp
+++ b/libopflex/comms/peer.cpp
@@ -12,7 +12,6 @@
 #endif
 
 #include <opflex/yajr/internal/comms.hpp>
-#include <opflex/yajr/transport/engine.hpp>
 #include <opflex/logging/internal/logging.hpp>
 
 namespace yajr {

--- a/libopflex/comms/rpc.cpp
+++ b/libopflex/comms/rpc.cpp
@@ -16,7 +16,6 @@
 #include <yajr/rpc/methods.hpp>
 #include <opflex/yajr/rpc/rpc.hpp>
 
-#include <rapidjson/document.h>
 
 namespace yajr {
     namespace rpc {
@@ -119,13 +118,10 @@ bool OutboundMessage::send() {
             "to a proper communication peer "
             "before outbound messages are sent");
 
-    unsigned char connected = cP->connected_;
-
-    if (!connected) {
+    if (!cP->connected_) {
         cP->onError(UV_ENOTCONN);
         return false;
     }
-
 
 #if __cpp_exceptions || __EXCEPTIONS
     try {

--- a/libopflex/comms/rpc/JsonRpcConnection.cpp
+++ b/libopflex/comms/rpc/JsonRpcConnection.cpp
@@ -14,8 +14,6 @@
 #  include <config.h>
 #endif
 
-#include <boost/scoped_ptr.hpp>
-
 #include "opflex/logging/internal/logging.hpp"
 #include "opflex/rpc/JsonRpcConnection.h"
 
@@ -39,7 +37,7 @@ void RpcConnection::cleanup() {
 
 void RpcConnection::sendMessage(JsonRpcMessage* message, bool sync) {
     if (sync) {
-        boost::scoped_ptr<JsonRpcMessage> messagep(message);
+        std::unique_ptr<JsonRpcMessage> messagep(message);
         doWrite(message);
     } else {
         const std::lock_guard<std::mutex> lock(queue_mutex);
@@ -59,7 +57,7 @@ void RpcConnection::processWriteQueue() {
                        << " of type " << qi.first->getType();
             continue;
         }
-        boost::scoped_ptr<JsonRpcMessage> message(qi.first);
+        std::unique_ptr<JsonRpcMessage> message(qi.first);
         write_queue.pop_front();
         doWrite(message.get());
     }

--- a/libopflex/comms/test/comms_test.cpp
+++ b/libopflex/comms/test/comms_test.cpp
@@ -20,18 +20,13 @@
 #include <yajr/transport/ZeroCopyOpenSSL.hpp>
 #include <opflex/yajr/internal/comms.hpp>
 
-#include <opflex/logging/OFLogHandler.h>
 #include <opflex/logging/StdOutLogHandler.h>
-
 #include <opflex/logging/internal/logging.hpp>
 
 #include <boost/test/unit_test_log.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <boost/lexical_cast.hpp>
-#include <boost/scoped_ptr.hpp>
-
-#include <utility>
 
 #define DEFAULT_COMMSTEST_TIMEOUT 7200
 const uint16_t kPortOffset = 1;
@@ -110,7 +105,8 @@ class CommsFixture {
         CommsFixture::current_loop = &loop_;
 
         uv_loop_init(CommsFixture::current_loop);
-
+        prepare_ = {};
+        timer_ = {};
         prepare_.data = timer_.data = this;
 
         int rc = ::yajr::initLoop(CommsFixture::current_loop);
@@ -1294,7 +1290,6 @@ BOOST_FIXTURE_TEST_CASE( STABLE_test_destroy_client_for_non_existent_service, Co
     BOOST_CHECK_EQUAL(!p, 0);
 
     loop_until_final(range_t(0,0), pc_no_peers);
-
 }
 
 BOOST_FIXTURE_TEST_CASE( STABLE_test_disconnect_client_for_non_existent_host, CommsFixture ) {
@@ -1320,7 +1315,6 @@ BOOST_FIXTURE_TEST_CASE( STABLE_test_disconnect_client_for_non_existent_service,
     BOOST_CHECK_EQUAL(!p, 0);
 
     loop_until_final(range_t(1,1), pc_retrying_client);
-
 }
 
 #ifdef YAJR_HAS_OPENSSL
@@ -1383,7 +1377,7 @@ BOOST_FIXTURE_TEST_CASE( STABLE_test_no_message_on_SSL, CommsFixture ) {
 
     LOG(DEBUG);
 
-    boost::scoped_ptr< ::yajr::transport::ZeroCopyOpenSSL::Ctx > serverCtx(
+    std::unique_ptr< ::yajr::transport::ZeroCopyOpenSSL::Ctx > serverCtx(
         ::yajr::transport::ZeroCopyOpenSSL::Ctx::createCtx(
             NULL,
             SRCDIR"/test/server.pem",
@@ -1417,7 +1411,7 @@ BOOST_FIXTURE_TEST_CASE( STABLE_test_no_message_on_SSL, CommsFixture ) {
 
     BOOST_CHECK_EQUAL(!p, 0);
 
-    boost::scoped_ptr< ::yajr::transport::ZeroCopyOpenSSL::Ctx > clientCtx(
+    std::unique_ptr< ::yajr::transport::ZeroCopyOpenSSL::Ctx > clientCtx(
         ::yajr::transport::ZeroCopyOpenSSL::Ctx::createCtx(
             SRCDIR"/test/ca.pem",
             NULL
@@ -1488,7 +1482,7 @@ BOOST_FIXTURE_TEST_CASE( STABLE_test_single_message_on_SSL, CommsFixture ) {
 
     LOG(DEBUG);
 
-    boost::scoped_ptr< ::yajr::transport::ZeroCopyOpenSSL::Ctx > serverCtx(
+    std::unique_ptr< ::yajr::transport::ZeroCopyOpenSSL::Ctx > serverCtx(
         ::yajr::transport::ZeroCopyOpenSSL::Ctx::createCtx(
             NULL,
             SRCDIR"/test/server.pem",
@@ -1522,7 +1516,7 @@ BOOST_FIXTURE_TEST_CASE( STABLE_test_single_message_on_SSL, CommsFixture ) {
 
     BOOST_CHECK_EQUAL(!p, 0);
 
-    boost::scoped_ptr< ::yajr::transport::ZeroCopyOpenSSL::Ctx > clientCtx(
+    std::unique_ptr< ::yajr::transport::ZeroCopyOpenSSL::Ctx > clientCtx(
         ::yajr::transport::ZeroCopyOpenSSL::Ctx::createCtx(
             SRCDIR"/test/ca.pem",
             NULL
@@ -1551,7 +1545,7 @@ BOOST_FIXTURE_TEST_CASE( STABLE_test_single_message_with_client_cert_on_SSL, Com
 
     LOG(DEBUG);
 
-    boost::scoped_ptr< ::yajr::transport::ZeroCopyOpenSSL::Ctx > serverCtx(
+    std::unique_ptr< ::yajr::transport::ZeroCopyOpenSSL::Ctx > serverCtx(
         ::yajr::transport::ZeroCopyOpenSSL::Ctx::createCtx(
             SRCDIR"/test/ca.pem",
             SRCDIR"/test/server.pem",
@@ -1587,7 +1581,7 @@ BOOST_FIXTURE_TEST_CASE( STABLE_test_single_message_with_client_cert_on_SSL, Com
 
     BOOST_CHECK_EQUAL(!p, 0);
 
-    boost::scoped_ptr< ::yajr::transport::ZeroCopyOpenSSL::Ctx > clientCtx(
+    std::unique_ptr< ::yajr::transport::ZeroCopyOpenSSL::Ctx > clientCtx(
         ::yajr::transport::ZeroCopyOpenSSL::Ctx::createCtx(
             SRCDIR"/test/ca.pem",
             SRCDIR"/test/server.pem",
@@ -1617,7 +1611,7 @@ BOOST_FIXTURE_TEST_CASE( STABLE_test_keepalive_on_SSL, CommsFixture ) {
 
     LOG(DEBUG);
 
-    boost::scoped_ptr< ::yajr::transport::ZeroCopyOpenSSL::Ctx > serverCtx(
+    std::unique_ptr< ::yajr::transport::ZeroCopyOpenSSL::Ctx > serverCtx(
         ::yajr::transport::ZeroCopyOpenSSL::Ctx::createCtx(
             NULL,
             SRCDIR"/test/server.pem",
@@ -1652,7 +1646,7 @@ BOOST_FIXTURE_TEST_CASE( STABLE_test_keepalive_on_SSL, CommsFixture ) {
 
     BOOST_CHECK_EQUAL(!p, 0);
 
-    boost::scoped_ptr< ::yajr::transport::ZeroCopyOpenSSL::Ctx > clientCtx(
+    std::unique_ptr< ::yajr::transport::ZeroCopyOpenSSL::Ctx > clientCtx(
         ::yajr::transport::ZeroCopyOpenSSL::Ctx::createCtx(
             SRCDIR"/test/ca.pem",
             NULL
@@ -1708,7 +1702,7 @@ BOOST_FIXTURE_TEST_CASE( STABLE_test_several_SSL_peers, CommsFixture ) {
 
     LOG(DEBUG);
 
-    boost::scoped_ptr< ::yajr::transport::ZeroCopyOpenSSL::Ctx > serverCtx(
+    std::unique_ptr< ::yajr::transport::ZeroCopyOpenSSL::Ctx > serverCtx(
         ::yajr::transport::ZeroCopyOpenSSL::Ctx::createCtx(
             NULL,
             SRCDIR"/test/server.pem",
@@ -1722,7 +1716,7 @@ BOOST_FIXTURE_TEST_CASE( STABLE_test_several_SSL_peers, CommsFixture ) {
         return;
     }
 
-    boost::scoped_ptr< ::yajr::transport::ZeroCopyOpenSSL::Ctx > clientCtx(
+    std::unique_ptr< ::yajr::transport::ZeroCopyOpenSSL::Ctx > clientCtx(
         ::yajr::transport::ZeroCopyOpenSSL::Ctx::createCtx(
             SRCDIR"/test/ca.pem",
             NULL

--- a/libopflex/comms/transport/PlainText.cpp
+++ b/libopflex/comms/transport/PlainText.cpp
@@ -17,8 +17,6 @@
 
 #include <opflex/logging/internal/logging.hpp>
 
-#include <sys/uio.h>
-
 namespace yajr {
 namespace transport {
 

--- a/libopflex/cwrapper/test/cwrapper_test.cpp
+++ b/libopflex/cwrapper/test/cwrapper_test.cpp
@@ -61,7 +61,11 @@ public:
     }
 
     ~ServerFixture() {
-        opflexServer.stop();
+        try {
+            opflexServer.stop();
+        } catch (...) {
+            LOG(WARNING) << "Exception thrown while stopping opflex server instance";
+        }
     }
 
     void setPeerStatus(int status) {

--- a/libopflex/engine/InspectorClientConn.cpp
+++ b/libopflex/engine/InspectorClientConn.cpp
@@ -26,7 +26,10 @@ using yajr::Peer;
 
 InspectorClientConn::InspectorClientConn(HandlerFactory& handlerFactory,
                                          const std::string& name_)
-    : OpflexConnection(handlerFactory), name(name_), peer(NULL) {}
+    : OpflexConnection(handlerFactory), name(name_), peer(NULL) {
+    client_loop = {};
+    timer = {};
+}
 
 InspectorClientConn::~InspectorClientConn() {
 

--- a/libopflex/engine/InspectorClientImpl.cpp
+++ b/libopflex/engine/InspectorClientImpl.cpp
@@ -16,7 +16,6 @@
 
 #include <boost/foreach.hpp>
 #include <boost/optional.hpp>
-#include <boost/scoped_ptr.hpp>
 
 #include "opflex/modb/internal/ObjectStore.h"
 #include "opflex/engine/internal/InspectorClientHandler.h"
@@ -39,8 +38,8 @@ InspectorClient::newInstance(const std::string& name,
 namespace engine {
 
 using std::string;
+using std::unique_ptr;
 using boost::optional;
-using boost::scoped_ptr;
 using opflex::modb::ObjectStore;
 using opflex::modb::PropertyInfo;
 using opflex::modb::ClassInfo;
@@ -86,7 +85,7 @@ void InspectorClientImpl::execute() {
 
 void InspectorClientImpl::executeCommands() {
     while (!commands.empty()) {
-        scoped_ptr<Cmd> command(commands.front());
+        unique_ptr<Cmd> command(commands.front());
         commands.pop_front();
         pendingRequests += command->execute(*this);
     }

--- a/libopflex/engine/Processor.cpp
+++ b/libopflex/engine/Processor.cpp
@@ -66,6 +66,10 @@ Processor::Processor(ObjectStore* store_, ThreadManager& threadManager_)
       processingDelay(DEFAULT_PROC_DELAY),
       retryDelay(DEFAULT_RETRY_DELAY),
       proc_active(false) {
+    cleanup_async = {};
+    proc_async = {};
+    connect_async = {};
+    proc_timer = {};
 }
 
 Processor::~Processor() {

--- a/libopflex/engine/include/opflex/engine/Inspector.h
+++ b/libopflex/engine/include/opflex/engine/Inspector.h
@@ -17,7 +17,6 @@
 #include <string>
 
 #include <boost/noncopyable.hpp>
-#include <boost/scoped_ptr.hpp>
 #include <uv.h>
 
 #include "opflex/engine/internal/OpflexConnection.h"
@@ -90,7 +89,7 @@ public:
 private:
     modb::ObjectStore* db;
     internal::MOSerializer serializer;
-    boost::scoped_ptr<internal::OpflexListener> listener;
+    std::unique_ptr<internal::OpflexListener> listener;
 
     std::string name;
 

--- a/libopflex/engine/test/Processor_test.cpp
+++ b/libopflex/engine/test/Processor_test.cpp
@@ -167,7 +167,11 @@ public:
     }
 
     ~ServerFixture() {
-        opflexServer.stop();
+        try {
+            opflexServer.stop();
+        } catch (...) {
+            LOG(WARNING) << "Exception thrown while stopping opflex server instance";
+        }
     }
 
     void startClient() {

--- a/libopflex/include/opflex/util/ThreadManager.h
+++ b/libopflex/include/opflex/util/ThreadManager.h
@@ -15,11 +15,11 @@
 #ifndef OPFLEX_UTIL_THREADMANAGER_H
 #define OPFLEX_UTIL_THREADMANAGER_H
 
+#include <memory>
 #include <string>
 #include <unordered_map>
 
 #include <boost/noncopyable.hpp>
-#include <boost/scoped_ptr.hpp>
 #include <uv.h>
 
 #include "opflex/ofcore/MainLoopAdaptor.h"
@@ -80,7 +80,7 @@ private:
         uv_loop_t main_loop;
     };
 
-    boost::scoped_ptr<AdaptorImpl> adaptor;
+    std::unique_ptr<AdaptorImpl> adaptor;
 
     typedef std::unordered_map<std::string, Task> task_map_t;
     task_map_t task_map;

--- a/libopflex/include/opflex/yajr/internal/comms.hpp
+++ b/libopflex/include/opflex/yajr/internal/comms.hpp
@@ -339,8 +339,8 @@ class Peer : public SafeListBaseHook {
             :
               uvLoopSelector_(uvLoopSelector ? : &uvDefaultLoop),
               uvRefCnt_(1),
-              connected_(0),
-              destroying_(0),
+              connected_(false),
+              destroying_(false),
               passive_(passive),
               choked_(1),
               createFail_(1),
@@ -427,9 +427,9 @@ class Peer : public SafeListBaseHook {
     /** reference count */
     boost::atomic<unsigned int>  uvRefCnt_;
     /** Is this peer connected */
-    unsigned char connected_  :1;
+    std::atomic<bool> connected_;
     /** Is the peer begin destroyed */
-    unsigned char destroying_ :1;
+    std::atomic<bool> destroying_;
     /** Is this peer passive */
     unsigned char passive_    :1;
     /** Is the peer currently choked */
@@ -806,7 +806,7 @@ class CommunicationPeer : public Peer, virtual public ::yajr::Peer {
     mutable size_t pendingBytes_;
     mutable uint64_t nextId_;
 
-    uint64_t keepAliveInterval_;
+    std::atomic<uint64_t> keepAliveInterval_;
     mutable uint64_t lastHeard_;
 
     ::yajr::transport::Transport transport_;

--- a/libopflex/ofcore/OFFramework.cpp
+++ b/libopflex/ofcore/OFFramework.cpp
@@ -18,7 +18,6 @@
 
 #include <boost/assign.hpp>
 #include <boost/foreach.hpp>
-#include <boost/scoped_ptr.hpp>
 
 #include "opflex/ofcore/OFFramework.h"
 #include "opflex/engine/Processor.h"
@@ -35,7 +34,7 @@ namespace ofcore {
 using namespace boost::assign;
 using namespace opflex::modb;
 using engine::internal::MOSerializer;
-using boost::scoped_ptr;
+using std::unique_ptr;
 using std::string;
 
 class OFFramework::OFFrameworkImpl {
@@ -49,7 +48,7 @@ public:
     util::ThreadManager threadManager;
     modb::ObjectStore db;
     engine::Processor processor;
-    scoped_ptr<engine::Inspector> inspector;
+    unique_ptr<engine::Inspector> inspector;
     uv_key_t mutator_key;
     bool started;
     opflex::ofcore::OFConstants::OpflexElementMode mode;

--- a/libopflex/ofcore/test/Inspector_test.cpp
+++ b/libopflex/ofcore/test/Inspector_test.cpp
@@ -16,7 +16,6 @@
 
 #include <cstdio>
 #include <boost/test/unit_test.hpp>
-#include <boost/scoped_ptr.hpp>
 #include <sys/stat.h>
 
 #include "BaseFixture.h"
@@ -29,7 +28,6 @@ namespace opflex {
 namespace ofcore {
 
 using std::string;
-using boost::scoped_ptr;
 using modb::BaseFixture;
 using modb::URI;
 using modb::mointernal::ObjectInstance;


### PR DESCRIPTION
Addressing coverity and clang-tidy issues

Init members before use
Remove unneeded #include statements
Prefer std::unique_ptr over boost::scoped_ptr

Signed-off-by: Tom Flynn <tom.flynn@gmail.com>