### PR TITLE
Address duplicate metric issues in OpenShift on OpenStack setup

### DIFF
--- a/agent-ovs/lib/AgentPrometheusManager.cpp
+++ b/agent-ovs/lib/AgentPrometheusManager.cpp
@@ -1506,7 +1506,6 @@ bool AgentPrometheusManager::createDynamicGaugeEp (EP_METRICS metric,
         // Suppressing below log for all the other metrics of this EP
         if (metric == EP_METRICS_MIN) {
             LOG(ERROR) << "duplicate ep dyn gauge family: " << ep_name
-                       << " metric: " << metric
                        << " uuid: " << uuid
                        << " label hash: " << hash
                        << " gaugeptr: " << &gauge;

--- a/agent-ovs/lib/EndpointManager.cpp
+++ b/agent-ovs/lib/EndpointManager.cpp
@@ -1450,6 +1450,7 @@ void EndpointManager::updateEndpointCounters(const std::string& uuid,
         auto& ep_name = es.endpoint->getAccessInterface();
         if (ep_name)
             prometheusManager.addNUpdateEpCounter(uuid, ep_name.get(),
+                                                  es.endpoint->isAnnotateEpName(),
                                                   es.endpoint->getAttributeHash(),
                                                   es.endpoint->getAttributes(),
                                                   newVals);

--- a/agent-ovs/lib/FSEndpointSource.cpp
+++ b/agent-ovs/lib/FSEndpointSource.cpp
@@ -118,6 +118,8 @@ void FSEndpointSource::updated(const fs::path& filePath) {
     static const std::string EP_DISABLE_ADV("disable-adv");
     static const std::string EP_ACCESS_ALLOW_UNTAGGED("access-allow-untagged");
 
+    static const std::string NEUTRON_NW("neutron-network");
+
     try {
         using boost::property_tree::ptree;
         Endpoint newep;
@@ -272,11 +274,16 @@ void FSEndpointSource::updated(const fs::path& filePath) {
         }
 
 #ifdef HAVE_PROMETHEUS_SUPPORT
+        optional<string> isOpenStack = properties.get_optional<string>(NEUTRON_NW);
+        if (isOpenStack) {
+            newep.setAnnotateEpName(true);
+        }
         auto acc_intf = newep.getAccessInterface();
         if (acc_intf) {
             newep.setAttributeHash(
                 AgentPrometheusManager::calcHashEpAttributes(
                                             acc_intf.get(),
+                                            newep.isAnnotateEpName(),
                                             newep.getAttributes(),
                                             manager->getAgent().getPrometheusEpAttributes()));
         }

--- a/agent-ovs/lib/ModelEndpointSource.cpp
+++ b/agent-ovs/lib/ModelEndpointSource.cpp
@@ -171,6 +171,7 @@ void ModelEndpointSource::objectUpdated (opflex::modb::class_id_t class_id,
                 newep.setAttributeHash(
                     AgentPrometheusManager::calcHashEpAttributes(
                                             acc_intf.get(),
+                                            newep.isAnnotateEpName(),
                                             newep.getAttributes(),
                                             manager->getAgent().getPrometheusEpAttributes()));
             }

--- a/agent-ovs/lib/include/opflexagent/Endpoint.h
+++ b/agent-ovs/lib/include/opflexagent/Endpoint.h
@@ -41,6 +41,7 @@ public:
                  external(false), aapModeAA(false), disableAdv(false),
                  accessAllowUntagged(false), extEncap(0) {
 #ifdef HAVE_PROMETHEUS_SUPPORT
+        annotateEpName = false;
         attr_hash = 0;
 #endif
     }
@@ -57,6 +58,7 @@ public:
           external(false), aapModeAA(false), disableAdv(false),
           accessAllowUntagged(false), extEncap(0) {
 #ifdef HAVE_PROMETHEUS_SUPPORT
+        annotateEpName = false;
         attr_hash = 0;
 #endif
     }
@@ -530,6 +532,26 @@ public:
     typedef std::unordered_map<std::string, std::string> attr_map_t;
 
 #ifdef HAVE_PROMETHEUS_SUPPORT
+    /**
+      * Add EP name as annotation to avoid dup metric
+      * issues in Openshift on openstack use case
+      *
+      * @param annotateEpName the value of EP name
+      */
+    void setAnnotateEpName (bool annotateEpName) {
+        this->annotateEpName = annotateEpName;
+    }
+
+    /**
+      * Get the current value of annotateEpName flag
+      * for this endpoint
+      *
+      * @return true if annotateEpName is set
+      */
+    bool isAnnotateEpName() const {
+        return annotateEpName;
+    }
+
     // Set hash of all EP attributes that are prometheus compatible
     void setAttributeHash (const size_t& hash) {
         attr_hash = hash;
@@ -1311,6 +1333,7 @@ private:
     bool accessAllowUntagged;
     attr_map_t attributes;
 #ifdef HAVE_PROMETHEUS_SUPPORT
+    bool annotateEpName;
     /**
      * Hash of all the ep attributes. Will be used to detect any
      * attribute changes in the map when processed by prometheus

--- a/agent-ovs/lib/include/opflexagent/PrometheusManager.h
+++ b/agent-ovs/lib/include/opflexagent/PrometheusManager.h
@@ -88,7 +88,6 @@ public:
         {
             const lock_guard<mutex> lock(dup_mutex);
             if (metrics.count(metric)) {
-                LOG(ERROR) << "Duplicate metric detected: " << metric;
                 return true;
             }
             return false;
@@ -266,12 +265,15 @@ public:
      *
      * @param ep_name       Name of the endpoint. Usually the
      * access interface name
+     * @param annotate_ep_name   flag to indicate if ep name
+     * needs to be annotated to avoid duplicate metric issues
      * @param attr_map      The map of endpoint attributes
      * @param allowed_set   The set of allowed ep attributes from
      * agent configuration file
      * @return            the hash value of endpoint attributes
      */
     static size_t calcHashEpAttributes(const string& ep_name,
+                                       bool annotate_ep_name,
             const unordered_map<string, string>&    attr_map,
             const unordered_set<string>&        allowed_set);
     /**
@@ -280,12 +282,17 @@ public:
      *
      * @param uuid        uuid of ep
      * @param ep_name     the name of the ep
+     * @param annotate_ep_name flag to indicate if ep name needs
+     *                         to be annotated to avoid metric
+     *                         duplication issues in case of multiple
+     *                         interfaces for the same VM
      * @param attr_hash   hash of prometheus compatible ep attr
      * @param attr_map    map of all ep attributes
      * @param counters    struct holding all the counters of an EP
      */
     void addNUpdateEpCounter(const string& uuid,
                              const string& ep_name,
+                             bool annotate_ep_name,
                              const size_t& attr_hash,
         const unordered_map<string, string>& attr_map,
                              const EpCounters& counters);
@@ -556,7 +563,8 @@ private:
     mutex ep_counter_mutex;
 
     enum EP_METRICS {
-        EP_RX_BYTES, EP_RX_PKTS, EP_RX_DROPS,
+        EP_METRICS_MIN,
+        EP_RX_BYTES = EP_METRICS_MIN, EP_RX_PKTS, EP_RX_DROPS,
         EP_RX_UCAST, EP_RX_MCAST, EP_RX_BCAST,
         EP_TX_BYTES, EP_TX_PKTS, EP_TX_DROPS,
         EP_TX_UCAST, EP_TX_MCAST, EP_TX_BCAST,
@@ -609,6 +617,7 @@ private:
     bool createDynamicGaugeEp(EP_METRICS metric,
                               const string& uuid,
                               const string& ep_name,
+                              bool annotate_ep_name,
                               const size_t& attr_hash,
         const unordered_map<string, string>&    attr_map);
     // func to get gauge for EpCounter given metric type, uuid
@@ -631,6 +640,7 @@ private:
     // Create a label map that can be used for annotation, given the ep attr map
     // and agent config's allowed ep-attribute-set
     static map<string,string> createLabelMapFromEpAttr(const string& ep_name_,
+                                                       bool annotate_ep_name,
                            const unordered_map<string, string>&      attr_map,
                            const unordered_set<string>&          allowed_set);
     // Maximum number of labels that can be used for annotating a metric

--- a/agent-ovs/lib/test/EndpointManager_test.cpp
+++ b/agent-ovs/lib/test/EndpointManager_test.cpp
@@ -587,6 +587,7 @@ BOOST_FIXTURE_TEST_CASE( fssource, FSEndpointFixture ) {
        << "\"ip\":[\"10.0.0.1\",\"10.0.0.2\",\"10.0.0.3\"],"
        << "\"interface-name\":\"veth0\","
        << "\"access-interface\":\"veth0-acc\","
+       << "\"neutron-network\":\"12345-abcde\","
        << "\"endpoint-group\":\"/PolicyUniverse/PolicySpace/test/GbpEpGroup/epg/\","
        << "\"security-group\":["
        << "{\"policy-space\":\"sg1-space1\",\"name\":\"sg1\"},"
@@ -728,13 +729,13 @@ BOOST_FIXTURE_TEST_CASE( fssource, FSEndpointFixture ) {
     BOOST_CHECK_NE(pos, std::string::npos);
     pos = output1.find("opflex_endpoint_removed_total 0.000000");
     BOOST_CHECK_NE(pos, std::string::npos);
-    pos = output1.find("opflex_endpoint_rx_bytes{name=\"veth0-acc\"} 6400.000000");
+    pos = output1.find("opflex_endpoint_rx_bytes{if=\"veth0-acc\",name=\"veth0-acc\"} 6400.000000");
     BOOST_CHECK_NE(pos, std::string::npos);
-    pos = output1.find("opflex_endpoint_rx_packets{name=\"veth0-acc\"} 100.000000");
+    pos = output1.find("opflex_endpoint_rx_packets{if=\"veth0-acc\",name=\"veth0-acc\"} 100.000000");
     BOOST_CHECK_NE(pos, std::string::npos);
-    pos = output1.find("opflex_endpoint_tx_bytes{name=\"veth0-acc\"} 6400.000000");
+    pos = output1.find("opflex_endpoint_tx_bytes{if=\"veth0-acc\",name=\"veth0-acc\"} 6400.000000");
     BOOST_CHECK_NE(pos, std::string::npos);
-    pos = output1.find("opflex_endpoint_tx_packets{name=\"veth0-acc\"} 100.000000");
+    pos = output1.find("opflex_endpoint_tx_packets{if=\"veth0-acc\",name=\"veth0-acc\"} 100.000000");
     BOOST_CHECK_NE(pos, std::string::npos);
 #endif
 


### PR DESCRIPTION
- nested VM have multiple interfaces. Since we annotate only with "vm-name", there is duplication of EP metrics.
- duplication is not expected to happen in k8s setups since (name,namespace) are supposed to be unique.
- To address this only in openstack setup, "neutron-network" presence is checked in EP file; EP name is tagged as additional annotation to avoid duplication.
- make check changes done and manually tested in build VM
- cleaned up duplicate metric logging
- TBD: similar changes have to be done in nested VMs on ESX. (change expected only in FSEndpointSource). This will be tracked with a separate issue.

Signed-off-by: Gautam Venkataramanan <gautam.chennai@gmail.com>