### PR TITLE
Support for agent specific prometheus metrics in opflex-server

### DIFF
--- a/agent-ovs/Makefile.am
+++ b/agent-ovs/Makefile.am
@@ -439,6 +439,7 @@ endif
 agent_test_CFLAGS =
 agent_test_CXXFLAGS = \
 	-I$(top_srcdir)/lib/include \
+	-I$(top_srcdir)/server/include \
 	-I$(top_srcdir)/cmd/test/include \
 	$(libopflex_CFLAGS) $(libmodelgbp_CFLAGS) \
 	-DBOOST_TEST_DYN_LINK
@@ -482,6 +483,8 @@ agent_test_SOURCES = \
 	lib/test/SnatManager_test.cpp \
 	lib/test/QosManager_test.cpp \
 	lib/test/FaultManager_test.cpp \
+	server/test/AgentStats_test.cpp \
+	server/ServerPrometheusManager.cpp \
 	cmd/test/agent_test.cpp
 
 agent_test_LDADD = \
@@ -491,6 +494,10 @@ agent_test_LDADD = \
 	$(BOOST_SYSTEM_LIB) \
 	$(BOOST_UNIT_TEST_FRAMEWORK_LIB) \
 	libopflex_agent.la
+if ENABLE_PROMETHEUS
+agent_test_LDADD += $(PROMETHEUS_CORE_LIBS)
+agent_test_LDADD += $(PROMETHEUS_PULL_LIBS)
+endif
 
 if RENDERER_OVS
   agent_test_CFLAGS += \

--- a/agent-ovs/server/ServerPrometheusManager.cpp
+++ b/agent-ovs/server/ServerPrometheusManager.cpp
@@ -10,15 +10,83 @@
  */
 
 #include <opflexagent/PrometheusManager.h>
+#include <opflex/ofcore/OFServerStats.h>
 
 namespace opflexagent {
 
 using std::make_shared;
 using namespace prometheus::detail;
 
+static string ofagent_family_names[] =
+{
+  "opflex_agent_identity_req_count",
+  "opflex_agent_policy_update_count",
+  "opflex_agent_policy_unavailable_resolve_count",
+  "opflex_agent_policy_resolve_count",
+  "opflex_agent_policy_resolve_err_count",
+  "opflex_agent_policy_unresolve_count",
+  "opflex_agent_policy_unresolve_err_count",
+  "opflex_agent_ep_declare_count",
+  "opflex_agent_ep_declare_err_count",
+  "opflex_agent_ep_undeclare_count",
+  "opflex_agent_ep_undeclare_err_count",
+  "opflex_agent_ep_resolve_count",
+  "opflex_agent_ep_resolve_err_count",
+  "opflex_agent_ep_unresolve_count",
+  "opflex_agent_ep_unresolve_err_count",
+  "opflex_agent_state_report_count",
+  "opflex_agent_state_report_err_count"
+};
+
+static string ofagent_family_help[] =
+{
+  "number of identity requests received from an opflex agent",
+  "number of policy updates received from grpc server that are sent to an opflex agent",
+  "number of unavailable policies on resolves received from an opflex agent",
+  "number of policy resolves received from an opflex agent",
+  "number of errors on policy resolves received from an opflex agent",
+  "number of policy unresolves received from an opflex agent",
+  "number of errors on policy unresolves received from an opflex agent",
+  "number of endpoint declares received from an opflex agent",
+  "number of errors on endpoint declares received from an opflex agent",
+  "number of endpoint undeclares received from an opflex agent",
+  "number of errors on endpoint undeclares received from an opflex agent",
+  "number of endpoint resolves received from an opflex agent",
+  "number of errors on endpoint resolves received from an opflex agent",
+  "number of endpoint unresolves received from an opflex agent",
+  "number of errors on endpoint unresolves received from an opflex agent",
+  "number of state reports received from an opflex agent",
+  "number of errors on state reports received from an opflex agent"
+};
+
 // construct ServerPrometheusManager for opflex server
 ServerPrometheusManager::ServerPrometheusManager ()
-                                 : PrometheusManager() {}
+                                 : PrometheusManager()
+{
+    init();
+}
+
+// initialize state of ServerPrometheusManager instance
+void ServerPrometheusManager::init ()
+{
+    {
+        const lock_guard<mutex> lock(ofagent_stats_mutex);
+        for (OFAGENT_METRICS metric=OFAGENT_METRICS_MIN;
+                metric <= OFAGENT_METRICS_MAX;
+                    metric = OFAGENT_METRICS(metric+1)) {
+            gauge_ofagent_family_ptr[metric] = nullptr;
+        }
+    }
+}
+
+// create all gauge families during start
+void ServerPrometheusManager::createStaticGaugeFamilies (void)
+{
+    {
+        const lock_guard<mutex> lock(ofagent_stats_mutex);
+        createStaticGaugeFamiliesOFAgent();
+    }
+}
 
 // Start of ServerPrometheusManager instance
 void ServerPrometheusManager::start (bool exposeLocalHostOnly)
@@ -43,6 +111,11 @@ void ServerPrometheusManager::start (bool exposeLocalHostOnly)
 
     // ask the exposer to scrape the registry on incoming scrapes
     exposer_ptr->RegisterCollectable(registry_ptr);
+
+    /* Initialize Metric families which can be created during
+     * init time */
+    createStaticCounterFamilies();
+    createStaticGaugeFamilies();
 }
 
 // Stop of ServerPrometheusManager instance
@@ -52,6 +125,13 @@ void ServerPrometheusManager::stop ()
     disabled = true;
     LOG(DEBUG) << "stopping prometheus manager";
 
+    // Gracefully delete state
+    // Remove metrics
+    removeDynamicGauges();
+
+    // Remove metric families
+    removeStaticGaugeFamilies();
+
     gauge_check.clear();
     counter_check.clear();
 
@@ -60,6 +140,226 @@ void ServerPrometheusManager::stop ()
 
     registry_ptr.reset();
     registry_ptr = nullptr;
+}
+
+// Remove all statically allocated gauge families
+void ServerPrometheusManager::removeStaticGaugeFamilies()
+{
+    // OFAgent stats specific
+    {
+        const lock_guard<mutex> lock(ofagent_stats_mutex);
+        removeStaticGaugeFamiliesOFAgent();
+    }
+}
+
+// remove all dynamic counters during stop
+void ServerPrometheusManager::removeDynamicGauges ()
+{
+    // Remove OFAgentStat related gauges
+    {
+        const lock_guard<mutex> lock(ofagent_stats_mutex);
+        removeDynamicGaugeOFAgent();
+    }
+}
+
+// create all OFAgent specific gauge families during start
+void ServerPrometheusManager::createStaticGaugeFamiliesOFAgent (void)
+{
+    // add a new gauge family to the registry (families combine values with the
+    // same name, but distinct label dimensions)
+    // Note: There is a unique ptr allocated and referencing the below reference
+    // during Register().
+
+    for (OFAGENT_METRICS metric=OFAGENT_METRICS_MIN;
+            metric <= OFAGENT_METRICS_MAX;
+                metric = OFAGENT_METRICS(metric+1)) {
+        auto& gauge_ofagent_family = BuildGauge()
+                             .Name(ofagent_family_names[metric])
+                             .Help(ofagent_family_help[metric])
+                             .Labels({})
+                             .Register(*registry_ptr);
+        gauge_ofagent_family_ptr[metric] = &gauge_ofagent_family;
+    }
+}
+
+// Create OFAgentStats gauge given metric type, agent (IP,port) tuple
+void ServerPrometheusManager::createDynamicGaugeOFAgent (OFAGENT_METRICS metric,
+                                                       const string& agent)
+{
+    // Retrieve the Gauge if its already created
+    if (getDynamicGaugeOFAgent(metric, agent))
+        return;
+
+    auto& gauge = gauge_ofagent_family_ptr[metric]->Add({{"agent", agent}});
+    if (gauge_check.is_dup(&gauge)) {
+        LOG(ERROR) << "duplicate ofagent dyn gauge family"
+                   << " metric: " << metric
+                   << " agent: " << agent;
+        return;
+    }
+    LOG(DEBUG) << "created ofagent dyn gauge family"
+               << " metric: " << metric
+               << " agent: " << agent;
+    gauge_check.add(&gauge);
+    ofagent_gauge_map[metric][agent] = &gauge;
+}
+
+// Get OFAgent stats gauge given the metric, agent (IP,port) tuple
+Gauge * ServerPrometheusManager::getDynamicGaugeOFAgent (OFAGENT_METRICS metric,
+                                                       const string& agent)
+{
+    Gauge *pgauge = nullptr;
+    auto itr = ofagent_gauge_map[metric].find(agent);
+    if (itr == ofagent_gauge_map[metric].end()) {
+        LOG(DEBUG) << "Dyn Gauge OFAgent stats not found"
+                   << " metric: " << metric
+                   << " agent: " << agent;
+    } else {
+        pgauge = itr->second;
+    }
+
+    return pgauge;
+}
+
+// Remove dynamic OFAgentStats gauge given a metic type and agent (IP,port) tuple
+// Note: The below api doesnt get called today. But keeping it in case we have
+// a requirement to delete a gauge metric per agent, in case an agent goes down
+// or restarts. This can be used after changes to remove the corresponding
+// observer mo.
+bool ServerPrometheusManager::removeDynamicGaugeOFAgent (OFAGENT_METRICS metric,
+                                                       const string& agent)
+{
+    Gauge *pgauge = getDynamicGaugeOFAgent(metric, agent);
+    if (pgauge) {
+        ofagent_gauge_map[metric].erase(agent);
+        gauge_check.remove(pgauge);
+        gauge_ofagent_family_ptr[metric]->Remove(pgauge);
+    } else {
+        LOG(DEBUG) << "remove dynamic gauge ofagent stats not found agent:" << agent;
+        return false;
+    }
+    return true;
+}
+
+// Remove dynamic OFAgentStats gauge given a metric type
+void ServerPrometheusManager::removeDynamicGaugeOFAgent (OFAGENT_METRICS metric)
+{
+    auto itr = ofagent_gauge_map[metric].begin();
+    while (itr != ofagent_gauge_map[metric].end()) {
+        LOG(DEBUG) << "Delete OFAgent stats agent: " << itr->first
+                   << " Gauge: " << itr->second;
+        gauge_check.remove(itr->second);
+        gauge_ofagent_family_ptr[metric]->Remove(itr->second);
+        itr++;
+    }
+
+    ofagent_gauge_map[metric].clear();
+}
+
+// Remove dynamic OFAgentStats gauges for all metrics
+void ServerPrometheusManager::removeDynamicGaugeOFAgent ()
+{
+    for (OFAGENT_METRICS metric=OFAGENT_METRICS_MIN;
+            metric <= OFAGENT_METRICS_MAX;
+                metric = OFAGENT_METRICS(metric+1)) {
+        removeDynamicGaugeOFAgent(metric);
+    }
+}
+
+// Remove all statically allocated OFAgent gauge families
+void ServerPrometheusManager::removeStaticGaugeFamiliesOFAgent ()
+{
+    for (OFAGENT_METRICS metric=OFAGENT_METRICS_MIN;
+            metric <= OFAGENT_METRICS_MAX;
+                metric = OFAGENT_METRICS(metric+1)) {
+        gauge_ofagent_family_ptr[metric] = nullptr;
+    }
+}
+
+/* Function called from PolicyStatsManager to update OFAgentStats */
+void ServerPrometheusManager::addNUpdateOFAgentStats (const std::string& agent,
+                                                    const std::shared_ptr<OFServerStats> stats)
+{
+    RETURN_IF_DISABLED
+    const lock_guard<mutex> lock(ofagent_stats_mutex);
+
+    if (!stats)
+        return;
+
+    // Create gauge metrics if they arent present already
+    for (OFAGENT_METRICS metric=OFAGENT_METRICS_MIN;
+            metric <= OFAGENT_METRICS_MAX;
+                metric = OFAGENT_METRICS(metric+1))
+        createDynamicGaugeOFAgent(metric, agent);
+
+    // Update the metrics
+    for (OFAGENT_METRICS metric=OFAGENT_METRICS_MIN;
+            metric <= OFAGENT_METRICS_MAX;
+                metric = OFAGENT_METRICS(metric+1)) {
+        Gauge *pgauge = getDynamicGaugeOFAgent(metric, agent);
+        optional<uint64_t>   metric_opt;
+        switch (metric) {
+        case OFAGENT_IDENT_REQS:
+            metric_opt = stats->getIdentReqs();
+            break;
+        case OFAGENT_POL_UPDATES:
+            metric_opt = stats->getPolUpdates();
+            break;
+        case OFAGENT_POL_UNAVAILABLE_RESOLVES:
+            metric_opt = stats->getPolUnavailableResolves();
+            break;
+        case OFAGENT_POL_RESOLVES:
+            metric_opt = stats->getPolResolves();
+            break;
+        case OFAGENT_POL_RESOLVE_ERRS:
+            metric_opt = stats->getPolResolveErrs();
+            break;
+        case OFAGENT_POL_UNRESOLVES:
+            metric_opt = stats->getPolUnresolves();
+            break;
+        case OFAGENT_POL_UNRESOLVE_ERRS:
+            metric_opt = stats->getPolUnresolveErrs();
+            break;
+        case OFAGENT_EP_DECLARES:
+            metric_opt = stats->getEpDeclares();
+            break;
+        case OFAGENT_EP_DECLARE_ERRS:
+            metric_opt = stats->getEpDeclareErrs();
+            break;
+        case OFAGENT_EP_UNDECLARES:
+            metric_opt = stats->getEpUndeclares();
+            break;
+        case OFAGENT_EP_UNDECLARE_ERRS:
+            metric_opt = stats->getEpUndeclareErrs();
+            break;
+        case OFAGENT_EP_RESOLVES:
+            metric_opt = stats->getEpResolves();
+            break;
+        case OFAGENT_EP_RESOLVE_ERRS:
+            metric_opt = stats->getEpResolveErrs();
+            break;
+        case OFAGENT_EP_UNRESOLVES:
+            metric_opt = stats->getEpUnresolves();
+            break;
+        case OFAGENT_EP_UNRESOLVE_ERRS:
+            metric_opt = stats->getEpUnresolveErrs();
+            break;
+        case OFAGENT_STATE_REPORTS:
+            metric_opt = stats->getStateReports();
+            break;
+        case OFAGENT_STATE_REPORT_ERRS:
+            metric_opt = stats->getStateReportErrs();
+            break;
+        default:
+            LOG(ERROR) << "Unhandled ofagent metric: " << metric;
+        }
+        if (metric_opt && pgauge)
+            pgauge->Set(static_cast<double>(metric_opt.get()));
+        if (!pgauge) {
+            LOG(ERROR) << "Invalid ofagent update agent: " << agent;
+            break;
+        }
+    }
 }
 
 } /* namespace opflexagent */

--- a/agent-ovs/server/StatsIO.cpp
+++ b/agent-ovs/server/StatsIO.cpp
@@ -104,8 +104,13 @@ void StatsIO::on_timer_stats (const boost::system::error_code& ec) {
                     .setEpUndeclareErrs(peerStat.second->getEpUndeclareErrs())
                     .setEpResolves(peerStat.second->getEpResolves())
                     .setEpResolveErrs(peerStat.second->getEpResolveErrs())
+                    .setEpUnresolves(peerStat.second->getEpUnresolves())
+                    .setEpUnresolveErrs(peerStat.second->getEpUnresolveErrs())
                     .setStateReports(peerStat.second->getStateReports())
                     .setStateReportErrs(peerStat.second->getStateReportErrs());
+#ifdef HAVE_PROMETHEUS_SUPPORT
+            prometheusManager.addNUpdateOFAgentStats(peerStat.first, peerStat.second);
+#endif
         }
     }
     mutator.commit();

--- a/agent-ovs/server/test/AgentStats_test.cpp
+++ b/agent-ovs/server/test/AgentStats_test.cpp
@@ -1,0 +1,197 @@
+/*
+ * Test suite for class OFServerStats.
+ *
+ * Copyright (c) 2020 Cisco Systems, Inc. and others.  All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ */
+
+#include <sstream>
+#include <boost/test/unit_test.hpp>
+#include <boost/assign/list_of.hpp>
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <opflexagent/logging.h>
+#include <opflexagent/test/BaseFixture.h>
+#include <lib/util.h>
+#include <opflex/modb/Mutator.h>
+#ifdef HAVE_PROMETHEUS_SUPPORT
+#include <opflexagent/PrometheusManager.h>
+#endif
+#include <opflex/ofcore/OFServerStats.h>
+
+using namespace boost::assign;
+using boost::optional;
+using std::shared_ptr;
+using std::string;
+using namespace modelgbp::gbp;
+using namespace modelgbp::gbpe;
+using modelgbp::observer::PolicyStatUniverse;
+using opflex::modb::class_id_t;
+using opflex::modb::Mutator;
+
+namespace opflexagent {
+
+class AgentStatsFixture : public BaseFixture {
+    typedef opflex::ofcore::OFConstants::OpflexElementMode opflex_elem_t;
+public:
+    AgentStatsFixture(opflex_elem_t mode = opflex_elem_t::INVALID_MODE) : BaseFixture(mode)
+    {
+        prometheusManager.start(true);
+    }
+
+    virtual ~AgentStatsFixture()
+    {
+        prometheusManager.stop();
+    }
+
+    void updateOFAgentStats(std::shared_ptr<OFServerStats> opflexStats);
+#ifdef HAVE_PROMETHEUS_SUPPORT
+    void verifyOFAgentMetrics(const std::string& agent, uint32_t count);
+    const string cmd = "curl --proxy \"\" --compressed --silent http://127.0.0.1:9632/metrics 2>&1;";
+    ServerPrometheusManager prometheusManager;
+#endif
+};
+
+void AgentStatsFixture::
+updateOFAgentStats (std::shared_ptr<OFServerStats> opflexStats)
+{
+    opflexStats->incrIdentReqs();
+    opflexStats->incrPolUpdates();
+    opflexStats->incrPolUnavailableResolves();
+    opflexStats->incrPolResolves();
+    opflexStats->incrPolResolveErrs();
+    opflexStats->incrPolUnresolves();
+    opflexStats->incrPolUnresolveErrs();
+    opflexStats->incrEpDeclares();
+    opflexStats->incrEpDeclareErrs();
+    opflexStats->incrEpUndeclares();
+    opflexStats->incrEpUndeclareErrs();
+    opflexStats->incrEpResolves();
+    opflexStats->incrEpResolveErrs();
+    opflexStats->incrEpUnresolves();
+    opflexStats->incrEpUnresolveErrs();
+    opflexStats->incrStateReports();
+    opflexStats->incrStateReportErrs();
+}
+
+#ifdef HAVE_PROMETHEUS_SUPPORT
+void AgentStatsFixture::
+verifyOFAgentMetrics (const std::string& agent, uint32_t count)
+{
+    const std::string& output = BaseFixture::getOutputFromCommand(cmd);
+    size_t pos = std::string::npos;
+    const auto& val = std::to_string(count) + ".000000";
+
+    const std::string& ident_req = "opflex_agent_identity_req_count{agent=\""
+                                   + agent + "\"} " + val;
+    pos = output.find(ident_req);
+    BOOST_CHECK_NE(pos, std::string::npos);
+
+    const std::string& pol_upd = "opflex_agent_policy_update_count{agent=\""
+                                   + agent + "\"} " + val;
+    pos = output.find(pol_upd);
+    BOOST_CHECK_NE(pos, std::string::npos);
+
+    const std::string& res_un = "opflex_agent_policy_unavailable_resolve_count{agent=\""
+                                   + agent + "\"} " + val;
+    pos = output.find(res_un);
+    BOOST_CHECK_NE(pos, std::string::npos);
+
+    const std::string& res_req = "opflex_agent_policy_resolve_count{agent=\""
+                                   + agent + "\"} " + val;
+    pos = output.find(res_req);
+    BOOST_CHECK_NE(pos, std::string::npos);
+    const std::string& res_err = "opflex_agent_policy_resolve_err_count{agent=\""
+                                   + agent + "\"} " + val;
+    pos = output.find(res_err);
+    BOOST_CHECK_NE(pos, std::string::npos);
+
+    const std::string& unres_req = "opflex_agent_policy_unresolve_count{agent=\""
+                                   + agent + "\"} " + val;
+    pos = output.find(unres_req);
+    BOOST_CHECK_NE(pos, std::string::npos);
+    const std::string& unres_err = "opflex_agent_policy_unresolve_err_count{agent=\""
+                                   + agent + "\"} " + val;
+    pos = output.find(unres_err);
+    BOOST_CHECK_NE(pos, std::string::npos);
+
+    const std::string& epd_req = "opflex_agent_ep_declare_count{agent=\""
+                                   + agent + "\"} " + val;
+    pos = output.find(epd_req);
+    BOOST_CHECK_NE(pos, std::string::npos);
+    const std::string& epd_err = "opflex_agent_ep_declare_err_count{agent=\""
+                                   + agent + "\"} " + val;
+    pos = output.find(epd_err);
+    BOOST_CHECK_NE(pos, std::string::npos);
+
+    const std::string& epud_req = "opflex_agent_ep_undeclare_count{agent=\""
+                                   + agent + "\"} " + val;
+    pos = output.find(epud_req);
+    BOOST_CHECK_NE(pos, std::string::npos);
+    const std::string& epud_err = "opflex_agent_ep_undeclare_err_count{agent=\""
+                                   + agent + "\"} " + val;
+    pos = output.find(epud_err);
+    BOOST_CHECK_NE(pos, std::string::npos);
+
+    const std::string& epr_req = "opflex_agent_ep_resolve_count{agent=\""
+                                   + agent + "\"} " + val;
+    pos = output.find(epr_req);
+    BOOST_CHECK_NE(pos, std::string::npos);
+    const std::string& epr_err = "opflex_agent_ep_resolve_err_count{agent=\""
+                                   + agent + "\"} " + val;
+    pos = output.find(epr_err);
+    BOOST_CHECK_NE(pos, std::string::npos);
+
+    const std::string& epur_req = "opflex_agent_ep_unresolve_count{agent=\""
+                                   + agent + "\"} " + val;
+    pos = output.find(epur_req);
+    BOOST_CHECK_NE(pos, std::string::npos);
+    const std::string& epur_err = "opflex_agent_ep_unresolve_err_count{agent=\""
+                                   + agent + "\"} " + val;
+    pos = output.find(epur_err);
+    BOOST_CHECK_NE(pos, std::string::npos);
+
+    const std::string& rep_req = "opflex_agent_state_report_count{agent=\""
+                                   + agent + "\"} " + val;
+    pos = output.find(rep_req);
+    BOOST_CHECK_NE(pos, std::string::npos);
+    const std::string& rep_err = "opflex_agent_state_report_err_count{agent=\""
+                                   + agent + "\"} " + val;
+    pos = output.find(rep_err);
+    BOOST_CHECK_NE(pos, std::string::npos);
+}
+#endif
+
+BOOST_AUTO_TEST_SUITE(AgentStats_test)
+
+BOOST_FIXTURE_TEST_CASE(testOFAgent, AgentStatsFixture) {
+
+    LOG(DEBUG) << "### OfAgent start";
+    std::shared_ptr<OFServerStats> opflexStats = std::make_shared<OFServerStats>();
+    const std::string agent = "127.0.0.1:9999";
+
+    updateOFAgentStats(opflexStats);
+#ifdef HAVE_PROMETHEUS_SUPPORT
+    prometheusManager.addNUpdateOFAgentStats("127.0.0.1:9999",
+                                             opflexStats);
+    verifyOFAgentMetrics(agent, 1);
+#endif
+
+    updateOFAgentStats(opflexStats);
+#ifdef HAVE_PROMETHEUS_SUPPORT
+    prometheusManager.addNUpdateOFAgentStats("127.0.0.1:9999",
+                                             opflexStats);
+    verifyOFAgentMetrics(agent, 2);
+#endif
+    LOG(DEBUG) << "### OFAgent end";
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}


### PR DESCRIPTION
- integration with prometheus
- macke check integration as part of agent_test
- TODO:
    - OFAgent/OFServerStats today dont get freed up on connection restart. Will be addressed next.
    - Readme and grafana to be updated

Sample curl output:
# HELP opflex_agent_identity_req_count number of identity requests received from an opflex agent
# TYPE opflex_agent_identity_req_count gauge
opflex_agent_identity_req_count{agent="127.0.0.1:9999"} 1.000000
# HELP opflex_agent_policy_update_count number of policy updates received from grpc server that are sent to an opflex agent
# TYPE opflex_agent_policy_update_count gauge
opflex_agent_policy_update_count{agent="127.0.0.1:9999"} 1.000000
# HELP opflex_agent_policy_unavailable_resolve_count number of unavailable policies on resolves received from an opflex agent
# TYPE opflex_agent_policy_unavailable_resolve_count gauge
opflex_agent_policy_unavailable_resolve_count{agent="127.0.0.1:9999"} 1.000000
# HELP opflex_agent_policy_resolve_count number of policy resolves received from an opflex agent
# TYPE opflex_agent_policy_resolve_count gauge
opflex_agent_policy_resolve_count{agent="127.0.0.1:9999"} 1.000000
# HELP opflex_agent_policy_resolve_err_count number of errors on policy resolves received from an opflex agent
# TYPE opflex_agent_policy_resolve_err_count gauge
opflex_agent_policy_resolve_err_count{agent="127.0.0.1:9999"} 0.000000

Signed-off-by: Gautam Venkataramanan <gautam.chennai@gmail.com>