### PR TITLE
Fix a data race in GbpOpflexServer - protect prr_timer with mutex

### DIFF
--- a/libopflex/engine/include/opflex/engine/internal/GbpOpflexServerImpl.h
+++ b/libopflex/engine/include/opflex/engine/internal/GbpOpflexServerImpl.h
@@ -19,6 +19,7 @@
 #include "opflex/engine/internal/OpflexHandler.h"
 #include "opflex/engine/internal/OpflexServerHandler.h"
 
+#include <mutex>
 #include <thread>
 #include <atomic>
 #include <boost/asio.hpp>
@@ -206,6 +207,7 @@ private:
     std::unique_ptr<boost::asio::deadline_timer> prr_timer;
     std::atomic_bool stopping;
     int prr_interval_secs;
+    std::mutex prr_timer_mutex;
 };
 
 } /* namespace internal */


### PR DESCRIPTION
==================
WARNING: ThreadSanitizer: data race (pid=19679)
  Read of size 1 at 0x7b1000034990 by main thread:
    #0 boost::asio::detail::deadline_timer_service<boost::asio::time_traits<boost::posix_time::ptime> >::cancel(boost::asio::detail::deadline_timer_service<boost::asio::time_traits<boost::posix_time::ptime> >
::implementation_type&, boost::system::error_code&) /usr/include/boost/asio/detail/deadline_timer_service.hpp:100 (libopflex.so.0+0x1630e3)
    #1 boost::asio::deadline_timer_service<boost::posix_time::ptime, boost::asio::time_traits<boost::posix_time::ptime> >::cancel(boost::asio::detail::deadline_timer_service<boost::asio::time_traits<boost::po
six_time::ptime> >::implementation_type&, boost::system::error_code&) /usr/include/boost/asio/deadline_timer_service.hpp:96 (libopflex.so.0+0x1630e3)
    #2 boost::asio::basic_deadline_timer<boost::posix_time::ptime, boost::asio::time_traits<boost::posix_time::ptime>, boost::asio::deadline_timer_service<boost::posix_time::ptime, boost::asio::time_traits<bo
ost::posix_time::ptime> > >::cancel() /usr/include/boost/asio/basic_deadline_timer.hpp:216 (libopflex.so.0+0x1630e3)
    #3 opflex::engine::internal::GbpOpflexServerImpl::stop() /home/noiro/work/opflex/libopflex/engine/GbpOpflexServer.cpp:129 (libopflex.so.0+0x1630e3)
    #4 opflex::test::GbpOpflexServer::stop() /home/noiro/work/opflex/libopflex/engine/GbpOpflexServer.cpp:53 (libopflex.so.0+0x1631f2)
    #5 main server/opflex_server.cpp:297 (opflex_server+0x22fc3)

  Previous write of size 1 at 0x7b1000034990 by thread T12:
    #0 boost::asio::detail::deadline_timer_service<boost::asio::time_traits<boost::posix_time::ptime> >::cancel(boost::asio::detail::deadline_timer_service<boost::asio::time_traits<boost::posix_time::ptime> >
::implementation_type&, boost::system::error_code&) /usr/include/boost/asio/detail/deadline_timer_service.hpp:109 (libopflex.so.0+0x163a50)
    #1 boost::asio::detail::deadline_timer_service<boost::asio::time_traits<boost::posix_time::ptime> >::cancel(boost::asio::detail::deadline_timer_service<boost::asio::time_traits<boost::posix_time::ptime> >
::implementation_type&, boost::system::error_code&) /usr/include/boost/asio/detail/deadline_timer_service.hpp:98 (libopflex.so.0+0x163a50)
    #2 boost::asio::detail::deadline_timer_service<boost::asio::time_traits<boost::posix_time::ptime> >::expires_at(boost::asio::detail::deadline_timer_service<boost::asio::time_traits<boost::posix_time::ptim
e> >::implementation_type&, boost::posix_time::ptime const&, boost::system::error_code&) /usr/include/boost/asio/detail/deadline_timer_service.hpp:144 (libopflex.so.0+0x163a50)
    #3 boost::asio::deadline_timer_service<boost::posix_time::ptime, boost::asio::time_traits<boost::posix_time::ptime> >::expires_at(boost::asio::detail::deadline_timer_service<boost::asio::time_traits<boost
::posix_time::ptime> >::implementation_type&, boost::posix_time::ptime const&, boost::system::error_code&) /usr/include/boost/asio/deadline_timer_service.hpp:116 (libopflex.so.0+0x163a50)
    #4 boost::asio::basic_deadline_timer<boost::posix_time::ptime, boost::asio::time_traits<boost::posix_time::ptime>, boost::asio::deadline_timer_service<boost::posix_time::ptime, boost::asio::time_traits<bo
ost::posix_time::ptime> > >::expires_at(boost::posix_time::ptime const&) /usr/include/boost/asio/basic_deadline_timer.hpp:344 (libopflex.so.0+0x163a50)
    #5 opflex::engine::internal::GbpOpflexServerImpl::on_timer(boost::system::error_code const&) /home/noiro/work/opflex/libopflex/engine/GbpOpflexServer.cpp:149 (libopflex.so.0+0x163a50)
    #6 operator() /home/noiro/work/opflex/libopflex/engine/GbpOpflexServer.cpp:119 (libopflex.so.0+0x163f24)
    #7 operator() /usr/include/boost/asio/detail/bind_handler.hpp:47 (libopflex.so.0+0x163f24)
    #8 asio_handler_invoke<boost::asio::detail::binder1<opflex::engine::internal::GbpOpflexServerImpl::start()::<lambda(const boost::system::error_code&)>, boost::system::error_code> > /usr/include/boost/asio
/handler_invoke_hook.hpp:69 (libopflex.so.0+0x163f24)
    #9 invoke<boost::asio::detail::binder1<opflex::engine::internal::GbpOpflexServerImpl::start()::<lambda(const boost::system::error_code&)>, boost::system::error_code>, opflex::engine::internal::GbpOpflexSe
rverImpl::start()::<lambda(const boost::system::error_code&)> > /usr/include/boost/asio/detail/handler_invoke_helpers.hpp:37 (libopflex.so.0+0x163f24)
    #10 do_complete /usr/include/boost/asio/detail/wait_handler.hpp:70 (libopflex.so.0+0x163f24)
    #11 boost::asio::detail::task_io_service_operation::complete(boost::asio::detail::task_io_service&, boost::system::error_code const&, unsigned long) /usr/include/boost/asio/detail/task_io_service_operatio
n.hpp:38 (libopflex.so.0+0x16b3e2)
    #12 boost::asio::detail::task_io_service::do_run_one(boost::asio::detail::scoped_lock<boost::asio::detail::posix_mutex>&, boost::asio::detail::task_io_service_thread_info&, boost::system::error_code const
&) /usr/include/boost/asio/detail/impl/task_io_service.ipp:372 (libopflex.so.0+0x16b3e2)
    #13 boost::asio::detail::task_io_service::run(boost::system::error_code&) /usr/include/boost/asio/detail/impl/task_io_service.ipp:149 (libopflex.so.0+0x16b3e2)
    #14 boost::asio::io_service::run() /usr/include/boost/asio/impl/io_service.ipp:59 (libopflex.so.0+0x1625ff)
    #15 operator() /home/noiro/work/opflex/libopflex/engine/GbpOpflexServer.cpp:121 (libopflex.so.0+0x1625ff)
    #16 __invoke_impl<void, opflex::engine::internal::GbpOpflexServerImpl::start()::<lambda()> > /usr/include/c++/9/bits/invoke.h:60 (libopflex.so.0+0x1625ff)
    #17 __invoke<opflex::engine::internal::GbpOpflexServerImpl::start()::<lambda()> > /usr/include/c++/9/bits/invoke.h:95 (libopflex.so.0+0x1625ff)
    #18 _M_invoke<0> /usr/include/c++/9/thread:244 (libopflex.so.0+0x1625ff)
    #19 operator() /usr/include/c++/9/thread:251 (libopflex.so.0+0x1625ff)
    #20 _M_run /usr/include/c++/9/thread:195 (libopflex.so.0+0x1625ff)
    #21 <null> <null> (libstdc++.so.6+0xd086f)

Signed-off-by: Gautam Venkataramanan <gautam.chennai@gmail.com>