### PR TITLE
Address duplicate metric issues in OpenShift on OpenStack setup

### DIFF
--- a/agent-ovs/lib/EndpointManager.cpp
+++ b/agent-ovs/lib/EndpointManager.cpp
@@ -1436,6 +1436,7 @@ void EndpointManager::updateEndpointCounters(const std::string& uuid,
         auto& ep_name = es.endpoint->getAccessInterface();
         if (ep_name)
             prometheusManager.addNUpdateEpCounter(uuid, ep_name.get(),
+                                                  es.endpoint->isAnnotateEpName(),
                                                   es.endpoint->getAttributeHash(),
                                                   es.endpoint->getAttributes());
         else

--- a/agent-ovs/lib/FSEndpointSource.cpp
+++ b/agent-ovs/lib/FSEndpointSource.cpp
@@ -117,6 +117,8 @@ void FSEndpointSource::updated(const fs::path& filePath) {
     static const std::string EP_DISABLE_ADV("disable-adv");
     static const std::string EP_ACCESS_ALLOW_UNTAGGED("access-allow-untagged");
 
+    static const std::string NEUTRON_NW("neutron-network");
+
     try {
         using boost::property_tree::ptree;
         Endpoint newep;
@@ -251,11 +253,16 @@ void FSEndpointSource::updated(const fs::path& filePath) {
         }
 
 #ifdef HAVE_PROMETHEUS_SUPPORT
+        optional<string> isOpenStack = properties.get_optional<string>(NEUTRON_NW);
+        if (isOpenStack) {
+            newep.setAnnotateEpName(true);
+        }
         auto acc_intf = newep.getAccessInterface();
         if (acc_intf) {
             newep.setAttributeHash(
                 PrometheusManager::calcHashEpAttributes(
                                             acc_intf.get(),
+                                            newep.isAnnotateEpName(),
                                             newep.getAttributes(),
                                             manager->getAgent().getPrometheusEpAttributes()));
         }

--- a/agent-ovs/lib/ModelEndpointSource.cpp
+++ b/agent-ovs/lib/ModelEndpointSource.cpp
@@ -172,6 +172,7 @@ void ModelEndpointSource::objectUpdated (opflex::modb::class_id_t class_id,
                 newep.setAttributeHash(
                     PrometheusManager::calcHashEpAttributes(
                                             acc_intf.get(),
+                                            newep.isAnnotateEpName(),
                                             newep.getAttributes(),
                                             manager->getAgent().getPrometheusEpAttributes()));
             }

--- a/agent-ovs/lib/include/opflexagent/Endpoint.h
+++ b/agent-ovs/lib/include/opflexagent/Endpoint.h
@@ -39,7 +39,12 @@ public:
      */
     Endpoint() : promiscuousMode(false), discoveryProxyMode(false), natMode(false),
                  external(false), aapModeAA(false), disableAdv(false),
-                 accessAllowUntagged(false), extEncap(0) {}
+                 accessAllowUntagged(false), extEncap(0) {
+#ifdef HAVE_PROMETHEUS_SUPPORT
+        annotateEpName = false;
+        attr_hash = 0;
+#endif
+    }
 
     /**
      * Construct a new Endpoint with the given uuid.  Note that
@@ -53,6 +58,7 @@ public:
           external(false), aapModeAA(false), disableAdv(false),
           accessAllowUntagged(false), extEncap(0) {
 #ifdef HAVE_PROMETHEUS_SUPPORT
+        annotateEpName = false;
         attr_hash = 0;
 #endif
     }
@@ -548,6 +554,26 @@ public:
     typedef std::unordered_map<std::string, std::string> attr_map_t;
 
 #ifdef HAVE_PROMETHEUS_SUPPORT
+    /**
+      * Add EP name as annotation to avoid dup metric
+      * issues in Openshift on openstack use case
+      *
+      * @param annotateEpName the value of EP name
+      */
+    void setAnnotateEpName (bool annotateEpName) {
+        this->annotateEpName = annotateEpName;
+    }
+
+    /**
+      * Get the current value of annotateEpName flag
+      * for this endpoint
+      *
+      * @return true if annotateEpName is set
+      */
+    bool isAnnotateEpName() const {
+        return annotateEpName;
+    }
+
     // Set hash of all EP attributes that are prometheus compatible
     void setAttributeHash (const size_t& hash) {
         attr_hash = hash;
@@ -1328,6 +1354,7 @@ private:
     bool accessAllowUntagged;
     attr_map_t attributes;
 #ifdef HAVE_PROMETHEUS_SUPPORT
+    bool annotateEpName;
     /**
      * Hash of all the ep attributes. Will be used to detect any
      * attribute changes in the map when processed by prometheus

--- a/agent-ovs/lib/include/opflexagent/PrometheusManager.h
+++ b/agent-ovs/lib/include/opflexagent/PrometheusManager.h
@@ -80,12 +80,15 @@ public:
      *
      * @param ep_name       Name of the endpoint. Usually the
      * access interface name
+     * @param annotate_ep_name   flag to indicate if ep name
+     * needs to be annotated to avoid duplicate metric issues
      * @param attr_map      The map of endpoint attributes
      * @param allowed_set   The set of allowed ep attributes from
      * agent configuration file
      * @return            the hash value of endpoint attributes
      */
     static size_t calcHashEpAttributes(const string& ep_name,
+                                       bool annotate_ep_name,
             const unordered_map<string, string>&    attr_map,
             const unordered_set<string>&        allowed_set);
     /**
@@ -94,11 +97,16 @@ public:
      *
      * @param uuid        uuid of ep
      * @param ep_name     the name of the ep
+     * @param annotate_ep_name flag to indicate if ep name needs
+     *                         to be annotated to avoid metric
+     *                         duplication issues in case of multiple
+     *                         interfaces for the same VM
      * @param attr_hash   hash of prometheus compatible ep attr
      * @param attr_map    map of all ep attributes
      */
     void addNUpdateEpCounter(const string& uuid,
                              const string& ep_name,
+                             bool annotate_ep_name,
                              const size_t& attr_hash,
         const unordered_map<string, string>&    attr_map);
     /**
@@ -419,7 +427,8 @@ private:
     mutex ep_counter_mutex;
 
     enum EP_METRICS {
-        EP_RX_BYTES, EP_RX_PKTS, EP_RX_DROPS,
+        EP_METRICS_MIN,
+        EP_RX_BYTES = EP_METRICS_MIN, EP_RX_PKTS, EP_RX_DROPS,
         EP_RX_UCAST, EP_RX_MCAST, EP_RX_BCAST,
         EP_TX_BYTES, EP_TX_PKTS, EP_TX_DROPS,
         EP_TX_UCAST, EP_TX_MCAST, EP_TX_BCAST,
@@ -472,6 +481,7 @@ private:
     bool createDynamicGaugeEp(EP_METRICS metric,
                               const string& uuid,
                               const string& ep_name,
+                              bool annotate_ep_name,
                               const size_t& attr_hash,
         const unordered_map<string, string>&    attr_map);
     // func to get gauge for EpCounter given metric type, uuid
@@ -494,6 +504,7 @@ private:
     // Create a label map that can be used for annotation, given the ep attr map
     // and agent config's allowed ep-attribute-set
     static map<string,string> createLabelMapFromEpAttr(const string& ep_name_,
+                                                       bool annotate_ep_name,
                            const unordered_map<string, string>&      attr_map,
                            const unordered_set<string>&          allowed_set);
     // Maximum number of labels that can be used for annotating a metric


### PR DESCRIPTION
-nested VM have multiple interfaces. Since we annotate only with "vm-name", there is duplication of EP metrics.
-duplication is not expected to happen in k8s setups since (name,namespace) are supposed to be unique.
-To address this only in openstack setup, "neutron-network" presence is checked in EP file; EP name is tagged as additional annotation to avoid duplication.
-manually tested in build VM
-cleaned up duplicate metric logging

Signed-off-by: Gautam Venkataramanan <gautam.chennai@gmail.com>