### PR TITLE
Address codacity warnings: convert all usleep to nanosleep

### DIFF
--- a/agent-ovs/cmd/test/framework_stress.cpp
+++ b/agent-ovs/cmd/test/framework_stress.cpp
@@ -14,6 +14,7 @@
 #include <string>
 #include <vector>
 #include <iostream>
+#include <time.h>
 
 #include <boost/program_options.hpp>
 
@@ -190,7 +191,10 @@ int main(int argc, char** argv) {
             int c = 0;
             while (gotconfig < 2 && c < 500) {
                 c += 1;
-                usleep(1000);
+                struct timespec ts;
+                ts.tv_sec = 0;
+                ts.tv_nsec = 1000000L;
+                nanosleep(&ts, NULL);
             }
             framework.prettyPrintMODB(opflexagent::Logger(INFO, __FILE__,
                                                           __LINE__,

--- a/agent-ovs/lib/include/opflexagent/test/BaseFixture.h
+++ b/agent-ovs/lib/include/opflexagent/test/BaseFixture.h
@@ -9,6 +9,7 @@
  * and is available at http://www.eclipse.org/legal/epl-v10.html
  */
 
+#include <time.h>
 #include <opflex/ofcore/OFFramework.h>
 #include <opflex/ofcore/OFConstants.h>
 #include <modelgbp/metadata/metadata.hpp>
@@ -131,7 +132,10 @@ public:
         while (_c < count) {                               \
             if (condition) break;                          \
             _c += 1;                                       \
-            usleep(1000);                                  \
+            struct timespec ts;                            \
+            ts.tv_sec = 0;                                 \
+            ts.tv_nsec = 1000000L;                         \
+            nanosleep(&ts, NULL);                          \
             stmt;                                          \
         }                                                  \
         BOOST_CHECK((condition));                          \

--- a/agent-ovs/lib/test/EndpointManager_test.cpp
+++ b/agent-ovs/lib/test/EndpointManager_test.cpp
@@ -9,6 +9,7 @@
  * and is available at http://www.eclipse.org/legal/epl-v10.html
  */
 
+#include <time.h>
 #include <opflex/modb/ObjectListener.h>
 #include <modelgbp/ascii/StringMatchTypeEnumT.hpp>
 #include <modelgbp/gbp/RoutingModeEnumT.hpp>
@@ -1096,7 +1097,10 @@ BOOST_FIXTURE_TEST_CASE( remoteEndpoint, BaseFixture ) {
     WAIT_FOR(listener.numUpdates() == 3, 500);
 
     // Wait for egDomain and remoteEp updates to settle down
-    usleep(100000);
+    struct timespec ts;
+    ts.tv_sec = 0;
+    ts.tv_nsec = 100000000L;
+    nanosleep(&ts, NULL);
     listener.clear();
     // update epg for ep
     rep1->addInvRemoteInventoryEpToGroupRSrc()

--- a/libopflex/modb/test/TestListener.h
+++ b/libopflex/modb/test/TestListener.h
@@ -15,6 +15,7 @@
 #include <mutex>
 #include <uv.h>
 #include <unordered_set>
+#include <time.h>
 
 #include "opflex/modb/ObjectListener.h"
 
@@ -46,7 +47,10 @@ public:
         while (_c < count) {                               \
             if (condition) break;                          \
             _c += 1;                                       \
-            usleep(1000);                                  \
+            struct timespec ts;                            \
+            ts.tv_sec = 0;                                 \
+            ts.tv_nsec = 1000000L;                         \
+            nanosleep(&ts, NULL);                          \
             stmt;                                          \
         }                                                  \
         BOOST_CHECK((condition));                          \


### PR DESCRIPTION
usleep - This C routine is considered obsolete (as opposed to the shell command by the same name). The interaction of this function with SIGALRM and other timer functions such as sleep(), alarm(), setitimer(), and nanosleep() is unspecified (CWE-676).

Signed-off-by: Gautam Venkataramanan <gautam.chennai@gmail.com>