### PR TITLE
Fixing tsan issues while running opflex server: protecting opflex ser…

### DIFF
--- a/libopflex/engine/OpflexListener.cpp
+++ b/libopflex/engine/OpflexListener.cpp
@@ -193,6 +193,7 @@ void OpflexListener::addPendingUpdate(opflex::modb::class_id_t class_id,
                                       const opflex::modb::URI& uri,
                                       opflex::gbp::PolicyUpdateOp op) {
     if (!active) return;
+    const std::lock_guard<std::recursive_mutex> lock(conn_mutex);
     BOOST_FOREACH(OpflexServerConnection* conn, conns) {
         if (conn->getUri(uri))
             conn->addPendingUpdate(class_id, uri, op);
@@ -203,6 +204,7 @@ void OpflexListener::addPendingUpdate(opflex::modb::class_id_t class_id,
 
 void OpflexListener::sendUpdates() {
     if (!active) return;
+    const std::lock_guard<std::recursive_mutex> lock(conn_mutex);
     BOOST_FOREACH(OpflexServerConnection* conn, conns) {
         conn->sendUpdates();
     }
@@ -210,6 +212,7 @@ void OpflexListener::sendUpdates() {
 
 void OpflexListener::sendTimeouts() {
     if (!active) return;
+    const std::lock_guard<std::recursive_mutex> lock(conn_mutex);
     BOOST_FOREACH(OpflexServerConnection* conn, conns) {
         conn->sendTimeouts();
     }


### PR DESCRIPTION
…ver connection set in few cases

WARNING: ThreadSanitizer: data race (pid=24355)
  Read of size 8 at 0x7b0c00012140 by thread T13:
    #0 opflex::engine::internal::OpflexListener::sendTimeouts() /home/noiro/work/opflex/libopflex/engine/OpflexListener.cpp:213 (libopflex.so.0+0x154c70)
    #1 opflex::engine::internal::GbpOpflexServerImpl::on_timer(boost::system::error_code const&) /home/noiro/work/opflex/libopflex/engine/GbpOpflexServer.cpp:146 (libopflex.so.0+0x163808)
    #2 operator() /home/noiro/work/opflex/libopflex/engine/GbpOpflexServer.cpp:119 (libopflex.so.0+0x163dd4)
    #3 operator() /usr/include/boost/asio/detail/bind_handler.hpp:47 (libopflex.so.0+0x163dd4)
    #4 asio_handler_invoke<boost::asio::detail::binder1<opflex::engine::internal::GbpOpflexServerImpl::start()::<lambda(const boost::system::error_code&)>, boost::system::error_code> > /usr/include/boost/asio
/handler_invoke_hook.hpp:69 (libopflex.so.0+0x163dd4)
    #5 invoke<boost::asio::detail::binder1<opflex::engine::internal::GbpOpflexServerImpl::start()::<lambda(const boost::system::error_code&)>, boost::system::error_code>, opflex::engine::internal::GbpOpflexSe
rverImpl::start()::<lambda(const boost::system::error_code&)> > /usr/include/boost/asio/detail/handler_invoke_helpers.hpp:37 (libopflex.so.0+0x163dd4)
    #6 do_complete /usr/include/boost/asio/detail/wait_handler.hpp:70 (libopflex.so.0+0x163dd4)
    #7 boost::asio::detail::task_io_service_operation::complete(boost::asio::detail::task_io_service&, boost::system::error_code const&, unsigned long) /usr/include/boost/asio/detail/task_io_service_operation
.hpp:38 (libopflex.so.0+0x16b292)

  Previous write of size 8 at 0x7b0c00012140 by thread T14 (mutexes: write M620, write M198):
    #9 opflex::engine::internal::OpflexListener::on_new_connection(yajr::Listener*, void*, int) /home/noiro/work/opflex/libopflex/engine/OpflexListener.cpp:162 (libopflex.so.0+0x15589f)
    #10 yajr::comms::internal::ListeningPeer::getConnectionHandlerData() ../include/opflex/yajr/internal/comms.hpp:1116 (libopflex.so.0+0xb98a8)
    #11 yajr::comms::internal::ListeningTcpPeer::getNewPassive() /home/noiro/work/opflex/libopflex/comms/passive_listener.cpp:333 (libopflex.so.0+0xb98a8)
    #12 yajr::comms::internal::on_passive_connection(uv_stream_s*, int) /home/noiro/work/opflex/libopflex/comms/passive_listener.cpp:296 (libopflex.so.0+0xb7074)

  Location is heap block of size 40 at 0x7b0c00012120 allocated by thread T14:
    #9 opflex::engine::internal::OpflexListener::on_new_connection(yajr::Listener*, void*, int) /home/noiro/work/opflex/libopflex/engine/OpflexListener.cpp:162 (libopflex.so.0+0x15589f)
    #10 yajr::comms::internal::ListeningPeer::getConnectionHandlerData() ../include/opflex/yajr/internal/comms.hpp:1116 (libopflex.so.0+0xb98a8)
    #11 yajr::comms::internal::ListeningTcpPeer::getNewPassive() /home/noiro/work/opflex/libopflex/comms/passive_listener.cpp:333 (libopflex.so.0+0xb98a8)
    #12 yajr::comms::internal::on_passive_connection(uv_stream_s*, int) /home/noiro/work/opflex/libopflex/comms/passive_listener.cpp:296 (libopflex.so.0+0xb7074)

SUMMARY: ThreadSanitizer: data race /home/noiro/work/opflex/libopflex/engine/OpflexListener.cpp:213 in opflex::engine::internal::OpflexListener::sendTimeouts()

Signed-off-by: Gautam Venkataramanan <gautam.chennai@gmail.com>