### PR TITLE
clang-tidy: Prefer std::to_string over boost::lexical_cast

### DIFF
--- a/agent-ovs/cmd/test/policy_repo_stress.cpp
+++ b/agent-ovs/cmd/test/policy_repo_stress.cpp
@@ -77,7 +77,7 @@ opflexagent::Endpoint createEndpoint(const uint32_t epId,
 
     std::string uri =
         boost::replace_all_copy(epgTemplate, "<group_id>",
-                                boost::lexical_cast<std::string>(groupId));
+                                std::to_string(groupId));
     ep.setEgURI(opflex::modb::URI(uri));
 
     return ep;
@@ -342,22 +342,18 @@ int main(int argc, char** argv) {
 
     std::vector<TestAgent> agents;
     for (uint32_t i = 0; i < num_agents; i++) {
+        std::string identity =
+            boost::replace_all_copy(identity_template, "<agent_id>",
+                                    std::to_string(i));
+        LOG(INFO) << "Creating agent " << identity;
         try {
-            std::string identity =
-                boost::replace_all_copy(identity_template, "<agent_id>",
-                                        boost::lexical_cast<std::string>(i));
-            LOG(INFO) << "Creating agent " << identity;
-            try {
-                agents.emplace_back(domain, identity);
-            } catch (const boost::asio::invalid_service_owner &e) {
-                LOG(WARNING) << "unable to add test agent: " << e.what();
-            }
-        } catch (const boost::bad_lexical_cast& e) {
-            LOG(WARNING) << "unable to create identity: " << e.what();
+            agents.emplace_back(domain, identity);
+        } catch (const boost::asio::invalid_service_owner &e) {
+            LOG(WARNING) << "unable to add test agent: " << e.what();
         }
     }
 
-    if (agents.size() == 0) {
+    if (agents.empty()) {
         LOG(opflexagent::ERROR) << "No agents created";
         return 4;
     }

--- a/agent-ovs/lib/test/LearningBridgeManager_test.cpp
+++ b/agent-ovs/lib/test/LearningBridgeManager_test.cpp
@@ -15,7 +15,6 @@
 
 #include <opflexagent/test/BaseFixture.h>
 
-#include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string/join.hpp>
 
 #include <sstream>
@@ -212,7 +211,7 @@ BOOST_FIXTURE_TEST_CASE( vlans, LBFixture ) {
     for (size_t i = 0; i < test_cases.size(); i++) {
         LOG(INFO) << "Checking add " << i;
         LearningBridgeIface iface;
-        iface.setUUID(boost::lexical_cast<std::string>(i));
+        iface.setUUID(std::to_string(i));
         for (const auto& r : test_cases[i].input) {
             iface.addTrunkVlans(r);
         }
@@ -225,7 +224,7 @@ BOOST_FIXTURE_TEST_CASE( vlans, LBFixture ) {
 
     for (size_t i = 0; i < test_cases.size(); i++) {
         LOG(INFO) << "Checking remove " << i;
-        lbSource.removeLBIface(boost::lexical_cast<std::string>(i));
+        lbSource.removeLBIface(std::to_string(i));
         BOOST_CHECK(test_cases[i].remove_expected == f());
         listener.logUpdates();
         BOOST_CHECK(test_cases[i].remove_notify == listener.getVlanUpdates());

--- a/agent-ovs/ovs/Packets.cpp
+++ b/agent-ovs/ovs/Packets.cpp
@@ -19,7 +19,6 @@
 #include <boost/system/error_code.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
-#include <boost/lexical_cast.hpp>
 #include <modelgbp/gbp/AutoconfigEnumT.hpp>
 
 #include <sstream>

--- a/agent-ovs/ovs/test/ContractStatsManager_test.cpp
+++ b/agent-ovs/ovs/test/ContractStatsManager_test.cpp
@@ -11,7 +11,6 @@
 #include <sstream>
 #include <boost/test/unit_test.hpp>
 #include <boost/assign/list_of.hpp>
-#include <boost/lexical_cast.hpp>
 
 #include <opflexagent/logging.h>
 #include <opflexagent/test/ModbFixture.h>
@@ -128,7 +127,7 @@ verifyOFPeerMetrics (const std::string& peer, uint32_t count)
 {
     const std::string& output = BaseFixture::getOutputFromCommand(cmd);
     size_t pos = std::string::npos;
-    const auto& val1 = boost::lexical_cast<std::string>(count) + ".000000";
+    const auto& val1 = std::to_string(count) + ".000000";
     const auto& val2 = "0.000000";
 
     const std::string& ident_req = "opflex_peer_identity_req_count{peer=\""
@@ -230,12 +229,12 @@ verifyPromMetrics (shared_ptr<L24Classifier> classifier,
                                 "policy:classifier3,[etype:2048,proto:6,dport:80-85,]\""\
                                 ",dst_epg=\"tenant:tenant0,policy:epg2\",src_epg=\""\
                                 "tenant:tenant0,policy:epg1\"} "\
-                                + boost::lexical_cast<std::string>(pkts) + ".000000";
+                                + std::to_string(pkts) + ".000000";
     const std::string& s_bytes = "opflex_contract_bytes{classifier=\"tenant:tenant0,"\
                                  "policy:classifier3,[etype:2048,proto:6,dport:80-85,]\""\
                                  ",dst_epg=\"tenant:tenant0,policy:epg2\",src_epg=\""\
                                  "tenant:tenant0,policy:epg1\"} "\
-                                 + boost::lexical_cast<std::string>(bytes) + ".000000";
+                                 + std::to_string(bytes) + ".000000";
 
     const std::string& output = BaseFixture::getOutputFromCommand(cmd);
     size_t pos = std::string::npos;
@@ -250,9 +249,9 @@ verifyRdDropPromMetrics (uint32_t pkts,
                          uint32_t bytes)
 {
     const std::string& s_pkts = "opflex_policy_drop_packets{routing_domain=\"tenant0:rd0\"} "\
-                                + boost::lexical_cast<std::string>(pkts) + ".000000";
+                                + std::to_string(pkts) + ".000000";
     const std::string& s_bytes = "opflex_policy_drop_bytes{routing_domain=\"tenant0:rd0\"} "\
-                                 + boost::lexical_cast<std::string>(bytes) + ".000000";
+                                 + std::to_string(bytes) + ".000000";
 
     const std::string& output = BaseFixture::getOutputFromCommand(cmd);
     size_t pos = std::string::npos;
@@ -271,8 +270,7 @@ verifyRoutingDomainDropStats(shared_ptr<RoutingDomain> rd,
     optional<shared_ptr<PolicyStatUniverse> > su =
         PolicyStatUniverse::resolve(agent.getFramework());
 
-    auto uuid =
-        boost::lexical_cast<string>(contractStatsManager.getAgentUUID());
+    auto uuid = contractStatsManager.getAgentUUID();
     WAIT_FOR_DO_ONFAIL(su.get()->resolveGbpeRoutingDomainDropCounter(uuid,
                                     contractStatsManager.getCurrDropGenId(),
                                     rd->getURI().toString()),
@@ -533,8 +531,7 @@ BOOST_FIXTURE_TEST_CASE(testContractDelete, ContractStatsManagerFixture) {
     mutator.commit();
     optional<shared_ptr<PolicyStatUniverse> > su =
         PolicyStatUniverse::resolve(agent.getFramework());
-    auto uuid =
-        boost::lexical_cast<std::string>(contractStatsManager.getAgentUUID());
+    auto uuid = contractStatsManager.getAgentUUID();
     optional<shared_ptr<L24ClassifierCounter> > myCounter;
     WAIT_FOR_DO_ONFAIL(!(su.get()->resolveGbpeL24ClassifierCounter(uuid,
                         contractStatsManager.getCurrClsfrGenId(),
@@ -568,8 +565,7 @@ BOOST_FIXTURE_TEST_CASE(testSEpgDelete, ContractStatsManagerFixture) {
     mutator.commit();
     optional<shared_ptr<PolicyStatUniverse> > su =
         PolicyStatUniverse::resolve(agent.getFramework());
-    auto uuid =
-        boost::lexical_cast<std::string>(contractStatsManager.getAgentUUID());
+    auto uuid = contractStatsManager.getAgentUUID();
     optional<shared_ptr<L24ClassifierCounter> > myCounter;
     WAIT_FOR_DO_ONFAIL(!(su.get()->resolveGbpeL24ClassifierCounter(uuid,
                         contractStatsManager.getCurrClsfrGenId(),
@@ -603,8 +599,7 @@ BOOST_FIXTURE_TEST_CASE(testrDSEpgDelete, ContractStatsManagerFixture) {
     mutator.commit();
     optional<shared_ptr<PolicyStatUniverse> > su =
         PolicyStatUniverse::resolve(agent.getFramework());
-    auto uuid =
-        boost::lexical_cast<std::string>(contractStatsManager.getAgentUUID());
+    auto uuid = contractStatsManager.getAgentUUID();
     optional<shared_ptr<L24ClassifierCounter> > myCounter;
     WAIT_FOR_DO_ONFAIL(!(su.get()->resolveGbpeL24ClassifierCounter(uuid,
                         contractStatsManager.getCurrClsfrGenId(),

--- a/agent-ovs/ovs/test/IntFlowManager_test.cpp
+++ b/agent-ovs/ovs/test/IntFlowManager_test.cpp
@@ -10,7 +10,6 @@
 
 #include <sstream>
 #include <boost/test/unit_test.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/assign/list_of.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/property_tree/ptree.hpp>
@@ -2867,7 +2866,7 @@ void BaseIntFlowManagerFixture::initExpPodServiceStats (const string& svc_ip,
     optional<shared_ptr<SvcStatUniverse> > su =
                 SvcStatUniverse::resolve(agent.getFramework());
     BOOST_CHECK(su);
-    auto aUuid = boost::lexical_cast<std::string>(agent.getUuid());
+    auto aUuid = agent.getUuid();
     WAIT_FOR_DO_ONFAIL(su.get()->resolveGbpeEpToSvcCounter(aUuid, epToSvcUuid), 500,
                         ,LOG(ERROR) << "ep2svc obj not resolved uuid: " << epToSvcUuid;);
     WAIT_FOR_DO_ONFAIL(su.get()->resolveGbpeSvcToEpCounter(aUuid, svcToEpUuid), 500,

--- a/agent-ovs/ovs/test/SecGrpStatsManager_test.cpp
+++ b/agent-ovs/ovs/test/SecGrpStatsManager_test.cpp
@@ -104,42 +104,42 @@ verifyPromMetrics (shared_ptr<L24Classifier> classifier,
     if (classifier == classifier1) {
         s_tx_bytes = "opflex_sg_tx_bytes{classifier=\"tenant:tenant0,policy:"\
                      "classifier1,[etype:2048,proto:6,dport:80]\"} "\
-                     + boost::lexical_cast<std::string>(bytes) + ".000000";
+                     + std::to_string(bytes) + ".000000";
         s_rx_bytes = "opflex_sg_rx_bytes{classifier=\"tenant:tenant0,policy:"\
                      "classifier1,[etype:2048,proto:6,dport:80]\"} "\
-                     + boost::lexical_cast<std::string>(bytes) + ".000000";
+                     + std::to_string(bytes) + ".000000";
         s_tx_pkts = "opflex_sg_tx_packets{classifier=\"tenant:tenant0,policy:"\
                     "classifier1,[etype:2048,proto:6,dport:80]\"} "\
-                    + boost::lexical_cast<std::string>(pkts) + ".000000";
+                    + std::to_string(pkts) + ".000000";
         s_rx_pkts = "opflex_sg_rx_packets{classifier=\"tenant:tenant0,policy:"\
                     "classifier1,[etype:2048,proto:6,dport:80]\"} "\
-                    + boost::lexical_cast<std::string>(pkts) + ".000000";
+                    + std::to_string(pkts) + ".000000";
     } else if (classifier == classifier2) {
         s_tx_bytes = "opflex_sg_tx_bytes{classifier=\"tenant:tenant0,policy:"\
                      "classifier2,[etype:2054,]\"} "\
-                     + boost::lexical_cast<std::string>(bytes) + ".000000";
+                     + std::to_string(bytes) + ".000000";
         s_rx_bytes = "opflex_sg_rx_bytes{classifier=\"tenant:tenant0,policy:"\
                      "classifier2,[etype:2054,]\"} "\
-                     + boost::lexical_cast<std::string>(bytes) + ".000000";
+                     + std::to_string(bytes) + ".000000";
         s_tx_pkts = "opflex_sg_tx_packets{classifier=\"tenant:tenant0,policy:"\
                     "classifier2,[etype:2054,]\"} "\
-                    + boost::lexical_cast<std::string>(pkts) + ".000000";
+                    + std::to_string(pkts) + ".000000";
         s_rx_pkts = "opflex_sg_rx_packets{classifier=\"tenant:tenant0,policy:"\
                     "classifier2,[etype:2054,]\"} "\
-                    + boost::lexical_cast<std::string>(pkts) + ".000000";
+                    + std::to_string(pkts) + ".000000";
     } else {
         s_tx_bytes = "opflex_sg_tx_bytes{classifier=\"tenant:tenant0,policy:"\
                      "classifier3,[etype:2048,proto:6,dport:80-85,]\"} "\
-                     + boost::lexical_cast<std::string>(bytes) + ".000000";
+                     + std::to_string(bytes) + ".000000";
         s_rx_bytes = "opflex_sg_rx_bytes{classifier=\"tenant:tenant0,policy:"\
                      "classifier3,[etype:2048,proto:6,dport:80-85,]\"} "\
-                     + boost::lexical_cast<std::string>(bytes) + ".000000";
+                     + std::to_string(bytes) + ".000000";
         s_tx_pkts = "opflex_sg_tx_packets{classifier=\"tenant:tenant0,policy:"\
                     "classifier3,[etype:2048,proto:6,dport:80-85,]\"} "\
-                    + boost::lexical_cast<std::string>(pkts) + ".000000";
+                    + std::to_string(pkts) + ".000000";
         s_rx_pkts = "opflex_sg_rx_packets{classifier=\"tenant:tenant0,policy:"\
                     "classifier3,[etype:2048,proto:6,dport:80-85,]\"} "\
-                    + boost::lexical_cast<std::string>(pkts) + ".000000";
+                    + std::to_string(pkts) + ".000000";
     }
 
     const std::string& output = BaseFixture::getOutputFromCommand(cmd);
@@ -345,8 +345,7 @@ BOOST_FIXTURE_TEST_CASE(testSecGrpDelete, SecGrpStatsManagerFixture) {
     mutator.commit();
     optional<shared_ptr<PolicyStatUniverse> > su =
         PolicyStatUniverse::resolve(agent.getFramework());
-    auto uuid =
-        boost::lexical_cast<std::string>(secGrpStatsManager.getAgentUUID());
+    auto uuid = secGrpStatsManager.getAgentUUID();
     optional<shared_ptr<SecGrpClassifierCounter> > myCounter;
     WAIT_FOR_DO_ONFAIL(!(su.get()->resolveGbpeSecGrpClassifierCounter(uuid,
                         secGrpStatsManager.getCurrClsfrGenId(),

--- a/agent-ovs/ovs/test/ServiceStatsManager_test.cpp
+++ b/agent-ovs/ovs/test/ServiceStatsManager_test.cpp
@@ -10,7 +10,6 @@
 
 #include <sstream>
 #include <boost/test/unit_test.hpp>
-#include <boost/lexical_cast.hpp>
 
 #include <opflexagent/Agent.h>
 #include <modelgbp/gbpe/SvcToEpCounter.hpp>
@@ -877,16 +876,16 @@ void ServiceStatsManagerFixture::checkSvcTgtPromMetrics (uint64_t pkts,
     const string& scope = isNodePort?"nodePort":"cluster";
     const string& s_rx_bytes = "opflex_svc_rx_bytes{name=\"coredns\"" \
                                ",namespace=\"kube-system\",scope=\"" + scope + "\"} "
-                            + boost::lexical_cast<std::string>(bytes) + ".000000";
+                            + std::to_string(bytes) + ".000000";
     const string& s_rx_pkts = "opflex_svc_rx_packets{name=\"coredns\"" \
                               ",namespace=\"kube-system\",scope=\"" + scope + "\"} "
-                            + boost::lexical_cast<std::string>(pkts) + ".000000";
+                            + std::to_string(pkts) + ".000000";
     const string& s_tx_bytes = "opflex_svc_tx_bytes{name=\"coredns\"" \
                                ",namespace=\"kube-system\",scope=\"" + scope + "\"} "
-                            + boost::lexical_cast<std::string>(bytes) + ".000000";
+                            + std::to_string(bytes) + ".000000";
     const string& s_tx_pkts = "opflex_svc_tx_packets{name=\"coredns\"" \
                               ",namespace=\"kube-system\",scope=\"" + scope + "\"} "
-                            + boost::lexical_cast<std::string>(pkts) + ".000000";
+                            + std::to_string(pkts) + ".000000";
     pos = output.find(s_rx_bytes);
     BOOST_CHECK_NE(pos, std::string::npos);
     pos = output.find(s_rx_pkts);
@@ -912,13 +911,13 @@ void ServiceStatsManagerFixture::checkSvcTgtPromMetrics (uint64_t pkts,
         tx_pkts = "opflex_svc_target_tx_packets{ip=\"";
     }
     const string& st_rx_bytes = rx_bytes + ip + s_ann
-                            + boost::lexical_cast<std::string>(bytes) + ".000000";
+                            + std::to_string(bytes) + ".000000";
     const string& st_rx_pkts = rx_pkts + ip + s_ann
-                            + boost::lexical_cast<std::string>(pkts) + ".000000";
+                            + std::to_string(pkts) + ".000000";
     const string& st_tx_bytes = tx_bytes + ip + s_ann
-                            + boost::lexical_cast<std::string>(bytes) + ".000000";
+                            + std::to_string(bytes) + ".000000";
     const string& st_tx_pkts = tx_pkts + ip + s_ann
-                            + boost::lexical_cast<std::string>(pkts) + ".000000";
+                            + std::to_string(pkts) + ".000000";
     pos = output.find(st_rx_bytes);
     BOOST_CHECK_NE(pos, std::string::npos);
     pos = output.find(st_rx_pkts);
@@ -937,19 +936,19 @@ void ServiceStatsManagerFixture::checkPodSvcPromMetrics (uint64_t pkts,
     const string& rx_bytes = "opflex_endpoint_to_svc_bytes{ep_name=\"coredns\"," \
                              "ep_namespace=\"default\",svc_name=\"coredns\"," \
                              "svc_namespace=\"kube-system\",svc_scope=\"cluster\"} " \
-                            + boost::lexical_cast<std::string>(bytes) + ".000000";
+                            + std::to_string(bytes) + ".000000";
     const string& rx_pkts = "opflex_endpoint_to_svc_packets{ep_name=\"coredns\"," \
                              "ep_namespace=\"default\",svc_name=\"coredns\"," \
                              "svc_namespace=\"kube-system\",svc_scope=\"cluster\"} " \
-                            + boost::lexical_cast<std::string>(pkts) + ".000000";
+                            + std::to_string(pkts) + ".000000";
     const string& tx_bytes = "opflex_svc_to_endpoint_bytes{ep_name=\"coredns\"," \
                              "ep_namespace=\"default\",svc_name=\"coredns\"," \
                              "svc_namespace=\"kube-system\",svc_scope=\"cluster\"} " \
-                            + boost::lexical_cast<std::string>(bytes) + ".000000";
+                            + std::to_string(bytes) + ".000000";
     const string& tx_pkts = "opflex_svc_to_endpoint_packets{ep_name=\"coredns\"," \
                              "ep_namespace=\"default\",svc_name=\"coredns\"," \
                              "svc_namespace=\"kube-system\",svc_scope=\"cluster\"} " \
-                            + boost::lexical_cast<std::string>(pkts) + ".000000";
+                            + std::to_string(pkts) + ".000000";
     size_t pos1 = output.find(rx_bytes);
     size_t pos2 = output.find(rx_pkts);
     size_t pos3 = output.find(tx_bytes);
@@ -1163,8 +1162,7 @@ ServiceStatsManagerFixture::checkPodSvcObjectStats (const std::string& epToSvcUu
     optional<shared_ptr<SvcStatUniverse> > su =
         SvcStatUniverse::resolve(agent.getFramework());
 
-    auto aUuid =
-        boost::lexical_cast<std::string>(agent.getUuid());
+    auto aUuid = agent.getUuid();
 
     LOG(DEBUG) << "checkObj expected pkt count: " << packet_count;
 
@@ -1262,15 +1260,7 @@ void ServiceStatsManagerFixture::checkPodSvcObsObj (bool add)
 
     optional<shared_ptr<SvcStatUniverse> > su =
         SvcStatUniverse::resolve(agent.getFramework());
-    std::string aUuid;
-    try {
-        aUuid =
-            boost::lexical_cast<std::string>(agent.getUuid());
-    } catch (const boost::bad_lexical_cast &e){
-        LOG(ERROR) << "Failed to get agent uuid " <<e.what();
-        BOOST_CHECK(false);
-        return;
-    };
+    std::string aUuid = agent.getUuid();
 
     LOG(DEBUG) << "Checking presence of"
                << " agentUuid: " << aUuid

--- a/agent-ovs/ovs/test/TableDropStatsManager_test.cpp
+++ b/agent-ovs/ovs/test/TableDropStatsManager_test.cpp
@@ -11,7 +11,6 @@
 #include <sstream>
 #include <boost/test/unit_test.hpp>
 #include <boost/assign/list_of.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/optional.hpp>
 
 #include <opflexagent/test/ModbFixture.h>
@@ -189,9 +188,9 @@ void TableDropStatsManagerFixture::checkPrometheusCounters(uint64_t exp_packet_c
     const string& output = BaseFixture::getOutputFromCommand(cmd);
     const string& promCtr= bridgeName+ "_" +tableName;
     string packets_key = "opflex_table_drop_packets{table=\"" + promCtr + "\"} "
-        + boost::lexical_cast<std::string>(exp_packet_count) + ".000000";
+        + std::to_string(exp_packet_count) + ".000000";
     string bytes_key = "opflex_table_drop_bytes{table=\"" + promCtr + "\"} "
-        + boost::lexical_cast<std::string>(exp_byte_count) + ".000000";
+        + std::to_string(exp_byte_count) + ".000000";
     string::size_type pos = output.find(packets_key);
     BOOST_CHECK_NE(pos, string::npos);
     pos = output.find(bytes_key);

--- a/agent-ovs/ovs/test/include/PolicyStatsManagerFixture.h
+++ b/agent-ovs/ovs/test/include/PolicyStatsManagerFixture.h
@@ -25,7 +25,6 @@
 #include "AccessFlowManager.h"
 #include "FlowManagerFixture.h"
 
-#include <boost/lexical_cast.hpp>
 #include <boost/asio/io_service.hpp>
 
 #include <vector>
@@ -108,8 +107,7 @@ public:
         optional<shared_ptr<PolicyStatUniverse> > su =
             PolicyStatUniverse::resolve(agent.getFramework());
         if (srcEpg.get() && dstEpg.get()) {
-            auto uuid =
-                boost::lexical_cast<std::string>(statsManager->getAgentUUID());
+            auto uuid = statsManager->getAgentUUID();
             LOG(DEBUG) << "verifying stats for src_epg: " << srcEpg->getURI().toString()
                         << " dst_epg: " << dstEpg->getURI().toString()
                         << " classifier: " << classifier->getURI().toString()
@@ -139,8 +137,7 @@ public:
             verifyPromMetrics(classifier, t_packet_count, t_byte_count);
 #endif
         } else {
-            auto uuid =
-                boost::lexical_cast<std::string>(statsManager->getAgentUUID());
+            auto uuid = statsManager->getAgentUUID();
             optional<shared_ptr<SecGrpClassifierCounter> > myCounter =
                 boost::make_optional<shared_ptr<SecGrpClassifierCounter> >(false, nullptr);
             LOG(DEBUG) << "verifying stats for"
@@ -370,8 +367,7 @@ public:
         }
         optional<shared_ptr<PolicyStatUniverse> > su =
             PolicyStatUniverse::resolve(agent.getFramework());
-        auto uuid =
-            boost::lexical_cast<std::string>(statsManager->getAgentUUID());
+        auto uuid = statsManager->getAgentUUID();
         if (srcEpg.get() && dstEpg.get()) {
             optional<shared_ptr<L24ClassifierCounter> > myCounter =
                 su.get()->resolveGbpeL24ClassifierCounter(uuid,firstId,

--- a/libopflex/comms/test/comms_test.cpp
+++ b/libopflex/comms/test/comms_test.cpp
@@ -28,7 +28,6 @@
 #include <boost/test/unit_test_log.hpp>
 #include <boost/test/unit_test.hpp>
 
-#include <boost/lexical_cast.hpp>
 #include <boost/scoped_ptr.hpp>
 
 #include <utility>
@@ -509,7 +508,7 @@ BOOST_FIXTURE_TEST_CASE( STABLE_test_ipv4, CommsFixture ) {
     BOOST_CHECK_EQUAL(!l, 0);
 
     ::yajr::Peer * p = ::yajr::Peer::create(
-            "localhost", boost::lexical_cast<std::string>(65535-kPortOffset), doNothingOnConnect,
+            "localhost", std::to_string(65535-kPortOffset), doNothingOnConnect,
             NULL, CommsFixture::loopSelector
     );
 
@@ -529,7 +528,7 @@ BOOST_FIXTURE_TEST_CASE( STABLE_test_ipv6, CommsFixture ) {
     BOOST_CHECK_EQUAL(!l, 0);
 
     ::yajr::Peer * p = ::yajr::Peer::create(
-            "::", boost::lexical_cast<std::string>(65534-kPortOffset), doNothingOnConnect,
+            "::", std::to_string(65534-kPortOffset), doNothingOnConnect,
             NULL, CommsFixture::loopSelector
     );
 
@@ -592,7 +591,7 @@ static void pc_non_existent(void) {
 BOOST_FIXTURE_TEST_CASE( STABLE_test_non_existent_host, CommsFixture ) {
 
     ::yajr::Peer * p = ::yajr::Peer::create(
-            "non_existent_host.", boost::lexical_cast<std::string>(65533-kPortOffset), doNothingOnConnect,
+            "non_existent_host.", std::to_string(65533-kPortOffset), doNothingOnConnect,
             NULL, CommsFixture::loopSelector
     );
 
@@ -605,7 +604,7 @@ BOOST_FIXTURE_TEST_CASE( STABLE_test_non_existent_host, CommsFixture ) {
 BOOST_FIXTURE_TEST_CASE( STABLE_test_non_existent_service, CommsFixture ) {
 
     ::yajr::Peer * p = ::yajr::Peer::create(
-            "127.0.0.1", boost::lexical_cast<std::string>(65533-kPortOffset), doNothingOnConnect,
+            "127.0.0.1", std::to_string(65533-kPortOffset), doNothingOnConnect,
             NULL, CommsFixture::loopSelector
     );
 
@@ -644,7 +643,7 @@ BOOST_FIXTURE_TEST_CASE( STABLE_test_keepalive, CommsFixture ) {
     BOOST_CHECK_EQUAL(!l, 0);
 
     ::yajr::Peer * p = ::yajr::Peer::create(
-            "127.0.0.1", boost::lexical_cast<std::string>(65532-kPortOffset), startPingingOnConnect,
+            "127.0.0.1", std::to_string(65532-kPortOffset), startPingingOnConnect,
             NULL, CommsFixture::loopSelector
     );
 
@@ -723,7 +722,7 @@ BOOST_FIXTURE_TEST_CASE( STABLE_test_destroy_client_early, CommsFixture ) {
     LOG(DEBUG);
 
     ::yajr::Peer * p = ::yajr::Peer::create(
-            "localhost", boost::lexical_cast<std::string>(65530-kPortOffset), doNothingOnConnect,
+            "localhost", std::to_string(65530-kPortOffset), doNothingOnConnect,
             NULL, CommsFixture::loopSelector
     );
 
@@ -775,7 +774,7 @@ BOOST_FIXTURE_TEST_CASE( STABLE_test_destroy_client_late, CommsFixture ) {
     BOOST_CHECK_EQUAL(!l, 0);
 
     ::yajr::Peer * p = ::yajr::Peer::create(
-            "localhost", boost::lexical_cast<std::string>(65529-kPortOffset), doNothingOnConnect,
+            "localhost", std::to_string(65529-kPortOffset), doNothingOnConnect,
             NULL, CommsFixture::loopSelector
     );
 
@@ -959,7 +958,7 @@ void DestroyOnDisconnect (
 BOOST_FIXTURE_TEST_CASE( STABLE_test_destroy_client_before_connect, CommsFixture ) {
 
     ::yajr::Peer * p = ::yajr::Peer::create(
-            "localhost", boost::lexical_cast<std::string>(65528-kPortOffset), destroyOnCallback,
+            "localhost", std::to_string(65528-kPortOffset), destroyOnCallback,
             NULL, CommsFixture::loopSelector
     );
 
@@ -997,7 +996,7 @@ void pc_retrying_client(void) {
 BOOST_FIXTURE_TEST_CASE( STABLE_test_disconnect_client_before_connect, CommsFixture ) {
 
     ::yajr::Peer * p = ::yajr::Peer::create(
-            "localhost", boost::lexical_cast<std::string>(65527-kPortOffset), disconnectOnCallback,
+            "localhost", std::to_string(65527-kPortOffset), disconnectOnCallback,
             NULL, CommsFixture::loopSelector
     );
 
@@ -1017,7 +1016,7 @@ BOOST_FIXTURE_TEST_CASE( STABLE_test_destroy_client_after_connect, CommsFixture 
     BOOST_CHECK_EQUAL(!l, 0);
 
     ::yajr::Peer * p = ::yajr::Peer::create(
-            "localhost", boost::lexical_cast<std::string>(65526-kPortOffset), destroyOnCallback,
+            "localhost", std::to_string(65526-kPortOffset), destroyOnCallback,
             NULL, CommsFixture::loopSelector
     );
 
@@ -1063,7 +1062,7 @@ BOOST_FIXTURE_TEST_CASE( STABLE_test_disconnect_client_after_connect, CommsFixtu
     BOOST_CHECK_EQUAL(!l, 0);
 
     ::yajr::Peer * p = ::yajr::Peer::create(
-            "localhost", boost::lexical_cast<std::string>(65525-kPortOffset), disconnectOnCallback,
+            "localhost", std::to_string(65525-kPortOffset), disconnectOnCallback,
             NULL, CommsFixture::loopSelector
     );
 
@@ -1082,7 +1081,7 @@ BOOST_FIXTURE_TEST_CASE( STABLE_test_destroy_server_after_connect, CommsFixture 
     BOOST_CHECK_EQUAL(!l, 0);
 
     ::yajr::Peer * p = ::yajr::Peer::create(
-            "localhost", boost::lexical_cast<std::string>(65524-kPortOffset), destroyOnDisconnect,
+            "localhost", std::to_string(65524-kPortOffset), destroyOnDisconnect,
             NULL, CommsFixture::loopSelector
     );
 
@@ -1101,7 +1100,7 @@ BOOST_FIXTURE_TEST_CASE( STABLE_test_disconnect_server_after_connect, CommsFixtu
     BOOST_CHECK_EQUAL(!l, 0);
 
     ::yajr::Peer * p = ::yajr::Peer::create(
-            "localhost", boost::lexical_cast<std::string>(65523-kPortOffset), destroyOnDisconnect,
+            "localhost", std::to_string(65523-kPortOffset), destroyOnDisconnect,
             NULL, CommsFixture::loopSelector
     );
 
@@ -1261,7 +1260,7 @@ BOOST_FIXTURE_TEST_CASE( STABLE_test_client_retry_more_than_once, CommsFixture )
     BOOST_CHECK_EQUAL(!flakyListener, 0);
 
     ::yajr::Peer * p = ::yajr::Peer::create(
-            "localhost", boost::lexical_cast<std::string>(65522-kPortOffset), countdownAttemptsOnCallback,
+            "localhost", std::to_string(65522-kPortOffset), countdownAttemptsOnCallback,
             NULL, CommsFixture::loopSelector
     );
 
@@ -1274,7 +1273,7 @@ BOOST_FIXTURE_TEST_CASE( STABLE_test_client_retry_more_than_once, CommsFixture )
 BOOST_FIXTURE_TEST_CASE( STABLE_test_destroy_client_for_non_existent_host, CommsFixture ) {
 
     ::yajr::Peer * p = ::yajr::Peer::create(
-            "non_existent_host.", boost::lexical_cast<std::string>(65521-kPortOffset), destroyOnCallback,
+            "non_existent_host.", std::to_string(65521-kPortOffset), destroyOnCallback,
             NULL, CommsFixture::loopSelector
     );
 
@@ -1287,7 +1286,7 @@ BOOST_FIXTURE_TEST_CASE( STABLE_test_destroy_client_for_non_existent_host, Comms
 BOOST_FIXTURE_TEST_CASE( STABLE_test_destroy_client_for_non_existent_service, CommsFixture ) {
 
     ::yajr::Peer * p = ::yajr::Peer::create(
-            "127.0.0.1", boost::lexical_cast<std::string>(65520-kPortOffset), destroyOnCallback,
+            "127.0.0.1", std::to_string(65520-kPortOffset), destroyOnCallback,
             NULL, CommsFixture::loopSelector
     );
 
@@ -1300,7 +1299,7 @@ BOOST_FIXTURE_TEST_CASE( STABLE_test_destroy_client_for_non_existent_service, Co
 BOOST_FIXTURE_TEST_CASE( STABLE_test_disconnect_client_for_non_existent_host, CommsFixture ) {
 
     ::yajr::Peer * p = ::yajr::Peer::create(
-            "localhost", boost::lexical_cast<std::string>(65519-kPortOffset), disconnectOnCallback,
+            "localhost", std::to_string(65519-kPortOffset), disconnectOnCallback,
             NULL, CommsFixture::loopSelector
     );
 
@@ -1313,7 +1312,7 @@ BOOST_FIXTURE_TEST_CASE( STABLE_test_disconnect_client_for_non_existent_host, Co
 BOOST_FIXTURE_TEST_CASE( STABLE_test_disconnect_client_for_non_existent_service, CommsFixture ) {
 
     ::yajr::Peer * p = ::yajr::Peer::create(
-            "localhost", boost::lexical_cast<std::string>(65518-kPortOffset), disconnectOnCallback,
+            "localhost", std::to_string(65518-kPortOffset), disconnectOnCallback,
             NULL, CommsFixture::loopSelector
     );
 
@@ -1410,7 +1409,7 @@ BOOST_FIXTURE_TEST_CASE( STABLE_test_no_message_on_SSL, CommsFixture ) {
 
     ::yajr::Peer * p = ::yajr::Peer::create(
             "127.0.0.1",
-            boost::lexical_cast<std::string>(65508-kPortOffset),
+            std::to_string(65508-kPortOffset),
             doNothingOnConnect,
             NULL, CommsFixture::loopSelector
     );
@@ -1515,7 +1514,7 @@ BOOST_FIXTURE_TEST_CASE( STABLE_test_single_message_on_SSL, CommsFixture ) {
 
     ::yajr::Peer * p = ::yajr::Peer::create(
             "127.0.0.1",
-            boost::lexical_cast<std::string>(65507-kPortOffset),
+            std::to_string(65507-kPortOffset),
             singlePingOnConnect,
             NULL, CommsFixture::loopSelector
     );
@@ -1580,7 +1579,7 @@ BOOST_FIXTURE_TEST_CASE( STABLE_test_single_message_with_client_cert_on_SSL, Com
 
     ::yajr::Peer * p = ::yajr::Peer::create(
             "127.0.0.1",
-            boost::lexical_cast<std::string>(65506-kPortOffset),
+            std::to_string(65506-kPortOffset),
             singlePingOnConnect,
             NULL, CommsFixture::loopSelector
     );
@@ -1645,7 +1644,7 @@ BOOST_FIXTURE_TEST_CASE( STABLE_test_keepalive_on_SSL, CommsFixture ) {
 
     ::yajr::Peer * p = ::yajr::Peer::create(
             "127.0.0.1",
-            boost::lexical_cast<std::string>(65505-kPortOffset),
+            std::to_string(65505-kPortOffset),
             startPingingOnConnect,
             NULL, CommsFixture::loopSelector
     );
@@ -1749,7 +1748,7 @@ BOOST_FIXTURE_TEST_CASE( STABLE_test_several_SSL_peers, CommsFixture ) {
 
         ::yajr::Peer * p = ::yajr::Peer::create(
                 "127.0.0.1",
-                boost::lexical_cast<std::string>(65504-kPortOffset-n),
+                std::to_string(65504-kPortOffset-n),
                 singlePingOnConnect,
                 NULL, CommsFixture::loopSelector
         );

--- a/libopflex/engine/OpflexClientConnection.cpp
+++ b/libopflex/engine/OpflexClientConnection.cpp
@@ -84,7 +84,7 @@ void OpflexClientConnection::connect() {
     remote_peer = rp.str();
 
     peer = yajr::Peer::create(hostname,
-                              boost::lexical_cast<string>(port),
+                              std::to_string(port),
                               on_state_change,
                               this, loop_selector);
 }


### PR DESCRIPTION
Signed-off-by: Tom Flynn <tom.flynn@gmail.com>