### PR TITLE
Remove support for EPG as src for ERSPAN session.

### DIFF
--- a/agent-ovs/lib/include/opflexagent/SpanManager.h
+++ b/agent-ovs/lib/include/opflexagent/SpanManager.h
@@ -41,7 +41,6 @@ namespace opflexagent {
     using namespace modelgbp::epr;
     namespace span = modelgbp::span;
     using namespace span;
-    using namespace modelgbp::gbp;
     using boost::optional;
 
 /**
@@ -194,20 +193,12 @@ public:
         const unsigned char dir);
 
     /**
-     * process EP group
-     * @param[in] uri uri pointing to src member
-     * @param[in] dir direction
-     */
-    void processEpGroup(const URI& uri, unsigned char dir);
-
-    /**
      * mutex for guarding span manager data structures.
     */
     static recursive_mutex updates;
 private:
 
     optional<shared_ptr<SrcMember>> findSrcMem(const URI& sessUri, const URI& uri);
-    boost::optional<shared_ptr<EpGroup>> getEpgIfPartOfSession(const URI& epgUri);
 
     opflex::ofcore::OFFramework& framework;
     /**

--- a/agent-ovs/lib/include/opflexagent/SpanSessionState.h
+++ b/agent-ovs/lib/include/opflexagent/SpanSessionState.h
@@ -20,6 +20,7 @@
 #include <modelgbp/platform/AdminStateEnumT.hpp>
 #include <modelgbp/span/ErspanVersionEnumT.hpp>
 #include <boost/asio.hpp>
+#include <utility>
 
 
 namespace opflexagent {
@@ -39,8 +40,8 @@ class SourceEndpoint {
          * @param[in] port_ source port name on the vswitch
          * @param[in] dir_ direction to be set
          */
-        SourceEndpoint(const string& name_, const string& port_, const unsigned char dir_) :
-            name(name_), port(port_), dir(dir_) {};
+        SourceEndpoint(string name_, string port_, const unsigned char dir_) :
+            name(std::move(name_)), port(std::move(port_)), dir(dir_) {};
 
         /**
          * Copy constructor
@@ -122,10 +123,11 @@ class SessionState {
          * @param uri_ URI of a Session object
          * @param name_ name of Session object
          */
-        SessionState(const URI& uri_, const string& name_) :
-            uri(uri_), name(name_),
+        SessionState(const URI& uri_, string name_) :
+            uri(uri_), name(std::move(name_)),
             adminState(modelgbp::platform::AdminStateEnumT::CONST_OFF),
-            version(modelgbp::span::ErspanVersionEnumT::CONST_V2) {};
+            version(modelgbp::span::ErspanVersionEnumT::CONST_V2),
+            sessionId(1) {};
 
         /**
          * gets the URI, which points to a Session object
@@ -204,12 +206,24 @@ class SessionState {
         */
        void setSessionId(uint16_t id) { sessionId = id; }
 
+       /**
+         * Get the dest port name
+         * @return session ID
+         */
+        const string& getDestPort() const { return destPort; }
+
+        /**
+         * Set the dest port name
+         */
+        void setDestPort(const string& port) { destPort = port; }
+
     private:
         URI uri;
         string name;
         uint8_t adminState;
         uint8_t version;
         uint16_t sessionId;
+        string destPort;
 
         srcEpSet srcEndpoints;
         // mapping DstSummary to dst IP

--- a/agent-ovs/lib/test/SimStats_test.cpp
+++ b/agent-ovs/lib/test/SimStats_test.cpp
@@ -16,6 +16,8 @@
 
 namespace opflexagent {
 
+using namespace modelgbp::gbp;
+
 class SimStatsFixture : public BaseFixture {
 public:
     SimStatsFixture() : BaseFixture(), epSource(&agent.getEndpointManager()), simStats(agent) {

--- a/agent-ovs/lib/test/SpanManager_test.cpp
+++ b/agent-ovs/lib/test/SpanManager_test.cpp
@@ -63,15 +63,11 @@ public:
         dstSumm1 = dstMem1->addSpanDstSummary();
         lEp1 = sess->addSpanLocalEp("localEp1");
         lEp1->setName("localEp1");
-        srcMem1->addSpanMemberToRefRSrc()->setTargetLocalEp(lEp1->
-            getURI());
+        srcMem1->addSpanMemberToRefRSrc()->setTargetLocalEp(lEp1->getURI());
         srcMem1->setDir('0');
         srcGrp1->addSpanSrcMember(srcMem1->getName().get());
         srcGrp1->addSpanSrcGrpToFltGrpRSrc(fltGrp1->getName().get())
             ->setTargetFilterGrp("fltGrp1");
-        srcMem2 = srcGrp1->addSpanSrcMember("SrcMem2");
-        srcMem2->addSpanMemberToRefRSrc()->setTargetEpGroup(eg2->getURI());
-        srcMem2->setDir('1');
 
         dstGrp1->addSpanDstMember(dstMem1->getName().get());
         dstSumm1->setDest("192.168.20.100");
@@ -87,14 +83,6 @@ public:
         ep1.setEgURI(eg1->getURI());
         epSource.updateEndpoint(ep1);
 
-        Endpoint ep2("e82e883b-851d-4cc6-bedb-fb5e27530044");
-        ep2.setMAC(MAC("00:00:00:00:00:02"));
-        ep2.addIP("10.1.1.4");
-        ep2.addIP("10.1.1.5");
-        ep2.setInterfaceName("veth2");
-        ep2.setEgURI(eg2->getURI());
-        epSource.updateEndpoint(ep2);
-
         Mutator mutatorElem(framework, "policyelement");
         shared_ptr<L2Universe> l2u = L2Universe::resolve(framework).get();
         l2E1 = l2u->addEprL2Ep(bd->getURI().toString(),
@@ -102,12 +90,6 @@ public:
         l2E1->setUuid(ep1.getUUID());
         l2E1->setGroup(eg1->getURI().toString());
         l2E1->setInterfaceName(ep1.getInterfaceName().get());
-
-        l2e2 = l2u->addEprL2Ep(bd->getURI().toString(),
-                ep2.getMAC().get());
-        l2e2->setUuid(ep2.getUUID());
-        l2e2->setGroup(eg2->getURI().toString());
-        l2e2->setInterfaceName(ep2.getInterfaceName().get());
 
         mutatorElem.commit();
 
@@ -128,9 +110,7 @@ public:
     MockEndpointSource epSource;
     shared_ptr<span::DstSummary> dstSumm1;
     shared_ptr<L2Ep> l2E1;
-    shared_ptr<L2Ep> l2e2;
     shared_ptr<span::SrcMember> srcMem1;
-    shared_ptr<span::SrcMember> srcMem2;
     shared_ptr<span::LocalEp> lEp1;
 };
 
@@ -151,7 +131,7 @@ static bool checkSrcEps(boost::optional<shared_ptr<SessionState>> pSess,
     }
     SessionState::srcEpSet srcEps;
     pSess.get()->getSrcEndpointSet(srcEps);
-    if (srcEps.size() != 2) {
+    if (srcEps.size() != 1) {
         return false;
     }
     auto it = srcEps.begin();
@@ -189,8 +169,6 @@ BOOST_FIXTURE_TEST_CASE( verify_artifacts, SpanFixture ) {
             sess->getURI()), 500);
     WAIT_FOR(checkSrcEps(agent.getSpanManager().getSessionState(sess->getURI()),
             srcMem1, l2E1), 500);
-    WAIT_FOR(checkSrcEps(agent.getSpanManager().getSessionState(sess->getURI()),
-            srcMem2, l2e2), 500);
     WAIT_FOR(checkDst(agent.getSpanManager().getSessionState(sess->getURI()),
             dstSumm1), 500);
     boost::optional<URI> uri("/SpanUniverse/SpanSession/sess1/");

--- a/agent-ovs/ovs/include/SpanRenderer.h
+++ b/agent-ovs/ovs/include/SpanRenderer.h
@@ -19,8 +19,6 @@
 
 namespace opflexagent {
 
-const string ERSPAN_PORT_PREFIX = "erspan-";
-
 /**
  * class to render span config on a virtual switch
  */
@@ -67,16 +65,18 @@ public:
      * @param[in] remoteIp remote destination
      * @param[in] version erspan version
      * @param[in] sessionId ERSPAN session ID
+     * @param[in] outputPortName Output port name
      */
     void createMirrorAndOutputPort(const string& session, const set<string>& srcPorts,
-        const set<string>& dstPorts, const string& remoteIp, const uint8_t version, const uint16_t sessionId);
+        const set<string>& dstPorts, const string& remoteIp, const uint8_t version,
+        const uint16_t sessionId, const string& outputPortName);
 
     /**
      * deletes mirror session
-     * @param[in] session name of session
+     * @param[in] sessionName name of session
      * @return true if success, false otherwise.
      */
-    void deleteMirrorAndOutputPort(const string& session);
+    void deleteMirror(const string& sessionName);
 
 private:
     /**

--- a/agent-ovs/ovs/test/SpanRenderer_test.cpp
+++ b/agent-ovs/ovs/test/SpanRenderer_test.cpp
@@ -20,8 +20,10 @@
 namespace opflexagent {
 
 using namespace std;
-using namespace rapidjson;
 using namespace modelgbp;
+using modelgbp::gbp::DirectionEnumT;
+
+const string ERSPAN_PORT_PREFIX = "erspan-";
 
 BOOST_AUTO_TEST_SUITE(SpanRenderer_test)
 
@@ -36,7 +38,7 @@ public:
 
         // simulate results of monitor
         OvsdbRowDetails rowDetails;
-        std::string uuid = "9b7295f4-07a8-41ac-a681-e0ee82560262";
+        string uuid = "9b7295f4-07a8-41ac-a681-e0ee82560262";
         rowDetails["uuid"] = OvsdbValue(uuid);
         OvsdbTableDetails tableDetails;
         tableDetails["br-int"] = rowDetails;
@@ -113,7 +115,7 @@ public:
 
         OvsdbTableDetails interfaceDetails;
         OvsdbRowDetails interfaceDetail;
-        std::string interfaceUuid = "9b7295f4-07a8-41ac-a681-e0ee82123456";
+        string interfaceUuid = "9b7295f4-07a8-41ac-a681-e0ee82123456";
         interfaceDetail["uuid"] = OvsdbValue(interfaceUuid);
         interfaceDetail["name"] = OvsdbValue(ERSPAN_PORT_PREFIX);
         map<string, string> options;
@@ -149,12 +151,12 @@ static bool verifyCreateDestroy(const shared_ptr<SpanRenderer>& spr, unique_ptr<
     }
 
     string sessionName("abc");
-    spr->deleteMirrorAndOutputPort(sessionName);
+    spr->deleteMirror(sessionName);
 
     set<string> src_ports = {"p1-tap", "p2-tap"};
     set<string> dst_ports = {"p1-tap", "p2-tap"};
     set<string> out_ports = {ERSPAN_PORT_PREFIX};
-    spr->createMirrorAndOutputPort("sess1", src_ports, dst_ports, "10.20.120.240", 1, 1);
+    spr->createMirrorAndOutputPort("sess1", src_ports, dst_ports, "10.20.120.240", 1, 1, ERSPAN_PORT_PREFIX);
     return true;
 }
 
@@ -165,7 +167,7 @@ BOOST_FIXTURE_TEST_CASE( verify_getport, SpanRendererFixture ) {
 BOOST_FIXTURE_TEST_CASE( delete_session, SpanRendererFixture ) {
     URI sessionUri("/SpanUniverse/SpanSession/abc/");
     string sessionName("abc");
-    shared_ptr<SessionState> sessionState = std::make_shared<SessionState>(sessionUri, sessionName);
+    shared_ptr<SessionState> sessionState = make_shared<SessionState>(sessionUri, sessionName);
     spr->spanDeleted(sessionState);
 }
 


### PR DESCRIPTION
Allow output ports to be shared between sessions.

TODO: Need to cleanup output port after last mirror using it is removed
Signed-off-by: Tom Flynn <tom.flynn@gmail.com>