### PR TITLE
Fix error logs in droplog

### DIFF
--- a/agent-ovs/ovs/PacketDecoder.cpp
+++ b/agent-ovs/ovs/PacketDecoder.cpp
@@ -89,7 +89,7 @@ void PacketDecoderLayerField::transformLog(uint32_t value, stringstream &ostr, P
                p.nextLayerTypeId, p.nextKey, layerName)) {
             ostr << layerName;
         } else {
-            ostr << value << "(unrecognized)";
+            ostr << value << "_unrecognized";
         }
         return;
     }
@@ -131,13 +131,13 @@ int PacketDecoderLayerField::decode(const unsigned char *buf, std::size_t length
             }
             unsigned char maskLow = ((1<<(8-(bitOffset%8)))-1);
             ptr[3-valBytes] = *data_ptr & maskLow;
-            for( uint32_t i=1; i < valBytes; i++) {
+            for( uint32_t i=1; i <= valBytes; i++) {
                 data_ptr++;
                 ptr[3-valBytes+i] = *data_ptr;
             }
             ptr[3] &= ~((1<<(remBits%8)) -1);
             value = ntohl(value);
-            if(remBits) {
+            if(remBits%8 != 0) {
                 value = value >> remBits;
             }
             transformLog(value, ostr, p);
@@ -399,7 +399,6 @@ int PacketDecoder::decode(const unsigned char *buf, std::size_t length, ParseInf
         }
         if(p.pendingOptionLength) {
             if(!getLayerByTypeKey(p.optionLayerTypeId, 0, pktDecoderLayer)){
-               failed = true;
                break;
             }
         } else {

--- a/agent-ovs/ovs/PacketDecoderLayers.cpp
+++ b/agent-ovs/ovs/PacketDecoderLayers.cpp
@@ -30,7 +30,7 @@ int QtagLayer::configure() {
     addField("pcp", 3, 0, PDF::FLDTYPE_BITFIELD, 0, 0, -1, 0, 0);
     addField("dei", 1, 3, PDF::FLDTYPE_BITFIELD, 0, 0, -1, 0, 0);
     addField("vid", 12, 4, PDF::FLDTYPE_BITFIELD, 0, 0, -1, 1, 0);
-    addField("eType", 16, 16, PDF::FLDTYPE_BYTES, 1, 0, -1, 0, 4);
+    addField("eType", 16, 16, PDF::FLDTYPE_BYTES, 1, 0, -1, 3, 4);
     return 0;
 }
 

--- a/agent-ovs/ovs/test/PacketDecoder_test.cpp
+++ b/agent-ovs/ovs/test/PacketDecoder_test.cpp
@@ -74,12 +74,39 @@ static const uint8_t tcpv6_buf[] = {0x04, 0x00, 0x65, 0x58, 0x00, 0x00, 0x01,
 0x02, 0x04, 0x05, 0xb4, 0x04, 0x02, 0x08, 0x0a, 0x07, 0x72, 0x09, 0x15, 0x00,
 0x00, 0x00, 0x00, 0x01, 0x03, 0x03, 0x09 };
 
+static const uint8_t igmp_buf[] = {
+0x1d, 0x00, 0x65, 0x58, 0x00, 0x00, 0x01, 0x00,
+0xff, 0xff, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+0xff, 0xff, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00,
+0xff, 0xff, 0x02, 0x01, 0x00, 0x00, 0x00, 0x00,
+0xff, 0xff, 0x03, 0x01, 0x00, 0x00, 0x00, 0x00,
+0xff, 0xff, 0x04, 0x01, 0x00, 0x00, 0x00, 0x00,
+0xff, 0xff, 0x05, 0x01, 0x00, 0x00, 0x00, 0x00,
+0xff, 0xff, 0x06, 0x01, 0x00, 0x00, 0x00, 0x00,
+0xff, 0xff, 0x07, 0x01, 0x00, 0x00, 0x00, 0x00,
+0xff, 0xff, 0x08, 0x01, 0x00, 0x00, 0x00, 0x00,
+0xff, 0xff, 0x09, 0x01, 0x00, 0x00, 0x00, 0x00,
+0xff, 0xff, 0x0a, 0x01, 0x00, 0x00, 0x00, 0x00,
+0xff, 0xff, 0x0b, 0x04, 0x00, 0x00, 0x00, 0x00,
+0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0x0c, 0x01,
+0x00, 0x00, 0x00, 0x01, 0x01, 0x00, 0x5e, 0x00,
+0x00, 0x16, 0xfa, 0x16, 0x3e, 0xd3, 0xf3, 0x0b,
+0x81, 0x00, 0x0f, 0xfe, 0x08, 0x00, 0x46, 0xc0,
+0x00, 0x28, 0x00, 0x00, 0x40, 0x00, 0x01, 0x02,
+0x71, 0x48, 0xc0, 0xa8, 0xd2, 0x08, 0xe0, 0x00,
+0x00, 0x16, 0x94, 0x04, 0x00, 0x00, 0x22, 0x00,
+0xf9, 0x02, 0x00, 0x00, 0x00, 0x01, 0x04, 0x00,
+0x00, 0x00, 0xe0, 0x00, 0x00, 0xfb
+};
+
 BOOST_FIXTURE_TEST_CASE(arp_test, PacketDecoderFixture) {
     auto pktDecoder = pktLogger.getDecoder();
     ParseInfo p(&pktDecoder);
     PacketTuple expectedTuple("", "Int-PORT_SECURITY_TABLE DENY", "9e:72:a6:94:18:af", "ff:ff:ff:ff:ff:ff", "ARP", "13.0.0.3", "13.0.0.5" ,"", "", "");
     std::string expected(" MAC=ff:ff:ff:ff:ff:ff:9e:72:a6:94:18:af:ARP ARP_SPA=13.0.0.3 ARP_TPA=13.0.0.5 ARP_OP=1");
-    pktDecoder.decode(arp_buf, 74, p);
+    int ret = pktDecoder.decode(arp_buf, 74, p);
+    BOOST_CHECK(ret == 0);
     std::string dropReason;
     pktLogger.getDropReason(p, dropReason);
     p.packetTuple.setField(0, dropReason);
@@ -92,7 +119,8 @@ BOOST_FIXTURE_TEST_CASE(icmp_test, PacketDecoderFixture) {
     ParseInfo p(&pktDecoder);
     PacketTuple expectedTuple("", "Acc-GROUP_MAP_TABLE MISS", "9e:72:a6:94:18:af", "5a:08:66:ce:0b:49", "IPv4", "14.0.0.2", "100.0.0.1" ,"ICMP", "", "");
     std::string expected(" MAC=5a:08:66:ce:0b:49:9e:72:a6:94:18:af:IPv4 SRC=14.0.0.2 DST=100.0.0.1 LEN=28 DSCP=0 TTL=255 ID=0 FLAGS=0 FRAG=0 PROTO=ICMP TYPE=8 CODE=0 ID=0 SEQ=0");
-    pktDecoder.decode(icmp_buf, 74, p);
+    int ret = pktDecoder.decode(icmp_buf, 74, p);
+    BOOST_CHECK(ret == 0);
     std::string dropReason;
     pktLogger.getDropReason(p, dropReason);
     p.packetTuple.setField(0, dropReason);
@@ -105,7 +133,8 @@ BOOST_FIXTURE_TEST_CASE(tcp_test, PacketDecoderFixture) {
     ParseInfo p(&pktDecoder);
     PacketTuple expectedTuple("", "Int-SOURCE_TABLE PERMIT", "9e:72:a6:94:18:af", "5a:08:66:ce:0b:49", "IPv4", "14.0.0.2", "100.0.0.1" ,"TCP", "41634", "179");
     std::string expected(" MAC=5a:08:66:ce:0b:49:9e:72:a6:94:18:af:IPv4 SRC=14.0.0.2 DST=100.0.0.1 LEN=28 DSCP=0 TTL=255 ID=0 FLAGS=0 FRAG=0 PROTO=TCP SPT=41634 DPT=179 SEQ=2939917199 ACK=0 LEN=10 WINDOWS=29200 SYN  URGP=0");
-    pktDecoder.decode(tcp_buf, 106, p);
+    int ret = pktDecoder.decode(tcp_buf, 106, p);
+    BOOST_CHECK(ret == 0);
     std::string dropReason;
     pktLogger.getDropReason(p, dropReason);
     p.packetTuple.setField(0, dropReason);
@@ -118,7 +147,8 @@ BOOST_FIXTURE_TEST_CASE(udp_test, PacketDecoderFixture) {
     ParseInfo p(&pktDecoder);
     PacketTuple expectedTuple("", "Acc-SEC_GROUP_OUT_TABLE", "9e:72:a6:94:18:af", "5a:08:66:ce:0b:49", "IPv4", "14.0.0.2", "100.0.0.1" ,"UDP", "60376", "161");
     std::string expected(" MAC=5a:08:66:ce:0b:49:9e:72:a6:94:18:af:IPv4 SRC=14.0.0.2 DST=100.0.0.1 LEN=28 DSCP=0 TTL=255 ID=0 FLAGS=0 FRAG=0 PROTO=UDP SPT=60376 DPT=161 LEN=74");
-    pktDecoder.decode(udp_buf, 66, p);
+    int ret = pktDecoder.decode(udp_buf, 66, p);
+    BOOST_CHECK(ret == 0);
     std::string dropReason;
     pktLogger.getDropReason(p, dropReason);
     p.packetTuple.setField(0, dropReason);
@@ -131,7 +161,8 @@ BOOST_FIXTURE_TEST_CASE(udp_over_v6_test, PacketDecoderFixture) {
     ParseInfo p(&pktDecoder);
     PacketTuple expectedTuple("", "Int-SERVICE_REV_TABLE", "9e:72:a6:94:18:af", "5a:08:66:ce:0b:49", "IPv6", "fe80::a00:27ff:fefe:8f95", "ff02::1:2" ,"UDP", "546", "547");
     std::string expected(" MAC=5a:08:66:ce:0b:49:9e:72:a6:94:18:af:IPv6 SRC=fe80::a00:27ff:fefe:8f95 DST=ff02::1:2 LEN=60 TC=0 HL=1 FL=0 PROTO=UDP SPT=546 DPT=547 LEN=60");
-    pktDecoder.decode(udpv6_buf, 86, p);
+    int ret = pktDecoder.decode(udpv6_buf, 86, p);
+    BOOST_CHECK(ret == 0);
     std::string dropReason;
     pktLogger.getDropReason(p, dropReason);
     p.packetTuple.setField(0, dropReason);
@@ -144,7 +175,8 @@ BOOST_FIXTURE_TEST_CASE(tcp_over_v6_test, PacketDecoderFixture) {
     ParseInfo p(&pktDecoder);
     PacketTuple expectedTuple("", "Int-BRIDGE_TABLE", "9e:72:a6:94:18:af", "5a:08:66:ce:0b:49", "IPv6", "fe80::a00:27ff:fefe:8f95", "ff02::1:2" ,"TCP", "41634", "179");
     std::string expected(" MAC=5a:08:66:ce:0b:49:9e:72:a6:94:18:af:IPv6 SRC=fe80::a00:27ff:fefe:8f95 DST=ff02::1:2 LEN=60 TC=0 HL=1 FL=0 PROTO=TCP SPT=41634 DPT=179 SEQ=2939917199 ACK=0 LEN=10 WINDOWS=29200 SYN  URGP=0");
-    pktDecoder.decode(tcpv6_buf, 118, p);
+    int ret = pktDecoder.decode(tcpv6_buf, 118, p);
+    BOOST_CHECK(ret == 0);
     std::string dropReason;
     pktLogger.getDropReason(p, dropReason);
     p.packetTuple.setField(0, dropReason);
@@ -152,4 +184,17 @@ BOOST_FIXTURE_TEST_CASE(tcp_over_v6_test, PacketDecoderFixture) {
     BOOST_CHECK(p.packetTuple == expectedTuple);
 }
 
+BOOST_FIXTURE_TEST_CASE(ip_options_unrecognized_test, PacketDecoderFixture) {
+    auto pktDecoder = pktLogger.getDecoder();
+    ParseInfo p(&pktDecoder);
+    PacketTuple expectedTuple("", "Int-PORT_SECURITY_TABLE", "fa:16:3e:d3:f3:0b", "01:00:5e:00:00:16", "IPv4", "192.168.210.8", "224.0.0.22" ,"2_unrecognized", "", "");
+    std::string expected(" MAC=01:00:5e:00:00:16:fa:16:3e:d3:f3:0b:Qtag QTAG=4094 SRC=192.168.210.8 DST=224.0.0.22 LEN=40 DSCP=48 TTL=1 ID=0 FLAGS=2 FRAG=0 PROTO=2_unrecognized");
+    int ret = pktDecoder.decode(igmp_buf, 178, p);
+    BOOST_CHECK(ret == 0);
+    std::string dropReason;
+    pktLogger.getDropReason(p, dropReason);
+    p.packetTuple.setField(0, dropReason);
+    BOOST_CHECK(p.parsedString == expected);
+    BOOST_CHECK(p.packetTuple == expectedTuple);
+}
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Ip options are currently not recognized, do not return error in this
case. Avoid including brackets in strings, as this seems to cause
errors in json parsing.Fix parsing of qtag

Signed-off-by: Kiran Shastri <shastrinator@gmail.com>