### PR TITLE
Give SNAT higher precedence to routed

### DIFF
--- a/agent-ovs/ovs/IntFlowManager.cpp
+++ b/agent-ovs/ovs/IntFlowManager.cpp
@@ -5409,7 +5409,8 @@ void IntFlowManager::handleRoutingDomainUpdate(const URI& rdURI) {
                         // For external networks mapped to a NAT EPG,
                         // set the next hop action to NAT_OUT
                         if (natEpgVnid) {
-                            snr.action()
+                            snr.priority(151 + extsub->getPrefixLen(0))
+                                .action()
                                 .reg(MFF_REG2, netVnid)
                                 .reg(MFF_REG7, natEpgVnid.get())
                                 .metadata(flow::meta::out::NAT,
@@ -5432,7 +5433,7 @@ void IntFlowManager::handleRoutingDomainUpdate(const URI& rdURI) {
                 }
                 {
                     FlowBuilder snn;
-                    matchSubnet(snn, rdId, 150, addr,
+                    matchSubnet(snn, rdId, 151, addr,
                                 extsub->getPrefixLen(0), true);
                     snn.action()
                         .reg(MFF_REG0, netVnid)

--- a/agent-ovs/ovs/test/IntFlowManager_test.cpp
+++ b/agent-ovs/ovs/test/IntFlowManager_test.cpp
@@ -2551,11 +2551,11 @@ void BaseIntFlowManagerFixture::initExpIpMapping(bool natEpgMap, bool nextHop) {
          .controller(65535).done());
 
     if (natEpgMap) {
-        ADDF(Bldr().table(RT).priority(166).ipv6().reg(RD, 1)
+        ADDF(Bldr().table(RT).priority(167).ipv6().reg(RD, 1)
              .isIpv6Dst("fdf1::/16")
              .actions().load(DEPG, 0x80000001).load(OUTPORT, 0x4242)
              .mdAct(opflexagent::flow::meta::out::NAT).go(POL).done());
-        ADDF(Bldr().table(RT).priority(158).ip().reg(RD, 1)
+        ADDF(Bldr().table(RT).priority(159).ip().reg(RD, 1)
              .isIpDst("5.0.0.0/8")
              .actions().load(DEPG, 0x80000001).load(OUTPORT, 0x4242)
              .mdAct(opflexagent::flow::meta::out::NAT).go(POL).done());
@@ -2570,13 +2570,13 @@ void BaseIntFlowManagerFixture::initExpIpMapping(bool natEpgMap, bool nextHop) {
              .go(STAT).done());
     }
 
-    ADDF(Bldr().table(NAT).priority(166).ipv6().reg(RD, 1)
+    ADDF(Bldr().table(NAT).priority(167).ipv6().reg(RD, 1)
          .isIpv6Src("fdf1::/16").actions()
          .load(SEPG, 0x80000001)
          .meta(opflexagent::flow::meta::out::REV_NAT,
                opflexagent::flow::meta::out::MASK |
                opflexagent::flow::meta::POLICY_APPLIED).go(POL).done());
-    ADDF(Bldr().table(NAT).priority(158).ip().reg(RD, 1)
+    ADDF(Bldr().table(NAT).priority(159).ip().reg(RD, 1)
          .isIpSrc("5.0.0.0/8").actions()
          .load(SEPG, 0x80000001)
          .meta(opflexagent::flow::meta::out::REV_NAT,

--- a/libopflex/engine/Processor.cpp
+++ b/libopflex/engine/Processor.cpp
@@ -130,7 +130,7 @@ void Processor::addRef(obj_state_by_exp::iterator& it,
         LOG(DEBUG2) << "addref " << uit->uri.toString()
                     << " (from " << it->uri.toString() << ")"
                     << " " << uit->details->refcount
-                    << " state " << uit->details->state;
+                    << " state " << ItemStateMap[uit->details->state];
 
         it->details->urirefs.insert(up);
     }
@@ -148,7 +148,7 @@ void Processor::removeRef(obj_state_by_exp::iterator& it,
             LOG(DEBUG2) << "removeref " << uit->uri.toString()
                         << " (from " << it->uri.toString() << ")"
                         << " " << uit->details->refcount
-                        << " state " << uit->details->state;
+                        << " state " << ItemStateMap[uit->details->state];
             if (uit->details->refcount <= 0) {
                 uint64_t nexp = now(proc_loop)+processingDelay;
                 uri_index.modify(uit, Processor::change_expiration(nexp));
@@ -376,7 +376,7 @@ void Processor::processItem(obj_state_by_exp::iterator& it) {
                << " item " << it->uri.toString()
                << " of class " << ci.getName()
                << " and type " << ci.getType()
-               << " in state " << curState;
+               << " in state " << ItemStateMap[curState];
 
     ItemState newState;
 
@@ -523,7 +523,8 @@ void Processor::processItem(obj_state_by_exp::iterator& it) {
             break;
         }
 
-        LOG(DEBUG) << "Purging state for " << it->uri.toString();
+        LOG(DEBUG) << "Purging state for " << it->uri.toString()
+                   << " in state " << ItemStateMap[it->details->state];
         exp_index.erase(it);
     } else {
         it->details->state = newState;

--- a/libopflex/engine/include/opflex/engine/Processor.h
+++ b/libopflex/engine/include/opflex/engine/Processor.h
@@ -324,6 +324,20 @@ private:
         DELETED
     };
 
+    /**
+     * map of ItemState to String
+     */
+    std::map<int, std::string> ItemStateMap = {
+        { NEW, "new" },
+        { UPDATED, "updated" },
+        { IN_SYNC, "in_sync" },
+        { REMOTE, "remote" },
+        { UNRESOLVED, "unresolved" },
+        { RESOLVED, "resolved" },
+        { PENDING_DELETE, "pending_delete" },
+        { DELETED, "deleted" }
+    };
+
     class item_details {
     public:
         /**


### PR DESCRIPTION
- when an RD is associated with two external domains,
  one with SNAT and one without for same subnet the
  behavior is undefined.
- This fix gives SNAT higher precedence.
- Added verbose names to Processer state machine.

Signed-off-by: Madhu Challa <challa@gmail.com>