### PR TITLE
Fix for lock order inversion between uri_map_mutex and conn_mutex

### DIFF
--- a/libopflex/engine/OpflexListener.cpp
+++ b/libopflex/engine/OpflexListener.cpp
@@ -185,6 +185,8 @@ void OpflexListener::sendToAll(OpflexMessage* message) {
 void OpflexListener::sendToOne(OpflexServerConnection* conn, OpflexMessage* message) {
     std::unique_ptr<OpflexMessage> messagep(message);
     if (!active) return;
+
+    // conn_mutex is held at OpflexServerConnection::on_policy_update_async()
     conn->sendMessage(message->clone());
 }
 

--- a/libopflex/engine/OpflexListener.cpp
+++ b/libopflex/engine/OpflexListener.cpp
@@ -184,7 +184,6 @@ void OpflexListener::sendToAll(OpflexMessage* message) {
 
 void OpflexListener::sendToOne(OpflexServerConnection* conn, OpflexMessage* message) {
     std::unique_ptr<OpflexMessage> messagep(message);
-    const std::lock_guard<std::recursive_mutex> lock(conn_mutex);
     if (!active) return;
     conn->sendMessage(message->clone());
 }

--- a/libopflex/engine/OpflexServerConnection.cpp
+++ b/libopflex/engine/OpflexServerConnection.cpp
@@ -251,7 +251,8 @@ void OpflexServerConnection::on_prr_timer_async(uv_async_t* handle) {
     OpflexServerConnection* conn = (OpflexServerConnection *)handle->data;
     GbpOpflexServerImpl* server = dynamic_cast<GbpOpflexServerImpl*>
         (conn->listener->getHandlerFactory());
-    std::lock_guard<std::mutex> lock(conn->uri_map_mutex);
+    const std::lock_guard<std::recursive_mutex> guard(conn->listener->conn_mutex);
+    const std::lock_guard<std::mutex> lock(conn->uri_map_mutex);
 
     auto it = conn->uri_map.begin();
     while (it != conn->uri_map.end()) {

--- a/libopflex/engine/OpflexServerConnection.cpp
+++ b/libopflex/engine/OpflexServerConnection.cpp
@@ -205,7 +205,7 @@ bool OpflexServerConnection::clearUri(const opflex::modb::URI& uri) {
 void OpflexServerConnection::addPendingUpdate(opflex::modb::class_id_t class_id,
                                               const opflex::modb::URI& uri,
                                               PolicyUpdateOp op) {
-    std::lock_guard<std::mutex> lock(uri_map_mutex);
+    std::lock_guard<std::mutex> lock(ref_vec_mutex);
     switch (op) {
     case PolicyUpdateOp::REPLACE:
         replace.emplace_back(class_id, uri);
@@ -234,7 +234,7 @@ void OpflexServerConnection::on_policy_update_async(uv_async_t* handle) {
     OpflexServerConnection* conn = (OpflexServerConnection *)handle->data;
     GbpOpflexServerImpl* server = dynamic_cast<GbpOpflexServerImpl*>
         (conn->listener->getHandlerFactory());
-    std::lock_guard<std::mutex> lock(conn->uri_map_mutex);
+    std::lock_guard<std::mutex> lock(conn->ref_vec_mutex);
 
     if (conn->replace.empty() && conn->merge.empty() && conn->deleted.empty())
         return;

--- a/libopflex/engine/OpflexServerConnection.cpp
+++ b/libopflex/engine/OpflexServerConnection.cpp
@@ -234,7 +234,8 @@ void OpflexServerConnection::on_policy_update_async(uv_async_t* handle) {
     OpflexServerConnection* conn = (OpflexServerConnection *)handle->data;
     GbpOpflexServerImpl* server = dynamic_cast<GbpOpflexServerImpl*>
         (conn->listener->getHandlerFactory());
-    std::lock_guard<std::mutex> lock(conn->ref_vec_mutex);
+    const std::lock_guard<std::recursive_mutex> guard(conn->listener->conn_mutex);
+    const std::lock_guard<std::mutex> lock(conn->ref_vec_mutex);
 
     if (conn->replace.empty() && conn->merge.empty() && conn->deleted.empty())
         return;

--- a/libopflex/engine/include/opflex/engine/internal/OpflexServerConnection.h
+++ b/libopflex/engine/include/opflex/engine/internal/OpflexServerConnection.h
@@ -141,6 +141,7 @@ private:
     std::vector<opflex::modb::reference_t> replace;
     std::vector<opflex::modb::reference_t> merge;
     std::vector<opflex::modb::reference_t> deleted;
+    std::mutex ref_vec_mutex;
 
     /**
      * Start a thread for sending policy updates to agent


### PR DESCRIPTION
- removing connection mutex lock in sendToOne() to remove order dependency
- protecting reference vectors using a new mutex instead of uri_map_mutex

Signed-off-by: Gautam Venkataramanan <gautam.chennai@gmail.com>