### PR TITLE
Stop using class IDs in relation URIs as they may change when upgrading

### DIFF
--- a/agent-ovs/ovs/OvsdbConnection.cpp
+++ b/agent-ovs/ovs/OvsdbConnection.cpp
@@ -70,6 +70,7 @@ void OvsdbConnection::stop() {
     }
     yajr::finiLoop(client_loop);
     threadManager.stopTask("OvsdbConnection");
+    cleanup();
 }
 
 void OvsdbConnection::on_state_change(yajr::Peer * p, void * data,

--- a/genie/src/main/java/org/opendaylight/opflex/genie/content/format/agent/structure/cpp/FClassDef.java
+++ b/genie/src/main/java/org/opendaylight/opflex/genie/content/format/agent/structure/cpp/FClassDef.java
@@ -1130,7 +1130,8 @@ public class FClassDef extends ItemFormatterTask
         out.println(aInIdent,"{");
         if (aInTargetClass != null && lClassProp != null)
         {
-            out.println(aInIdent + 1, "static const opflex::modb::class_id_t " + getPropParamName(aInChildClass, lClassProp.getPropName()) + " = " + aInTargetClass.getGID().getId() + ";");
+            String lValue = Strings.upFirstLetter(aInTargetClass.getModule().getLID().getName()) + Strings.upFirstLetter(aInTargetClass.getLID().getName());
+            out.println(aInIdent + 1, "static const std::string " + getPropParamName(aInChildClass, lClassProp.getPropName()) + " = \"" + lValue + "\";");
         }
         out.println(aInIdent + 1, "std::shared_ptr<" + aInFormattedChildClassName + "> result = addChild<" + aInFormattedChildClassName+ ">(");
         out.println(aInIdent + 2, "CLASS_ID, getURI(), " + toUnsignedStr(aInChildClass.getClassAsPropId(aInParentClass)) + ", " + aInChildClass.getGID().getId() + ",");
@@ -1234,7 +1235,8 @@ public class FClassDef extends ItemFormatterTask
         out.println(aInIdent,"{");
         if (aInTargetClass != null && lClassProp != null)
         {
-            out.println(aInIdent + 1, "static const opflex::modb::class_id_t " + getPropParamName(aInChildClass, lClassProp.getPropName()) + " = " + aInTargetClass.getGID().getId() + ";");
+            String lValue = Strings.upFirstLetter(aInTargetClass.getModule().getLID().getName()) + Strings.upFirstLetter(aInTargetClass.getLID().getName());
+            out.println(aInIdent + 1, "static const std::string " + getPropParamName(aInChildClass, lClassProp.getPropName()) + " = \"" + lValue + "\";");
         }
         out.println(aInIdent + 1, "return " + aInFormattedChildClassName + "::resolve(getFramework(), " + aInUriBuilder + ");");
         out.println(aInIdent,"}");

--- a/genie/src/main/java/org/opendaylight/opflex/genie/content/format/proxy/structure/cpp/FClassDef.java
+++ b/genie/src/main/java/org/opendaylight/opflex/genie/content/format/proxy/structure/cpp/FClassDef.java
@@ -862,7 +862,8 @@ public class FClassDef extends ItemFormatterTask
         out.println(aInIndent,"{");
         if (aInTargetClass != null && lClassProp != null)
         {
-            out.println(aInIndent + 1, "const opflex::modb::class_id_t " + getPropParamName(aInChildClass, lClassProp.getPropName()) + " = " + aInTargetClass.getGID().getId() + ";");
+            String lValue = Strings.upFirstLetter(aInTargetClass.getModule().getLID().getName()) + Strings.upFirstLetter(aInTargetClass.getLID().getName());
+            out.println(aInIndent + 1, "static const std::string " + getPropParamName(aInChildClass, lClassProp.getPropName()) + " = \"" + lValue + "\";");
         }
         out.println(aInIndent + 1, "boost::shared_ptr<" + aInFormattedChildClassName + "> result =");
         out.println(aInIndent + 2, "boost::static_pointer_cast<" + aInFormattedChildClassName + ">(");


### PR DESCRIPTION
End result has always been correct but it results in unneeded processing

Also explicitly cleanup OVSDB resources

Signed-off-by: Tom Flynn <tom.flynn@gmail.com>