### PR TITLE
Support metrics in opflex-server

### DIFF
--- a/agent-ovs/Makefile.am
+++ b/agent-ovs/Makefile.am
@@ -602,7 +602,8 @@ if ENABLE_GRPC
 %.grpc.pb.cc %.grpc.pb.h %.pb.cc %.pb.h: %.proto
 	protoc --cpp_out=. $^
 	protoc --grpc_out=. --plugin=protoc-gen-grpc=`which grpc_cpp_plugin` $^
-opflex_server_SOURCES += server/GbpClient.cpp
+opflex_server_SOURCES += server/GbpClient.cpp \
+                         server/StatsIO.cpp
 BUILT_SOURCES = server/gbp.pb.cc \
                 server/gbp.grpc.pb.cc \
                 server/gbp.pb.h \

--- a/agent-ovs/lib/Agent.cpp
+++ b/agent-ovs/lib/Agent.cpp
@@ -673,7 +673,7 @@ void Agent::start() {
     } else {
         // disable reporting of some stats for now (MODB only)
         LOG(INFO) << "Disable unsupported stat reporting";
-        framework.overrideObservableReporting(modelgbp::observer::OpflexCounter::CLASS_ID, false);
+        framework.overrideObservableReporting(modelgbp::observer::OpflexAgentCounter::CLASS_ID, false);
         framework.overrideObservableReporting(modelgbp::gbpe::EpToSvcCounter::CLASS_ID, false);
         framework.overrideObservableReporting(modelgbp::gbpe::SvcToEpCounter::CLASS_ID, false);
         framework.overrideObservableReporting(modelgbp::gbpe::TableDropCounter::CLASS_ID, false);

--- a/agent-ovs/lib/AgentPrometheusManager.cpp
+++ b/agent-ovs/lib/AgentPrometheusManager.cpp
@@ -10,7 +10,7 @@
  */
 
 #include <opflexagent/Agent.h>
-#include <opflex/ofcore/OFStats.h>
+#include <opflex/ofcore/OFAgentStats.h>
 #include <opflexagent/PrometheusManager.h>
 #include <modelgbp/gbpe/L24Classifier.hpp>
 #include <map>
@@ -2845,7 +2845,7 @@ void AgentPrometheusManager::addNUpdateRDDropCounter (const string& rdURI,
 
 /* Function called from PolicyStatsManager to update OFPeerStats */
 void AgentPrometheusManager::addNUpdateOFPeerStats (const std::string& peer,
-                                                    const std::shared_ptr<OFStats> stats)
+                                                    const std::shared_ptr<OFAgentStats> stats)
 {
     RETURN_IF_DISABLED
     const lock_guard<mutex> lock(ofpeer_stats_mutex);

--- a/agent-ovs/lib/include/opflexagent/PrometheusManager.h
+++ b/agent-ovs/lib/include/opflexagent/PrometheusManager.h
@@ -394,7 +394,7 @@ public:
      * @param stats   opflex stats corresponding to the peer
      */
     void addNUpdateOFPeerStats(const std::string& peer,
-                               const std::shared_ptr<OFStats> stats);
+                               const std::shared_ptr<OFAgentStats> stats);
 
 
     /* SvcCounter related APIs */

--- a/agent-ovs/ovs/PolicyStatsManager.cpp
+++ b/agent-ovs/ovs/PolicyStatsManager.cpp
@@ -280,14 +280,14 @@ on_timer_base(const error_code& ec,
 
     // flush OpFlex client stats
     // TODO: Move these to a separate class to avoid polluting Policy/FlowStatsManager
-    std::unordered_map<string, std::shared_ptr<OFStats>> stats;
+    std::unordered_map<string, std::shared_ptr<OFAgentStats>> stats;
     agent->getFramework().getOpflexPeerStats(stats);
     Mutator mutator(agent->getFramework(), "policyelement");
     optional<shared_ptr<SysStatUniverse> > ssu =
         SysStatUniverse::resolve(agent->getFramework());
     if (ssu) {
         for (const auto& peerStat : stats) {
-            ssu.get()->addObserverOpflexCounter(peerStat.first)
+            ssu.get()->addObserverOpflexAgentCounter(peerStat.first)
                     ->setIdentReqs(peerStat.second->getIdentReqs())
                     .setIdentResps(peerStat.second->getIdentResps())
                     .setIdentErrs(peerStat.second->getIdentErrs())

--- a/agent-ovs/ovs/test/ContractStatsManager_test.cpp
+++ b/agent-ovs/ovs/test/ContractStatsManager_test.cpp
@@ -92,7 +92,7 @@ public:
                             uint32_t bytes,
                             bool isTx=false) override;
     void verifyRdDropPromMetrics(uint32_t pkts, uint32_t bytes);
-    void updateOFPeerStats(std::shared_ptr<OFStats> opflexStats);
+    void updateOFPeerStats(std::shared_ptr<OFAgentStats> opflexStats);
     void verifyOFPeerMetrics(const std::string& peer, uint32_t count);
 #endif
     IntFlowManager  intFlowManager;
@@ -104,7 +104,7 @@ private:
 
 #ifdef HAVE_PROMETHEUS_SUPPORT
 void ContractStatsManagerFixture::
-updateOFPeerStats (std::shared_ptr<OFStats> opflexStats)
+updateOFPeerStats (std::shared_ptr<OFAgentStats> opflexStats)
 {
     opflexStats->incrIdentReqs();
     opflexStats->incrIdentResps();
@@ -620,7 +620,7 @@ BOOST_FIXTURE_TEST_CASE(testrDSEpgDelete, ContractStatsManagerFixture) {
 BOOST_FIXTURE_TEST_CASE(testOFPeer, ContractStatsManagerFixture) {
 
     LOG(DEBUG) << "### OfPeer start";
-    std::shared_ptr<OFStats> opflexStats = std::make_shared<OFStats>();
+    std::shared_ptr<OFAgentStats> opflexStats = std::make_shared<OFAgentStats>();
     const std::string peer = "127.0.0.1:8009";
 
     updateOFPeerStats(opflexStats);

--- a/agent-ovs/server/StatsIO.cpp
+++ b/agent-ovs/server/StatsIO.cpp
@@ -1,0 +1,123 @@
+/* -*- C++ -*-; c-basic-offset: 4; indent-tabs-mode: nil */
+/*
+ * Implementation of interface for stats IO thread in opflex-server.
+ *
+ * Copyright (c) 2020 Cisco Systems, Inc. and others.  All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ */
+
+#include <opflexagent/logging.h>
+#include "StatsIO.h"
+#include <opflex/ofcore/OFFramework.h>
+#include <opflex/ofcore/OFServerStats.h>
+#include <modelgbp/observer/SysStatUniverse.hpp>
+
+using boost::asio::deadline_timer;
+using boost::posix_time::seconds;
+using namespace opflex::modb;
+using namespace modelgbp::observer;
+
+namespace opflexagent {
+
+#ifdef HAVE_PROMETHEUS_SUPPORT
+StatsIO::StatsIO (ServerPrometheusManager& prometheusManager_,
+                  opflex::test::GbpOpflexServer& server_,
+                  opflex::ofcore::OFFramework& framework_,
+                  int stats_interval_secs_) :
+                  prometheusManager(prometheusManager_),
+                  server(server_),
+                  framework(framework_),
+                  stats_interval_secs(stats_interval_secs_),
+                  stopping(false) {
+}
+#else
+StatsIO::StatsIO (opflex::test::GbpOpflexServer& server_,
+                  const opflex::ofcore::OFFramework& framework_,
+                  int stats_interval_secs_) :
+                  server(server_),
+                  framework(framework_),
+                  stats_interval_secs(stats_interval_secs_),
+                  stopping(false) {
+}
+#endif
+
+StatsIO::~StatsIO() {
+}
+
+void StatsIO::start() {
+    if (stopping)
+        return;
+    LOG(DEBUG) << "starting stats IO thread";
+    const std::lock_guard<std::mutex> guard(stats_timer_mutex);
+    stats_timer.reset(new deadline_timer(io, seconds(stats_interval_secs)));
+    stats_timer->async_wait([this](const boost::system::error_code& ec) {
+            on_timer_stats(ec);
+        });
+
+    io_service_thread.reset(new std::thread([this]() { io.run(); }));
+}
+
+void StatsIO::stop() {
+    stopping = true;
+    LOG(DEBUG) << "stopping stats IO thread";
+    {
+        const std::lock_guard<std::mutex> guard(stats_timer_mutex);
+        if (stats_timer) {
+            stats_timer->cancel();
+        }
+    }
+
+    if (io_service_thread) {
+        io_service_thread->join();
+        io_service_thread.reset();
+    }
+}
+
+void StatsIO::on_timer_stats (const boost::system::error_code& ec) {
+    if (ec) {
+        const std::lock_guard<std::mutex> guard(stats_timer_mutex);
+        stats_timer.reset();
+        return;
+    }
+
+    std::unordered_map<string, std::shared_ptr<OFServerStats>> stats;
+    server.getOpflexPeerStats(stats);
+    Mutator mutator(framework, "policyelement");
+    optional<shared_ptr<SysStatUniverse> > ssu =
+        SysStatUniverse::resolve(framework);
+    if (ssu) {
+        for (const auto& peerStat : stats) {
+            ssu.get()->addObserverOpflexServerCounter(peerStat.first)
+                    ->setIdentReqs(peerStat.second->getIdentReqs())
+                    .setPolUpdates(peerStat.second->getPolUpdates())
+                    .setPolResolves(peerStat.second->getPolResolves())
+                    .setPolResolveErrs(peerStat.second->getPolResolveErrs())
+                    .setPolUnavailableResolves(peerStat.second->getPolUnavailableResolves())
+                    .setPolUnresolves(peerStat.second->getPolUnresolves())
+                    .setPolUnresolveErrs(peerStat.second->getPolUnresolveErrs())
+                    .setEpDeclares(peerStat.second->getEpDeclares())
+                    .setEpDeclareErrs(peerStat.second->getEpDeclareErrs())
+                    .setEpUndeclares(peerStat.second->getEpUndeclares())
+                    .setEpUndeclareErrs(peerStat.second->getEpUndeclareErrs())
+                    .setEpResolves(peerStat.second->getEpResolves())
+                    .setEpResolveErrs(peerStat.second->getEpResolveErrs())
+                    .setStateReports(peerStat.second->getStateReports())
+                    .setStateReportErrs(peerStat.second->getStateReportErrs());
+        }
+    }
+    mutator.commit();
+
+    if (!stopping) {
+        const std::lock_guard<std::mutex> guard(stats_timer_mutex);
+        stats_timer->expires_at(stats_timer->expires_at() +
+                              seconds(stats_interval_secs));
+        stats_timer->async_wait([this](const boost::system::error_code& ec) {
+                on_timer_stats(ec);
+            });
+    }
+}
+
+} /* namespace opflexagent */

--- a/agent-ovs/server/include/StatsIO.h
+++ b/agent-ovs/server/include/StatsIO.h
@@ -1,0 +1,67 @@
+/* -*- C++ -*-; c-basic-offset: 4; indent-tabs-mode: nil */
+/*!
+ * @file StatsIO.h
+ * @brief Interface definition file for Stats IO thread
+ */
+/*
+ * Copyright (c) 2020 Cisco Systems, Inc. and others.  All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ */
+
+#pragma once
+#ifndef STATS_IO_H
+#define STATS_IO_H
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <thread>
+#include <mutex>
+#include <boost/asio/io_service.hpp>
+#include <boost/asio/deadline_timer.hpp>
+
+#ifdef HAVE_PROMETHEUS_SUPPORT
+#include <opflexagent/PrometheusManager.h>
+#endif
+#include <opflex/ofcore/OFFramework.h>
+#include <opflex/test/GbpOpflexServer.h>
+
+namespace opflexagent {
+
+class StatsIO {
+public:
+#ifdef HAVE_PROMETHEUS_SUPPORT
+    StatsIO(ServerPrometheusManager& prometheusManager_,
+            opflex::test::GbpOpflexServer& server_,
+            opflex::ofcore::OFFramework& framework_,
+            int stats_interval_secs_);
+#else
+    StatsIO(opflex::ofcore::OFFramework& framework_,
+            opflex::test::GbpOpflexServer& server_,
+            int stats_interval_secs_);
+#endif
+    ~StatsIO();
+    void start();
+    void stop();
+private:
+    void on_timer_stats(const boost::system::error_code& ec);
+#ifdef HAVE_PROMETHEUS_SUPPORT
+    ServerPrometheusManager& prometheusManager;
+#endif
+    opflex::test::GbpOpflexServer& server;
+    opflex::ofcore::OFFramework& framework;
+    int stats_interval_secs;
+    std::atomic<bool> stopping;
+    std::unique_ptr<std::thread> io_service_thread;
+    boost::asio::io_service io;
+    std::unique_ptr<boost::asio::deadline_timer> stats_timer;
+    std::mutex stats_timer_mutex;
+};
+
+} /* namespace opflexagent */
+
+#endif /* STATS_IO_H */

--- a/genie/MODEL/SPECIFIC/OBSERVER/opflex.mdl
+++ b/genie/MODEL/SPECIFIC/OBSERVER/opflex.mdl
@@ -15,8 +15,8 @@ module[observer]
         }
     }
 
-    # OpFlex protocol related counters
-    class[OpflexCounter;
+    # OpFlex protocol related counters in opflex-agent
+    class[OpflexAgentCounter;
           super=observer/Observable;
           concrete;
           ]
@@ -95,5 +95,71 @@ module[observer]
  
         # the number of unresolved policies 
         member[polUnresolvedCount; type=scalar/UInt64]
+    }
+
+    # OpFlex protocol related counters in opflex-server
+    class[OpflexServerCounter;
+          super=observer/Observable;
+          concrete;
+          ]
+    {
+        contained
+        {
+            parent[class=observer/SysStatUniverse]
+        }
+        named
+        {
+            parent[class=*;]
+            {
+                component[prefix=opflex;
+                          member=peer]
+            }
+        }
+
+        member[peer; type=ascii/String]
+
+        # the number of identity requests received
+        member[identReqs; type=scalar/UInt64]
+
+        # number of policy updates received from gbp server
+        # and sent to a connection
+        member[polUpdates; type=scalar/UInt64]
+
+        # number of policy resolves received
+        member[polResolves; type=scalar/UInt64]
+        # number of policies unavailable on received resolves
+        member[polUnavailableResolves; type=scalar/UInt64]
+        # number of policy resolves received errors
+        member[polResolveErrs; type=scalar/UInt64]
+
+        # number of policy unresolves received
+        member[polUnresolves; type=scalar/UInt64]
+        # number of policy unresolves received errors
+        member[polUnresolveErrs; type=scalar/UInt64]
+
+        # number of endpoint declares received
+        member[epDeclares; type=scalar/UInt64]
+        # number of endpoint declares received errors
+        member[epDeclareErrs; type=scalar/UInt64]
+
+        # number of endpoint declares received
+        member[epUndeclares; type=scalar/UInt64]
+        # number of endpoint declares received errors
+        member[epUndeclareErrs; type=scalar/UInt64]
+
+        # number of endpoint resolves received
+        member[epResolves; type=scalar/UInt64]
+        # number of endpoint resolves received errors
+        member[epResolveErrs; type=scalar/UInt64]
+
+        # number of endpoint resolves received
+        member[epUnresolves; type=scalar/UInt64]
+        # number of endpoint resolves received errors
+        member[epUnresolveErrs; type=scalar/UInt64]
+
+        # the number of state reports received
+        member[stateReports; type=scalar/UInt64]
+        # the number of state reports received errors
+        member[stateReportErrs; type=scalar/UInt64]
     }
 }

--- a/libopflex/Makefile.am
+++ b/libopflex/Makefile.am
@@ -71,7 +71,8 @@ core_include_HEADERS = \
 	include/opflex/ofcore/MainLoopAdaptor.h \
 	include/opflex/ofcore/InspectorClient.h \
 	include/opflex/ofcore/OFConstants.h \
-	include/opflex/ofcore/OFStats.h
+	include/opflex/ofcore/OFAgentStats.h \
+	include/opflex/ofcore/OFServerStats.h
 test_includedir = $(includedir)/opflex/test
 test_include_HEADERS = \
 	include/opflex/test/GbpOpflexServer.h 

--- a/libopflex/engine/OpflexClientConnection.cpp
+++ b/libopflex/engine/OpflexClientConnection.cpp
@@ -40,7 +40,7 @@ OpflexClientConnection::OpflexClientConnection(HandlerFactory& handlerFactory,
       pool(pool_), hostname(hostname_), port(port_), role(0), peer(NULL),
       started(false), active(false), closing(false), ready(false),
       failureCount(0), handshake_timer(NULL) {
-    opflexStats = std::make_shared<OFStats>();
+    opflexStats = std::make_shared<OFAgentStats>();
 }
 
 OpflexClientConnection::~OpflexClientConnection() {

--- a/libopflex/engine/OpflexPool.cpp
+++ b/libopflex/engine/OpflexPool.cpp
@@ -478,7 +478,7 @@ void OpflexPool::addConfiguredPeers() {
 }
 
 
-void OpflexPool::getOpflexPeerStats(std::unordered_map<string, std::shared_ptr<OFStats>>& stats) {
+void OpflexPool::getOpflexPeerStats(std::unordered_map<string, std::shared_ptr<OFAgentStats>>& stats) {
     const std::lock_guard<std::recursive_mutex> lock(conn_mutex);
     for (conn_map_t::value_type& v : connections) {
         const string peername = v.first.first + ":" + std::to_string(v.first.second);

--- a/libopflex/engine/OpflexServerConnection.cpp
+++ b/libopflex/engine/OpflexServerConnection.cpp
@@ -36,6 +36,7 @@ OpflexServerConnection::OpflexServerConnection(OpflexListener* listener_)
     : OpflexConnection(listener_->handlerFactory),
       listener(listener_), peer(NULL) {
 
+      opflexStats = std::make_shared<OFServerStats>();
       uv_loop_init(&server_loop);
       policy_update_async.data = this;
       uv_async_init(&server_loop, &policy_update_async, on_policy_update_async);

--- a/libopflex/engine/include/opflex/engine/internal/GbpOpflexServerImpl.h
+++ b/libopflex/engine/include/opflex/engine/internal/GbpOpflexServerImpl.h
@@ -179,14 +179,22 @@ public:
                                      gbp::PolicyUpdateOp op);
 
     /**
-     * on timer callback
+     * on timer callback for prr
      */
-    void on_timer(const boost::system::error_code& ec);
+    void on_timer_prr(const boost::system::error_code& ec);
 
     /**
      * Get prr timer callback interval
      */
     int getPrrIntervalSecs() { return prr_interval_secs; }
+
+    /**
+     * Retrieve OpFlex server stats for each available peer
+     *
+     * @param stats Map of named peers to associated OpFlex stats
+     */
+    void getOpflexPeerStats(std::unordered_map<std::string, std::shared_ptr<OFServerStats>>& stats);
+
 private:
     uint16_t port;
     uint8_t roles;
@@ -204,8 +212,8 @@ private:
 
     std::unique_ptr<std::thread> io_service_thread;
     boost::asio::io_service io;
-    std::unique_ptr<boost::asio::deadline_timer> prr_timer;
     std::atomic_bool stopping;
+    std::unique_ptr<boost::asio::deadline_timer> prr_timer;
     int prr_interval_secs;
     std::mutex prr_timer_mutex;
 };

--- a/libopflex/engine/include/opflex/engine/internal/OpflexClientConnection.h
+++ b/libopflex/engine/include/opflex/engine/internal/OpflexClientConnection.h
@@ -15,7 +15,7 @@
 #ifndef OPFLEX_ENGINE_OPFLEXCLIENTCONNECTION_H
 #define OPFLEX_ENGINE_OPFLEXCLIENTCONNECTION_H
 
-#include <include/opflex/ofcore/OFStats.h>
+#include <include/opflex/ofcore/OFAgentStats.h>
 #include "opflex/engine/internal/OpflexConnection.h"
 
 namespace opflex {
@@ -98,7 +98,7 @@ public:
     virtual void setRoles(uint8_t _role) { role = _role; }
     virtual uint8_t getRoles() { return role; }
 
-    std::shared_ptr<OFStats> getOpflexStats() { return opflexStats; }
+    std::shared_ptr<OFAgentStats> getOpflexStats() { return opflexStats; }
 private:
     OpflexPool* pool;
 
@@ -115,7 +115,7 @@ private:
     bool ready;
     int failureCount;
 
-    std::shared_ptr<OFStats> opflexStats;
+    std::shared_ptr<OFAgentStats> opflexStats;
 
     uv_timer_t* handshake_timer;
 

--- a/libopflex/engine/include/opflex/engine/internal/OpflexListener.h
+++ b/libopflex/engine/include/opflex/engine/internal/OpflexListener.h
@@ -180,6 +180,10 @@ public:
      */
     bool isListening();
 
+    /**
+     * Return opflex stats per peer connection
+     */
+    void getOpflexPeerStats(std::unordered_map<std::string, std::shared_ptr<OFServerStats>>& stats);
 private:
     HandlerFactory& handlerFactory;
 

--- a/libopflex/engine/include/opflex/engine/internal/OpflexPool.h
+++ b/libopflex/engine/include/opflex/engine/internal/OpflexPool.h
@@ -350,7 +350,7 @@ public:
      *
      * @param stats Map of named peers to associated OpFlex stats
      */
-    void getOpflexPeerStats(std::unordered_map<std::string, std::shared_ptr<OFStats>>& stats);
+    void getOpflexPeerStats(std::unordered_map<std::string, std::shared_ptr<OFAgentStats>>& stats);
 
 private:
     HandlerFactory& factory;

--- a/libopflex/engine/include/opflex/engine/internal/OpflexServerConnection.h
+++ b/libopflex/engine/include/opflex/engine/internal/OpflexServerConnection.h
@@ -15,6 +15,7 @@
 #include <uv.h>
 #include <mutex>
 
+#include <include/opflex/ofcore/OFServerStats.h>
 #include "opflex/engine/internal/OpflexConnection.h"
 #include "opflex/modb/URI.h"
 #include "opflex/modb/PropertyInfo.h"
@@ -29,7 +30,6 @@ namespace opflex {
 namespace engine {
 namespace internal {
 
-class OpflexPool;
 class OpflexListener;
 
 /**
@@ -124,6 +124,7 @@ public:
      */
     void sendTimeouts();
 
+    std::shared_ptr<OFServerStats> getOpflexStats() { return opflexStats; }
 private:
     OpflexListener* listener;
 
@@ -157,6 +158,8 @@ private:
     static void on_prr_timer_async(uv_async_t* handle);
 
     yajr::Peer* peer;
+
+    std::shared_ptr<OFServerStats> opflexStats;
 };
 
 

--- a/libopflex/engine/test/Processor_test.cpp
+++ b/libopflex/engine/test/Processor_test.cpp
@@ -234,7 +234,6 @@ BOOST_FIXTURE_TEST_CASE( dereference, Fixture ) {
     BOOST_CHECK_EQUAL(0, processor.getRefCount(c4u));
     WAIT_FOR(!itemPresent(client2, 6, c6u), 1000);
 }
-
 static bool connReady(OpflexPool& pool, const char* host, int port) {
     OpflexConnection* conn = pool.getPeer(host, port);
     return (conn != NULL && conn->isReady());
@@ -261,7 +260,6 @@ void BasePFixture::testPeerSwap(void) {
                               vector<std::string>(), md, 60);
     GbpOpflexServerImpl peer2(8010, SERVER_ROLES, list_of(p1),
                               vector<std::string>(), md, 60);
-
     anycastServer.start();
     peer1.start();
     peer2.start();
@@ -922,5 +920,4 @@ BOOST_FIXTURE_TEST_CASE( test_override_observale_reporting, BasePFixture ) {
     processor.overrideObservableReporting(classId, true);
     BOOST_CHECK(processor.isObservableReportable(classId));
 }
-
 BOOST_AUTO_TEST_SUITE_END()

--- a/libopflex/include/opflex/ofcore/OFAgentStats.h
+++ b/libopflex/include/opflex/ofcore/OFAgentStats.h
@@ -1,6 +1,6 @@
 /* -*- C++ -*-; c-basic-offset: 4; indent-tabs-mode: nil */
 /*!
- * @file OFStats.h
+ * @file OFAgentStats.h
  * @brief Interface definition file for OFFramework
  */
 /*
@@ -18,19 +18,19 @@
 /**
  * OpFlex client stats counters
  */
-class OFStats {
+class OFAgentStats {
 
 public:
 
     /**
      * Create a new instance
      */
-    OFStats() {};
+    OFAgentStats() {};
 
     /**
      * Destroy the instance
      */
-    virtual ~OFStats() {};
+    virtual ~OFAgentStats() {};
 
     /** get the number of identity requests sent */
     uint64_t getIdentReqs() { return identReqs; }

--- a/libopflex/include/opflex/ofcore/OFFramework.h
+++ b/libopflex/include/opflex/ofcore/OFFramework.h
@@ -584,7 +584,7 @@
 #include "opflex/ofcore/MainLoopAdaptor.h"
 #include "opflex/ofcore/OFConstants.h"
 #include "boost/asio/ip/address_v4.hpp"
-#include "opflex/ofcore/OFStats.h"
+#include "opflex/ofcore/OFAgentStats.h"
 #include <opflex/modb/URI.h>
 #include <opflex/modb/PropertyInfo.h>
 
@@ -897,7 +897,7 @@ public:
      *
      * @param stats Map of named peers to associated OpFlex stats
      */
-    void getOpflexPeerStats(std::unordered_map<std::string, std::shared_ptr<OFStats>>& stats);
+    void getOpflexPeerStats(std::unordered_map<std::string, std::shared_ptr<OFAgentStats>>& stats);
 
     /**
      * Enable/Disable reporting of observable changes to registered observers

--- a/libopflex/include/opflex/ofcore/OFServerStats.h
+++ b/libopflex/include/opflex/ofcore/OFServerStats.h
@@ -1,0 +1,133 @@
+/* -*- C++ -*-; c-basic-offset: 4; indent-tabs-mode: nil */
+/*!
+ * @file OFServerStats.h
+ * @brief Interface definition file for OFServerStats.h
+ */
+/*
+ * Copyright (c) 2020 Cisco Systems, Inc. and others.  All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ */
+#ifndef OPFLEX_OFSERVERSTATS_H
+#define OPFLEX_OFSERVERSTATS_H
+
+#include <atomic>
+
+/**
+ * OpFlex server stats counters
+ */
+class OFServerStats {
+public:
+
+    /**
+     * Create a new instance
+     */
+    OFServerStats() {};
+
+    /**
+     * Destroy the instance
+     */
+    virtual ~OFServerStats() {};
+
+    /** get the number of identity requests received */
+    uint64_t getIdentReqs() { return identReqs; }
+    /** increment the number of identity requests received */
+    void incrIdentReqs() { identReqs++; }
+
+    /** get the number of policy updates received from gbp server
+      * and sent to a connection */
+    uint64_t getPolUpdates() { return polUpdates; }
+    /** increment the number of policy updates received from gbp server
+      * and sent to a connection */
+    void incrPolUpdates() { polUpdates++; }
+
+    /** get the number of policies unavilable on received resolve messages */
+    uint64_t getPolUnavailableResolves() { return polUnavailableResolves; }
+    /** increment the number of policies unavilable on received resolve messages */
+    void incrPolUnavailableResolves() { polUnavailableResolves++; }
+    /** get the number of policy_resolve msgs received */
+    uint64_t getPolResolves() { return polResolves; }
+    /** increment the number of policy_resolve msgs received */
+    void incrPolResolves() { polResolves++; }
+    /** get the number of policy_resolve msgs received errs */
+    uint64_t getPolResolveErrs() { return polResolveErrs; }
+    /** increment the number of policy_resolve msgs received errs */
+    void incrPolResolveErrs() { polResolveErrs++; }
+
+    /** get the number of policy_unresolve msgs received */
+    uint64_t getPolUnresolves() { return polUnresolves; }
+    /** increment the number of policy_unresolve msgs received */
+    void incrPolUnresolves() { polUnresolves++; }
+    /** get the number of policy_unresolve msgs received errs */
+    uint64_t getPolUnresolveErrs() { return polUnresolveErrs; }
+    /** increment the number of policy_unresolve msgs received errs */
+    void incrPolUnresolveErrs() { polUnresolveErrs++; }
+
+    /** get the number of endpoint_declare msgs received */
+    uint64_t getEpDeclares() { return epDeclares; }
+    /** increment the number of endpoint_declare msgs received */
+    void incrEpDeclares() { epDeclares++; }
+    /** get the number of endpoint_declare msgs received errs */
+    uint64_t getEpDeclareErrs() { return epDeclareErrs; }
+    /** increment the number of endpoint_declare msgs received errs */
+    void incrEpDeclareErrs() { epDeclareErrs++; }
+
+    /** get the number of endpoint_undeclare msgs received */
+    uint64_t getEpUndeclares() { return epUndeclares; }
+    /** increment the number of endpoint_undeclare msgs received */
+    void incrEpUndeclares() { epUndeclares++; }
+    /** get the number of endpoint_undeclare msgs received errs */
+    uint64_t getEpUndeclareErrs() { return epUndeclareErrs; }
+    /** increment the number of endpoint_undeclare msgs received errs */
+    void incrEpUndeclareErrs() { epUndeclareErrs++; }
+
+    /** get the number of endpoint_resolve msgs received */
+    uint64_t getEpResolves() { return epResolves; }
+    /** increment the number of endpoint_resolve msgs received */
+    void incrEpResolves() { epResolves++; }
+    /** get the number of endpoint_resolve msgs received errs */
+    uint64_t getEpResolveErrs() { return epResolveErrs; }
+    /** increment the number of endpoint_resolve msgs received errs */
+    void incrEpResolveErrs() { epResolveErrs++; }
+
+    /** get the number of endpoint_unresolve msgs received */
+    uint64_t getEpUnresolves() { return epUnresolves; }
+    /** increment the number of endpoint_unresolve msgs received */
+    void incrEpUnresolves() { epUnresolves++; }
+    /** get the number of endpoint_unresolve msgs received errs */
+    uint64_t getEpUnresolveErrs() { return epUnresolveErrs; }
+    /** increment the number of endpoint_unresolve msgs received errs */
+    void incrEpUnresolveErrs() { epUnresolveErrs++; }
+
+    /** get the number of state_report msgs received */
+    uint64_t getStateReports() { return stateReports; }
+    /** increment the number of state_report msgs received */
+    void incrStateReports() { stateReports++; }
+    /** get the number of state_report msgs received errs */
+    uint64_t getStateReportErrs() { return stateReportErrs; }
+    /** increment the number of state_report msgs received errs */
+    void incrStateReportErrs() { stateReportErrs++; }
+
+private:
+    std::atomic_ullong identReqs{};
+    std::atomic_ullong polUpdates{};
+    std::atomic_ullong polResolves{};
+    std::atomic_ullong polResolveErrs{};
+    std::atomic_ullong polUnavailableResolves{};
+    std::atomic_ullong polUnresolves{};
+    std::atomic_ullong polUnresolveErrs{};
+    std::atomic_ullong epDeclares{};
+    std::atomic_ullong epDeclareErrs{};
+    std::atomic_ullong epUndeclares{};
+    std::atomic_ullong epUndeclareErrs{};
+    std::atomic_ullong epResolves{};
+    std::atomic_ullong epResolveErrs{};
+    std::atomic_ullong epUnresolves{};
+    std::atomic_ullong epUnresolveErrs{};
+    std::atomic_ullong stateReports{};
+    std::atomic_ullong stateReportErrs{};
+};
+
+#endif //OPFLEX_OFSERVERSTATS_H

--- a/libopflex/include/opflex/test/GbpOpflexServer.h
+++ b/libopflex/include/opflex/test/GbpOpflexServer.h
@@ -11,12 +11,14 @@
  * and is available at http://www.eclipse.org/legal/epl-v10.html
  */
 
+#include <memory>
 #include <vector>
 #include <utility>
 #include <rapidjson/document.h>
 
 #include "opflex/modb/ModelMetadata.h"
 #include "opflex/gbp/Policy.h"
+#include <opflex/ofcore/OFServerStats.h>
 
 #pragma once
 #ifndef OPFLEX_TEST_GBPOPFLEXSERVER_H
@@ -140,6 +142,13 @@ public:
      * @return a bitmask containing the server roles
      */
     uint8_t getRoles() const;
+
+    /**
+     * Retrieve OpFlex server stats for each available peer
+     *
+     * @param stats Map of named peers to associated OpFlex stats
+     */
+    void getOpflexPeerStats(std::unordered_map<std::string, std::shared_ptr<OFServerStats>>& stats);
 
 private:
     engine::internal::GbpOpflexServerImpl* pimpl;

--- a/libopflex/ofcore/OFFramework.cpp
+++ b/libopflex/ofcore/OFFramework.cpp
@@ -275,7 +275,7 @@ void OFFramework::clearTLMutator() {
     uv_key_set(&pimpl->mutator_key, NULL);
 }
 
-void OFFramework::getOpflexPeerStats(std::unordered_map<string, std::shared_ptr<OFStats>>& stats) {
+void OFFramework::getOpflexPeerStats(std::unordered_map<string, std::shared_ptr<OFAgentStats>>& stats) {
     engine::internal::OpflexPool& pool = pimpl->processor.getPool();
     pool.getOpflexPeerStats(stats);
 }


### PR DESCRIPTION
- genie changes
- added stats per southbound connection in opflex-server
- created a new IO thread in opflex-server to periodically update modb
- tested using opflex-server/gbp_client_stress/opflex_agent
- Sample output:
sudo gbp_inspect --socket=/usr/local/var/run/opflex-server-inspect.sock -prfq ObserverSysStatUniverse
____ ObserverSysStatUniverse,/ObserverSysStatUniverse/
  ____ ObserverOpflexServerCounter,/ObserverSysStatUniverse/ObserverOpflexServerCounter/127.0.0.1%3a47844/
        {
          epDeclareErrs          : 0
          epDeclares             : 6
          epResolveErrs          : 0
          epResolves             : 0
          epUndeclareErrs        : 0
          epUndeclares           : 0
          identReqs              : 1
          peer                   : 127.0.0.1:47844
          polResolveErrs         : 0
          polResolves            : 37
          polUnavailableResolves : 37
          polUnresolveErrs       : 0
          polUnresolves          : 0
          polUpdates             : 8
          stateReportErrs        : 0
          stateReports           : 0
        }

TODO:
- prometheus integration
- make check integration for agent-ovs/server
- modb opflex stats(both agent and server) dont get cleaned on connection closure. Will raise separate issue to fix.

Signed-off-by: Gautam Venkataramanan <gautam.chennai@gmail.com>