### PR TITLE
Add support for gbp_inspect to opflex server

### DIFF
--- a/agent-ovs/lib/Agent.cpp
+++ b/agent-ovs/lib/Agent.cpp
@@ -562,25 +562,7 @@ void Agent::start() {
     Mutator mutator(framework, "init");
     std::shared_ptr<modelgbp::dmtree::Root> root =
         modelgbp::dmtree::Root::createRootElement(framework);
-    root->addPolicyUniverse();
-    root->addRelatorUniverse();
-    root->addSvcServiceUniverse();
-    root->addEprL2Universe();
-    root->addEprL3Universe();
-    root->addInvUniverse();
-    root->addEpdrL2Discovered();
-    root->addEpdrL3Discovered();
-    root->addGbpeVMUniverse();
-    root->addObserverEpStatUniverse();
-    root->addObserverSvcStatUniverse();
-    root->addObserverPolicyStatUniverse();
-    root->addObserverDropFlowConfigUniverse();
-    root->addSpanUniverse();
-    root->addEpdrExternalDiscovered();
-    root->addEpdrLocalRouteDiscovered();
-    root->addEprPeerRouteUniverse();
-    root->addFaultUniverse();
-    root->addObserverSysStatUniverse();
+    Agent::createUniverse(root);
     mutator.commit();
 
     // instantiate other components
@@ -755,6 +737,32 @@ void Agent::stop() {
     abort_timer.join();
 
     LOG(INFO) << "Agent stopped";
+}
+
+void Agent::createUniverse (std::shared_ptr<modelgbp::dmtree::Root> root)
+{
+    if (!root)
+        return;
+
+    root->addPolicyUniverse();
+    root->addRelatorUniverse();
+    root->addSvcServiceUniverse();
+    root->addEprL2Universe();
+    root->addEprL3Universe();
+    root->addInvUniverse();
+    root->addEpdrL2Discovered();
+    root->addEpdrL3Discovered();
+    root->addGbpeVMUniverse();
+    root->addObserverEpStatUniverse();
+    root->addObserverSvcStatUniverse();
+    root->addObserverPolicyStatUniverse();
+    root->addObserverDropFlowConfigUniverse();
+    root->addSpanUniverse();
+    root->addEpdrExternalDiscovered();
+    root->addEpdrLocalRouteDiscovered();
+    root->addEprPeerRouteUniverse();
+    root->addFaultUniverse();
+    root->addObserverSysStatUniverse();
 }
 
 inline StatMode Agent::getStatModeFromString(const std::string& mode) {

--- a/agent-ovs/lib/include/opflexagent/Agent.h
+++ b/agent-ovs/lib/include/opflexagent/Agent.h
@@ -324,6 +324,12 @@ public:
      */
     const LogParams& getLogParams() { return logParams; }
 
+    /**
+     * Common function b/w Agent and Server to add all supported universes
+     * @param root pointer to DmtreeRoot under which the universes will be created
+     */
+    static void createUniverse(std::shared_ptr<modelgbp::dmtree::Root> root);
+
 private:
     boost::asio::io_service agent_io;
     std::unique_ptr<boost::asio::io_service::work> io_work;
@@ -409,6 +415,7 @@ private:
                                      const std::string& interval_prop,
                                      const boost::property_tree::ptree& properties,
                                      Agent::StatProps& props);
+
     long contractInterval;
     long securityGroupInterval;
     long interfaceInterval;


### PR DESCRIPTION
- create framework and default inspector sock if not specified
- create DmtreeRoot
- Add the same set of universes during agent and server init under root

Tested in mock environment:
noiro@gautvenk-noiro-vm:~/work/opflex/agent-ovs$ sudo gbp_inspect --socket=/usr/local/var/run/opflex-server-inspect.sock -prq DmtreeRoot
____ DmtreeRoot,/
  ____ RelatorUniverse,/RelatorUniverse/
  ____ GbpeVMUniverse,/GbpeVMUniverse/
  ____ SpanUniverse,/SpanUniverse/
  ____ EpdrL2Discovered,/EpdrL2Discovered/
  ____ EpdrL3Discovered,/EpdrL3Discovered/
  ____ EpdrExternalDiscovered,/EpdrExternalDiscovered/
  ____ EpdrLocalRouteDiscovered,/EpdrLocalRouteDiscovered/
  ____ InvUniverse,/InvUniverse/
  ____ EprL2Universe,/EprL2Universe/
  ____ EprL3Universe,/EprL3Universe/
  ____ EprPeerRouteUniverse,/EprPeerRouteUniverse/
  ____ FaultUniverse,/FaultUniverse/
  ____ ObserverSysStatUniverse,/ObserverSysStatUniverse/
  ____ ObserverSvcStatUniverse,/ObserverSvcStatUniverse/
  ____ ObserverEpStatUniverse,/ObserverEpStatUniverse/
  ____ ObserverPolicyStatUniverse,/ObserverPolicyStatUniverse/
  ____ ObserverDropFlowConfigUniverse,/ObserverDropFlowConfigUniverse/
  ____ PolicyUniverse,/PolicyUniverse/
  ____ SvcServiceUniverse,/SvcServiceUniverse/