### PR TITLE
Reducing the number of supported logging levels in libopflex

### DIFF
--- a/agent-ovs/lib/AgentLogHandler.cpp
+++ b/agent-ovs/lib/AgentLogHandler.cpp
@@ -9,8 +9,6 @@
  * and is available at http://www.eclipse.org/legal/epl-v10.html
  */
 
-#include <iostream>
-
 #include <opflexagent/AgentLogHandler.h>
 #include <opflexagent/logging.h>
 
@@ -43,11 +41,7 @@ void AgentLogHandler::handleMessage(const std::string& file,
     case OFLogHandler::TRACE:
         agentLevel = opflexagent::TRACE;
         break;
-    case OFLogHandler::DEBUG4:
-    case OFLogHandler::DEBUG3:
-    case OFLogHandler::DEBUG2:
-    case OFLogHandler::DEBUG1:
-    case OFLogHandler::DEBUG0:
+    case OFLogHandler::DEBUG:
         agentLevel = opflexagent::DEBUG;
         break;
     case OFLogHandler::INFO:

--- a/agent-ovs/lib/logging.cpp
+++ b/agent-ovs/lib/logging.cpp
@@ -161,20 +161,8 @@ void setLoggingLevel(const std::string& newLevelstr) {
     std::transform(levelstr.begin(), levelstr.end(),
                    levelstr.begin(), ::tolower);
 
-    if (levelstr == "debug" || levelstr == "debug0") {
-        level = OFLogHandler::DEBUG0;
-        logLevel = DEBUG;
-    } else if (levelstr == "debug1") {
-        level = OFLogHandler::DEBUG1;
-        logLevel = DEBUG;
-    } else if (levelstr == "debug2") {
-        level = OFLogHandler::DEBUG2;
-        logLevel = DEBUG;
-    } else if (levelstr == "debug3") {
-        level = OFLogHandler::DEBUG3;
-        logLevel = DEBUG;
-    } else if (levelstr == "debug4") {
-        level = OFLogHandler::DEBUG4;
+    if (levelstr == "debug") {
+        level = OFLogHandler::DEBUG;
         logLevel = DEBUG;
     } else if (levelstr == "trace") {
         level = OFLogHandler::TRACE;

--- a/agent-ovs/opflex-agent-ovs.conf.in
+++ b/agent-ovs/opflex-agent-ovs.conf.in
@@ -4,8 +4,7 @@
     //     // Set the log level.
     //     // Possible values in descending order of verbosity:
     //     // "trace" (least level verbose logs"),
-    //     // "debug7"-"debug0", "debug" (synonym for "debug0"),
-    //     // "info", "warning", "error", "fatal"
+    //     // "debug", "info", "warning", "error", "fatal"
     //     // Default: "info"
     //     "level": "info"
     // },

--- a/libopflex/comms/ActivePeer.cpp
+++ b/libopflex/comms/ActivePeer.cpp
@@ -28,7 +28,7 @@ void ActivePeer::destroy(bool now) {
     }
 
     if (alreadyBeingDestroyed) {
-        LOG(DEBUG1) << this << " multiple destroy()s detected";
+        LOG(DEBUG) << this << " multiple destroy()s detected";
         return;
     }
 

--- a/libopflex/comms/ActiveTcpPeer.cpp
+++ b/libopflex/comms/ActiveTcpPeer.cpp
@@ -59,12 +59,7 @@ void ::yajr::comms::internal::ActiveTcpPeer::retry() {
                     getHostname(),
                     getService(),
                     &hints))) {
-        LOG(WARNING)
-            << "uv_getaddrinfo: ["
-            << uv_err_name(rc)
-            << "] "
-            << uv_strerror(rc)
-        ;
+        LOG(WARNING) << "uv_getaddrinfo: [" << uv_err_name(rc) << "] " << uv_strerror(rc);
         onError(rc);
         insert(internal::Peer::LoopData::RETRY_TO_CONNECT);
     } else {

--- a/libopflex/comms/CommunicationPeer.cpp
+++ b/libopflex/comms/CommunicationPeer.cpp
@@ -78,7 +78,7 @@ void CommunicationPeer::startKeepAlive(
         uint64_t begin,
         uint64_t repeat,
         uint64_t interval) {
-    LOG(DEBUG1) << this << " interval=" << interval << " begin=" << begin << " repeat=" << repeat;
+    LOG(DEBUG) << this << " interval=" << interval << " begin=" << begin << " repeat=" << repeat;
 
     sendEchoReq();
     bumpLastHeard();
@@ -88,7 +88,7 @@ void CommunicationPeer::startKeepAlive(
 }
 
 void CommunicationPeer::stopKeepAlive() {
-    LOG(DEBUG1)<< this;
+    LOG(DEBUG)<< this;
     uv_timer_stop(&keepAliveTimer_);
     keepAliveInterval_ = 0;
 }
@@ -106,7 +106,7 @@ void CommunicationPeer::onConnect() {
     status_ = internal::Peer::kPS_ONLINE;
 
     keepAliveTimer_.data = this;
-    LOG(DEBUG1) << this << " up() for a timer init";
+    LOG(DEBUG) << this << " up() for a timer init";
     up();
     uv_timer_init(getUvLoop(), &keepAliveTimer_);
     uv_unref((uv_handle_t*) &keepAliveTimer_);
@@ -119,7 +119,7 @@ void CommunicationPeer::onConnect() {
 }
 
 void CommunicationPeer::onDisconnect() {
-    LOG(DEBUG1) << this << " connected_ = " << connected_;
+    LOG(DEBUG) << this << " connected_ = " << connected_;
     if (!uv_is_closing(getHandle())) {
         uv_close(getHandle(), on_close);
     }
@@ -145,17 +145,17 @@ void CommunicationPeer::onDisconnect() {
     unlink();
 
     if (destroying_) {
-        LOG(DEBUG2) << this << " already destroying";
+        LOG(DEBUG) << this << " already destroying";
         return;
     }
 
     if (!passive_) {
-        LOG(DEBUG2) << this << " active => retry queue";
+        LOG(DEBUG) << this << " active => retry queue";
         /* we should attempt to reconnect later */
         insert(internal::Peer::LoopData::RETRY_TO_CONNECT);
         status_ = kPS_DISCONNECTED;
     } else {
-        LOG(DEBUG2) << this << " passive => eventually drop";
+        LOG(DEBUG) << this << " passive => eventually drop";
         /* whoever it was, hopefully will reconnect again */
         insert(internal::Peer::LoopData::PENDING_DELETE);
         status_ = kPS_PENDING_DELETE;
@@ -339,7 +339,7 @@ void CommunicationPeer::timeout() {
 
     if (uvRefCnt_ == 1) {
         /* we already have a pending close */
-        LOG(DEBUG4) << this << " Already closing";
+        LOG(TRACE) << this << " Already closing";
         return;
     }
 

--- a/libopflex/comms/common.cpp
+++ b/libopflex/comms/common.cpp
@@ -29,9 +29,7 @@ int ::yajr::initLoop(uv_loop_t * loop) {
 
 void ::yajr::finiLoop(uv_loop_t * loop) {
     LOG(INFO);
-
     static_cast< ::yajr::comms::internal::Peer::LoopData *>(loop->data)->destroy();
-
 }
 
 
@@ -61,7 +59,6 @@ using namespace yajr::comms::internal;
 namespace internal {
 
 char const * getUvHandleType(uv_handle_t * h) {
-
     char const * type;
 
     switch (h->type) {
@@ -74,11 +71,9 @@ char const * getUvHandleType(uv_handle_t * h) {
     }
 
     return type;
-
 }
 
 char const * getUvHandleField(uv_handle_t * h, internal::Peer * peer) {
-
     char const * hType = "???";
 
     if (h == reinterpret_cast< uv_handle_t * >(&peer->keepAliveTimer_)) {
@@ -90,11 +85,9 @@ char const * getUvHandleField(uv_handle_t * h, internal::Peer * peer) {
     }
 
     return hType;
-
 }
 
 void on_close(uv_handle_t * h) {
-
     if (!h) {
         LOG(ERROR) << "NULL handle";
         return;
@@ -102,18 +95,11 @@ void on_close(uv_handle_t * h) {
 
     CommunicationPeer * peer = Peer::get<CommunicationPeer>(h);
 
-    LOG(DEBUG1)
-        << peer
-        << " down() for an on_close("
-        << static_cast< void * >(h)
-        <<") "
-        << getUvHandleField(h, peer)
-        << " handle of type "
-        << getUvHandleType(h)
-    ;
+    LOG(DEBUG) << peer << " down() for an on_close("
+        << static_cast< void * >(h) <<") " << getUvHandleField(h, peer)
+        << " handle of type " << getUvHandleType(h);
 
     peer->choked_ = 1;
-
     peer->down();
 }
 

--- a/libopflex/comms/include/yajr/rpc/methods.hpp
+++ b/libopflex/comms/include/yajr/rpc/methods.hpp
@@ -121,7 +121,7 @@ namespace yajr {
                 )
                 : InboundError(peer, params, id)
                 {
-                    LOG(DEBUG3) << M->s;
+                    LOG(TRACE) << M->s;
                 }
 
             virtual void process() const;

--- a/libopflex/comms/loopdata.cpp
+++ b/libopflex/comms/loopdata.cpp
@@ -28,9 +28,7 @@ namespace yajr {
     namespace comms {
         namespace internal {
 
-std::ostream& operator << (
-        std::ostream& os,
-        Peer::LoopData const * lD);
+std::ostream& operator << (std::ostream& os, Peer::LoopData const * lD);
 
 
 void internal::Peer::LoopData::onPrepareLoop() {
@@ -83,11 +81,7 @@ void internal::Peer::LoopData::onPrepareLoop() {
 
     if ((now - lastRun_ > 15000) && !peers[RETRY_TO_LISTEN].empty()) {
 
-        LOG(INFO)
-            << "retrying all "
-            << peers[RETRY_TO_LISTEN].size()
-            << "RETRY_TO_LISTEN peers"
-        ;
+        LOG(INFO) << "retrying all " << peers[RETRY_TO_LISTEN].size() << "RETRY_TO_LISTEN peers";
 
         /* retry all listeners */
         peers[RETRY_TO_LISTEN]
@@ -102,7 +96,7 @@ prepared:
         /* We need to make sure we unblock */
 
         if (!uv_is_active((uv_handle_t *)&prepareAgain_)) {
-            LOG(DEBUG4) << " Starting prepareAgain_ @" << reinterpret_cast<void *>(&prepareAgain_);
+            LOG(TRACE) << " Starting prepareAgain_ @" << reinterpret_cast<void *>(&prepareAgain_);
         } // else we are just pushing it out in time :)
         uv_timer_start(&prepareAgain_, prepareAgainCB, 1250, 0);
     }
@@ -137,14 +131,7 @@ void internal::Peer::LoopData::destroy(bool now) {
 }
 
 std::ostream& operator << (std::ostream& os, Peer::LoopData const * lD) {
-    return os
-        << "{"
-        << reinterpret_cast<void const *>(lD)
-        << "}"
-        << "["
-        << lD->refCount_
-        << "]"
-    ;
+    return os << "{" << reinterpret_cast<void const *>(lD) << "}[" << lD->refCount_ << "]";
 }
 
 void internal::Peer::LoopData::walkAndCloseHandlesCb(
@@ -170,7 +157,6 @@ void internal::Peer::LoopData::walkAndCloseHandlesCb(
         << reinterpret_cast<void const *>(h);
 
     uv_close(h, closeHandle->closeCb);
-
 }
 
 
@@ -204,37 +190,25 @@ void internal::Peer::LoopData::walkAndCountHandlesCb(
 
     /** we assert() here, but everything will be cleaned up in production code */
     assert(uv_is_closing(h));
-
 }
 
-void Peer::LoopData::RetryPeer::operator () (Peer *peer)
-{
+void Peer::LoopData::RetryPeer::operator () (Peer *peer) {
     peer->retry();
 }
 
-void Peer::LoopData::PeerDeleter::operator () (Peer *peer)
-{
-    LOG(DEBUG1) << peer << " deleting abruptedly";
+void Peer::LoopData::PeerDeleter::operator () (Peer *peer) {
+    LOG(DEBUG) << peer << " deleting abruptedly";
     assert(!"peers should never get deleted this way");
     delete peer;
 }
 
 void Peer::LoopData::up() {
-    LOG(DEBUG2)
-        << this
-        << " LoopRefCnt: "
-        << refCount_
-        << " -> "
-        << refCount_ + 1
-    ;
-
+    LOG(DEBUG) << this << " LoopRefCnt: " << refCount_ << " -> " << refCount_ + 1;
     ++refCount_;
 }
 
 void Peer::LoopData::down() {
-
     assert(refCount_);
-
     --refCount_;
 
     if (destroying_ && !refCount_) {
@@ -244,8 +218,7 @@ void Peer::LoopData::down() {
 }
 
 Peer::LoopData::~LoopData() {
-
-    LOG(DEBUG1) << this << " is being deleted" ;
+    LOG(DEBUG) << this << " is being deleted" ;
 
     const std::lock_guard<std::recursive_mutex> lock(peerMutex);
     for (size_t i=0; i < Peer::LoopData::TOTAL_STATES; ++i) {
@@ -256,8 +229,7 @@ Peer::LoopData::~LoopData() {
     }
 }
 
-void Peer::LoopData::PeerDisposer::operator () (Peer *peer)
-{
+void Peer::LoopData::PeerDisposer::operator () (Peer *peer) {
     LOG(INFO) << peer << " destroy() because this communication thread is shutting down";
     peer->destroy(now_);
 }

--- a/libopflex/comms/passive_listener.cpp
+++ b/libopflex/comms/passive_listener.cpp
@@ -101,7 +101,7 @@
         ::yajr::Peer::UvLoopSelector uvLoopSelector
     ) {
 
-    LOG(DEBUG1) << socketName;
+    LOG(DEBUG) << socketName;
 
     ::yajr::comms::internal::ListeningUnixPeer * peer = NULL;
 #if __cpp_exceptions || __EXCEPTIONS
@@ -187,7 +187,7 @@ void ::yajr::comms::internal::ListeningTcpPeer::retry() {
     return;
 
 failed_after_init:
-    LOG(DEBUG1) << "closing tcp handle because of immediate failure after init";
+    LOG(DEBUG) << "closing tcp handle because of immediate failure after init";
     uv_close(getHandle(), on_close);
 
 failed_tcp_init:
@@ -255,7 +255,7 @@ void ::yajr::comms::internal::ListeningUnixPeer::retry() {
     return;
 
 failed_after_init:
-    LOG(DEBUG1) << "closing pipe handle because of immediate failure after init";
+    LOG(DEBUG) << "closing pipe handle because of immediate failure after init";
     uv_close(getHandle(), on_close);
 
 failed_unix_init:
@@ -299,12 +299,7 @@ void on_passive_connection(uv_stream_t * server_handle, int status)
 
     int rc;
     if ((rc = uv_accept(server_handle, (uv_stream_t*) peer->getHandle()))) {
-        LOG(DEBUG1)
-            << "uv_accept: ["
-            << uv_err_name(rc)
-            << "] "
-            << uv_strerror(rc)
-        ;
+        LOG(DEBUG) << "uv_accept: [" << uv_err_name(rc) << "] " << uv_strerror(rc);
         peer->onError(rc);
         uv_close(peer->getHandle(), on_close);
         return;

--- a/libopflex/comms/peer.cpp
+++ b/libopflex/comms/peer.cpp
@@ -77,12 +77,12 @@ bool Peer::down() {
 std::recursive_mutex Peer::LoopData::peerMutex{};
 
 void Peer::insert(Peer::LoopData::PeerState peerState) {
-    LOG(DEBUG3) << this << " is being inserted in " << peerState;
+    LOG(TRACE) << this << " is being inserted in " << peerState;
     Peer::LoopData::addPeer(getUvLoop(), peerState, this);
 }
 
 void Peer::unlink() {
-    LOG(DEBUG4) << this << " manually unlinking";
+    LOG(TRACE) << this << " manually unlinking";
     SafeListBaseHook::unlink();
 }
 

--- a/libopflex/comms/test/comms_test.cpp
+++ b/libopflex/comms/test/comms_test.cpp
@@ -80,7 +80,7 @@ struct CommsTests {
 
 };
 
-opflex::logging::StdOutLogHandler CommsTests::commsTestLogger_(DEBUG4);
+opflex::logging::StdOutLogHandler CommsTests::commsTestLogger_(TRACE);
 
 BOOST_GLOBAL_FIXTURE( CommsTests );
 
@@ -283,7 +283,7 @@ class CommsFixture {
 
         if (oldDbgLog != newDbgLog) {
             oldDbgLog = newDbgLog;
-            LOG(DEBUG3)  << newDbgLog;
+            LOG(TRACE)  << newDbgLog;
         }
 
         return std::make_pair(final_peers, transient_peers);

--- a/libopflex/comms/transport/PlainText.cpp
+++ b/libopflex/comms/transport/PlainText.cpp
@@ -35,7 +35,7 @@ int Cb< PlainText >::send_cb(CommunicationPeer * peer) {
 
     if (!peer->getPendingBytes()) {
         /* great success! */
-        LOG(DEBUG4) << "Nothing left to be sent!";
+        LOG(TRACE) << "Nothing left to be sent!";
         return 0;
     }
 
@@ -73,7 +73,7 @@ void Cb< PlainText >::on_read(uv_stream_t * h, ssize_t nread, uv_buf_t const * b
     }
 
     if (nread < 0) {
-        LOG(DEBUG2)
+        LOG(DEBUG)
             << peer << " nread = " <<  nread << " ["
             << uv_err_name(nread) << "] "
             << uv_strerror(nread) << " => closing";

--- a/libopflex/comms/transport/ZeroCopyOpenSSL.cpp
+++ b/libopflex/comms/transport/ZeroCopyOpenSSL.cpp
@@ -112,7 +112,7 @@ ssize_t Cb< ZeroCopyOpenSSL >::StaticHelpers::tryToDecrypt(
         peer->onDisconnect();
     }
 
-    LOG(totalRead ? DEBUG4 : DEBUG3) << peer << " Returning: " << (totalRead ?: nread);
+    LOG(TRACE) << peer << " Returning: " << (totalRead ?: nread);
     /* short-circuit a single non-positive nread */
     return totalRead ?: nread;
 }
@@ -122,13 +122,13 @@ ssize_t Cb< ZeroCopyOpenSSL >::StaticHelpers::tryToEncrypt(
 
     assert(!peer->getPendingBytes());
     if (peer->getPendingBytes()) {
-        LOG(DEBUG3) << peer << " has already got pending bytes. Should have not tried!";
+        LOG(TRACE) << peer << " has already got pending bytes. Should have not tried!";
         return 0;
     }
 
     /* we have to encrypt the plaintext data, if any is available */
     if (peer->getStringQueue().deque_.empty()) {
-        LOG(DEBUG4) << peer << " has no data to send";
+        LOG(TRACE) << peer << " has no data to send";
         return 0;
     }
 
@@ -200,7 +200,7 @@ int Cb< ZeroCopyOpenSSL >::StaticHelpers::tryToSend(
             e->bioExternal_,
             (char**)&buf.iov_base);
 
-    LOG(DEBUG4) << peer << ": " << nread << " bytes to be sent";
+    LOG(TRACE) << peer << ": " << nread << " bytes to be sent";
 
     if (nread <= 0) {
         return 0;
@@ -341,30 +341,15 @@ void Cb< ZeroCopyOpenSSL >::on_read(
         bool giveUp = false;
 
         if (whereTheWriteShouldHaveStarted != buf->base) {
-
-            LOG(ERROR)
-                << peer
-                << "unexpected discrepancy: buf->base = "
-                << buf->base
-                << " whereTheWriteShouldHaveStarted = "
-                << whereTheWriteShouldHaveStarted
-                << " will disconnect"
-            ;
-
+            LOG(ERROR) << peer << "unexpected discrepancy: buf->base = "
+                << buf->base << " whereTheWriteShouldHaveStarted = "
+                << whereTheWriteShouldHaveStarted << " will disconnect";
             giveUp = true;
         }
 
         if (advancement != nread) {
-
-            LOG(ERROR)
-                << peer
-                << "unexpected discrepancy: nread = "
-                << nread
-                << " advancement = "
-                << advancement
-                << " will disconnect"
-            ;
-
+            LOG(ERROR) << peer << "unexpected discrepancy: nread = "
+                << nread << " advancement = " << advancement << " will disconnect";
             giveUp = true;
         }
 
@@ -385,29 +370,21 @@ void Cb< ZeroCopyOpenSSL >::on_read(
                 (void) Cb< ZeroCopyOpenSSL >::StaticHelpers::tryToSend(peer);
 
                 if (peer->getPendingBytes()) {
-                    LOG(DEBUG4) << peer << " Retried to send and emitted " << peer->getPendingBytes() << " bytes";
+                    LOG(TRACE) << peer << " Retried to send and emitted " << peer->getPendingBytes() << " bytes";
                     return;
                 }
 
-                if (Cb< ZeroCopyOpenSSL >::StaticHelpers::
-                        tryToEncrypt(peer)) {
+                if (Cb< ZeroCopyOpenSSL >::StaticHelpers::tryToEncrypt(peer)) {
                     /* kick the can */
-                    (void) Cb< ZeroCopyOpenSSL >::StaticHelpers::
-                        tryToSend(peer);
+                    (void) Cb< ZeroCopyOpenSSL >::StaticHelpers::tryToSend(peer);
 
-                    LOG(DEBUG4)
-                        << peer
-                        << " Found no handshake data,"
-                           " but found actual payload and sent "
-                        << peer->getPendingBytes()
-                        << " bytes"
-                    ;
+                    LOG(TRACE) << peer << " Found no handshake data,"
+                        << " but found actual payload and sent "
+                        << peer->getPendingBytes() << " bytes";
                 }
             }
         }
-
     }
-
 }
 
 #if (OPENSSL_VERSION_NUMBER < 0x10100000L)
@@ -455,17 +432,11 @@ void ZeroCopyOpenSSL::lockingCallback(
 #endif
 
 int ZeroCopyOpenSSL::initOpenSSL(bool forMultipleThreads) {
-
     LOG(INFO);
 #if (OPENSSL_VERSION_NUMBER < 0x10100000L)
     assert(!rwlock);
-
     if (rwlock) {
-
-        LOG(ERROR)
-            << "OpenSSL was already initialized"
-        ;
-
+        LOG(ERROR) << "OpenSSL was already initialized";
         return UV_EEXIST;
     }
     SSL_library_init();
@@ -477,15 +448,9 @@ int ZeroCopyOpenSSL::initOpenSSL(bool forMultipleThreads) {
 #if (OPENSSL_VERSION_NUMBER < 0x10100000L)
     OpenSSL_add_all_algorithms();
     if (forMultipleThreads) {
-
         rwlock = new (std::nothrow) uv_rwlock_t[CRYPTO_num_locks()];
-
         if (!rwlock) {
-
-            LOG(ERROR)
-                << "Unable to allocate rwlock's for OpenSSL"
-            ;
-
+            LOG(ERROR) << "Unable to allocate rwlock's for OpenSSL";
             return UV_ENOMEM;
         }
 
@@ -494,7 +459,6 @@ int ZeroCopyOpenSSL::initOpenSSL(bool forMultipleThreads) {
         }
 
         CRYPTO_set_locking_callback(lockingCallback);
-
     }
 #endif
     return 0;
@@ -503,9 +467,7 @@ int ZeroCopyOpenSSL::initOpenSSL(bool forMultipleThreads) {
 #include <openssl/conf.h>
 #include <openssl/engine.h>
 void ZeroCopyOpenSSL::finiOpenSSL() {
-
     LOG(INFO);
-
 #if (OPENSSL_VERSION_NUMBER < 0x10100000L)
     if (rwlock) {
 
@@ -569,13 +531,9 @@ ZeroCopyOpenSSL::ZeroCopyOpenSSL(ZeroCopyOpenSSL::Ctx * ctx, bool passive)
 #endif
 
     if (passive) {
-
         SSL_set_accept_state(ssl_);
-
     } else {
-
         SSL_set_connect_state(ssl_);
-
     }
 
     /* This is the best way I found to do nothing visible yet trigger the SSL
@@ -585,11 +543,9 @@ ZeroCopyOpenSSL::ZeroCopyOpenSSL(ZeroCopyOpenSSL::Ctx * ctx, bool passive)
      */
     BIO_read (bioSSL_, reinterpret_cast< void * >(1), 0);
     BIO_write(bioSSL_, reinterpret_cast< void * >(1), 0);
-
 }
 
 ZeroCopyOpenSSL::~ZeroCopyOpenSSL() {
-
     if (bioSSL_) {
         BIO_free_all(bioSSL_);
     }
@@ -597,17 +553,15 @@ ZeroCopyOpenSSL::~ZeroCopyOpenSSL() {
     if (bioExternal_) {
         BIO_free_all(bioExternal_);
     }
-
 }
 
 void ZeroCopyOpenSSL::infoCallback(SSL const *, int where, int ret) {
-
     switch (where) {
         case SSL_CB_HANDSHAKE_START:
-            LOG(DEBUG2) << " Handshake start!";
+            LOG(DEBUG) << " Handshake start!";
             break;
         case SSL_CB_HANDSHAKE_DONE:
-            LOG(DEBUG2) << " Handshake done!";
+            LOG(DEBUG) << " Handshake done!";
             break;
     }
 }
@@ -845,12 +799,9 @@ ZeroCopyOpenSSL::Ctx * ZeroCopyOpenSSL::Ctx::createCtx(
         }
 
         if (failure) {
-
             delete ctx;
             ctx = NULL;
-
         } else {
-
             SSL_CTX_set_info_callback(sslCtx, infoCallback);
 
             /* just ask for a certificate from the peer anyway */
@@ -861,9 +812,7 @@ ZeroCopyOpenSSL::Ctx * ZeroCopyOpenSSL::Ctx::createCtx(
 
             /* GREAT SUCCESS! */
             return ctx;
-
         }
-
     }
 
     assert(!ctx);

--- a/libopflex/cwrapper/ofloghandler.cpp
+++ b/libopflex/cwrapper/ofloghandler.cpp
@@ -24,32 +24,15 @@ static int getLevel(OFLogHandler::Level level) {
     switch (level) {
     case OFLogHandler::FATAL:
         return LOG_FATAL;
-        break;
     case OFLogHandler::ERROR:
         return LOG_ERROR;
-        break;
     case OFLogHandler::WARNING:
         return LOG_WARNING;
-        break;
     case OFLogHandler::INFO:
         return LOG_INFO;
-        break;
-    case OFLogHandler::DEBUG1:
-        return LOG_DEBUG1;
-        break;
-    case OFLogHandler::DEBUG2:
-        return LOG_DEBUG2;
-        break;
-    case OFLogHandler::DEBUG3:
-        return LOG_DEBUG3;
-        break;
-    case OFLogHandler::DEBUG4:
-        return LOG_DEBUG4;
-        break;
     case OFLogHandler::TRACE:
     default:
         return LOG_TRACE;
-        break;
     }
 }
 
@@ -57,32 +40,15 @@ static OFLogHandler::Level getLevel(int level) {
     switch (level) {
     case LOG_INFO:
         return OFLogHandler::INFO;
-        break;
     case LOG_WARNING:
         return OFLogHandler::WARNING;
-        break;
     case LOG_ERROR:
         return OFLogHandler::ERROR;
-        break;
     case LOG_FATAL:
         return OFLogHandler::FATAL;
-        break;
-    case LOG_DEBUG1:
-        return OFLogHandler::DEBUG1;
-        break;
-    case LOG_DEBUG2:
-        return OFLogHandler::DEBUG2;
-        break;
-    case LOG_DEBUG3:
-        return OFLogHandler::DEBUG3;
-        break;
-    case LOG_DEBUG4:
-        return OFLogHandler::DEBUG4;
-        break;
     case LOG_TRACE:
     default:
         return OFLogHandler::TRACE;
-        break;
     }
 }
 
@@ -90,7 +56,7 @@ static OFLogHandler::Level getLevel(int level) {
 class COFLogHandler : public OFLogHandler {
 public:
     COFLogHandler(Level level, loghandler_p callback_)
-        : OFLogHandler(DEBUG1), callback(callback_) {}
+        : OFLogHandler(level), callback(callback_) {}
 
     virtual ~COFLogHandler() {}
 

--- a/libopflex/cwrapper/test/cwrapper_test.cpp
+++ b/libopflex/cwrapper/test/cwrapper_test.cpp
@@ -119,7 +119,7 @@ void peerstatus_health(void* user_data,
 }
 
 BOOST_FIXTURE_TEST_CASE( init, ServerFixture ) {
-    ofloghandler_register(LOG_DEBUG1, handler);
+    ofloghandler_register(LOG_DEBUG, handler);
 
     offramework_p framework = NULL;
     ofpeerstatuslistener_p peer_listener = NULL;

--- a/libopflex/engine/MOSerializer.cpp
+++ b/libopflex/engine/MOSerializer.cpp
@@ -276,7 +276,7 @@ void MOSerializer::deserialize(const rapidjson::Value& mo,
                                                          *notifs);
                         }
                     } else {
-                        LOG(DEBUG2) << "No parent present for "
+                        LOG(DEBUG) << "No parent present for "
                                     << uri.toString();
                     }
                 } catch (const std::out_of_range& e) {
@@ -334,7 +334,7 @@ void MOSerializer::deserialize(const rapidjson::Value& mo,
         }
 
         if (remoteUpdated) {
-            LOG(DEBUG2) << "Updated object " << uri;
+            LOG(DEBUG) << "Updated object " << uri;
             if (notifs)
                 client.queueNotification(ci.getId(), uri, *notifs);
             PolicyUpdateOp op = replaceChildren ? PolicyUpdateOp::REPLACE

--- a/libopflex/engine/Processor.cpp
+++ b/libopflex/engine/Processor.cpp
@@ -118,19 +118,17 @@ void Processor::addRef(obj_state_by_exp::iterator& it,
         obj_state_by_uri::iterator uit = uri_index.find(up.second);
 
         if (uit == uri_index.end()) {
-            LOG(DEBUG2) << "Tracking new nonlocal item "
-                        << up.second << " from reference";
-
+            LOG(DEBUG) << "Tracking new nonlocal item " << up.second << " from reference";
             obj_state.insert(item(up.second, up.first,
                                   0, policyRefTimerDuration,
                                   UNRESOLVED, false));
             uit = uri_index.find(up.second);
         }
         uit->details->refcount += 1;
-        LOG(DEBUG2) << "addref " << uit->uri.toString()
-                    << " (from " << it->uri.toString() << ")"
-                    << " " << uit->details->refcount
-                    << " state " << uit->details->state;
+        LOG(DEBUG) << "addref " << uit->uri.toString()
+                   << " (from " << it->uri.toString() << ")"
+                   << " " << uit->details->refcount
+                   << " state " << uit->details->state;
 
         it->details->urirefs.insert(up);
     }
@@ -145,10 +143,10 @@ void Processor::removeRef(obj_state_by_exp::iterator& it,
         obj_state_by_uri::iterator uit = uri_index.find(up.second);
         if (uit != uri_index.end()) {
             uit->details->refcount -= 1;
-            LOG(DEBUG2) << "removeref " << uit->uri.toString()
-                        << " (from " << it->uri.toString() << ")"
-                        << " " << uit->details->refcount
-                        << " state " << uit->details->state;
+            LOG(DEBUG) << "removeref " << uit->uri.toString()
+                       << " (from " << it->uri.toString() << ")"
+                       << " " << uit->details->refcount
+                       << " state " << uit->details->state;
             if (uit->details->refcount <= 0) {
                 uint64_t nexp = now(proc_loop)+processingDelay;
                 uri_index.modify(uit, Processor::change_expiration(nexp));
@@ -275,7 +273,7 @@ bool Processor::resolveObj(ClassInfo::class_type_t type, const item& i,
     switch (type) {
     case ClassInfo::POLICY:
         {
-            LOG(DEBUG2) << "Resolving policy " << i.uri;
+            LOG(DEBUG) << "Resolving policy " << i.uri;
             i.details->resolve_time = curTime;
             vector<reference_t> refs;
             refs.emplace_back(i.details->class_id, i.uri);
@@ -338,7 +336,7 @@ bool Processor::declareObj(ClassInfo::class_type_t type, const item& i,
         return true;
     case ClassInfo::OBSERVABLE:
         if (isParentSyncObject(i) && reportObservables && isObservableReportable(i.details->class_id)) {
-            LOG(DEBUG3) << "Declaring local observable " << i.uri;
+            LOG(TRACE) << "Declaring local observable " << i.uri;
             i.details->resolve_time = curTime;
             vector<reference_t> refs;
             refs.emplace_back(i.details->class_id, i.uri);
@@ -372,7 +370,7 @@ void Processor::processItem(obj_state_by_exp::iterator& it) {
     }
 
     const ClassInfo& ci = store->getClassInfo(it->details->class_id);
-    LOG(DEBUG2) << "Processing " << (local ? "local" : "nonlocal")
+    LOG(DEBUG) << "Processing " << (local ? "local" : "nonlocal")
                << " item " << it->uri.toString()
                << " of class " << ci.getName()
                << " and type " << ci.getType()
@@ -416,8 +414,7 @@ void Processor::processItem(obj_state_by_exp::iterator& it) {
             {
                 // requeue new items so if there are any pending references
                 // we won't remove them right away
-                LOG(DEBUG2) << "Queuing delete for orphan "
-                            << it->uri.toString();
+                LOG(DEBUG) << "Queuing delete for orphan " << it->uri.toString();
                 newState = PENDING_DELETE;
                 newexp = now(proc_loop) + processingDelay;
                 obj_state_by_exp& exp_index = obj_state.get<expiration_tag>();
@@ -490,7 +487,7 @@ void Processor::processItem(obj_state_by_exp::iterator& it) {
         switch (ci.getType()) {
         case ClassInfo::POLICY:
             if (it->details->resolve_time > 0) {
-                LOG(DEBUG2) << "Unresolving " << it->uri.toString();
+                LOG(DEBUG) << "Unresolving " << it->uri.toString();
                 vector<reference_t> refs;
                 refs.emplace_back(it->details->class_id, it->uri);
                 PolicyUnresolveReq* req =
@@ -649,9 +646,8 @@ void Processor::objectUpdated(modb::class_id_t class_id,
 
     if (uit == uri_index.end()) {
         if (present) {
-            LOG(DEBUG2) << "Tracking new "
-                        << (local ? "local" : "nonlocal")
-                        << " item " << uri << " from update";
+            LOG(DEBUG) << "Tracking new " << (local ? "local" : "nonlocal")
+                       << " item " << uri << " from update";
             uint64_t nexp = 0;
             if (local) nexp = curtime+processingDelay;
             double prrRange1 = prrTimerDuration/3;

--- a/libopflex/engine/test/main.cpp
+++ b/libopflex/engine/test/main.cpp
@@ -21,6 +21,6 @@ public:
     static StdOutLogHandler testLogger;
 };
 
-StdOutLogHandler EngineTest::testLogger(OFLogHandler::DEBUG2);
+StdOutLogHandler EngineTest::testLogger(OFLogHandler::DEBUG);
 
 BOOST_GLOBAL_FIXTURE(EngineTest);

--- a/libopflex/include/opflex/c/ofloghandler_c.h
+++ b/libopflex/include/opflex/c/ofloghandler_c.h
@@ -62,24 +62,9 @@ typedef void (*loghandler_p)(const char* file, int line,
 #define LOG_TRACE 10
 
 /**
- * Debug4 (lowest debug) log level
+ * Debug log level
  */
-#define LOG_DEBUG4 20
-
-/**
- * Debug 3 log level
- */
-#define LOG_DEBUG3 30
-
-/**
- * Debug 2 log level
- */
-#define LOG_DEBUG2 40
-
-/**
- * Debug 1 (highest debug) log level
- */
-#define LOG_DEBUG1 50
+#define LOG_DEBUG 50
 
 /**
  * Info log level

--- a/libopflex/include/opflex/logging/OFLogHandler.h
+++ b/libopflex/include/opflex/logging/OFLogHandler.h
@@ -57,11 +57,7 @@ public:
      */
     enum Level {
         TRACE,
-        DEBUG4,
-        DEBUG3,
-        DEBUG2,
-        DEBUG1,
-        DEBUG0,
+        DEBUG,
         INFO,
         WARNING,
         ERROR,

--- a/libopflex/logging/include/opflex/logging/internal/logging.hpp
+++ b/libopflex/logging/include/opflex/logging/internal/logging.hpp
@@ -67,34 +67,9 @@ private:
 #define TRACE opflex::logging::OFLogHandler::TRACE
 
 /**
- * Convenience macro for debug log level 0
+ * Convenience macro for debug log level
  */
-#define DEBUG0 opflex::logging::OFLogHandler::DEBUG0
-
-/**
- * Convenience macro for debug log level 1
- */
-#define DEBUG1 opflex::logging::OFLogHandler::DEBUG1
-
-/**
- * Alias for DEBUG0
- */
-#define DEBUG DEBUG0
-
-/**
- * Convenience macro for debug log level 2
- */
-#define DEBUG2 opflex::logging::OFLogHandler::DEBUG2
-
-/**
- * Convenience macro for debug log level 3
- */
-#define DEBUG3 opflex::logging::OFLogHandler::DEBUG3
-
-/**
- * Convenience macro for debug log level 4
- */
-#define DEBUG4 opflex::logging::OFLogHandler::DEBUG4
+#define DEBUG opflex::logging::OFLogHandler::DEBUG
 
 /**
  * Convenience macro for info log level


### PR DESCRIPTION
This matches the levels defined in agent-ovs

Existing logs have been remapped
DEBUG3/DEBUG4 -> TRACE
DEBUG1/DEBUG2 -> DEBUG

Signed-off-by: Tom Flynn <tom.flynn@gmail.com>