### PR TITLE
Fix buffer truncation issue

### DIFF
--- a/agent-ovs/ovs/PacketLogHandler.cpp
+++ b/agent-ovs/ovs/PacketLogHandler.cpp
@@ -66,7 +66,7 @@ void LocalClient::run() {
                     event_count++;
                 }
                 writer.EndArray();
-                pendingDataLen = (buffer.GetSize()>4096? 4096: buffer.GetSize());
+                pendingDataLen = (buffer.GetSize()>PACKET_EVENT_BUFFER_SIZE)? PACKET_EVENT_BUFFER_SIZE: buffer.GetSize();
                 memcpy(send_buffer.data(), buffer.GetString(),
                         pendingDataLen);
             }
@@ -145,7 +145,8 @@ void UdpServer::handleReceive(const boost::system::error_code& error,
 
     if (!error || error == boost::asio::error::message_size)
     {
-        uint32_t length = (bytes_transferred > 4096) ? 4096: bytes_transferred;
+        uint32_t length = (bytes_transferred > PACKET_CAPTURE_BUFFER_SIZE) ?
+            PACKET_CAPTURE_BUFFER_SIZE: bytes_transferred;
         this->pktLogger.parseLog(recv_buffer.data(), length);
     }
     if(!stopped) {
@@ -183,17 +184,26 @@ void PacketLogHandler::getDropReason(ParseInfo &p, std::string &dropReason) {
 }
 
 void PacketLogHandler::parseLog(unsigned char *buf , std::size_t length) {
+/* Skip printing Geneve Header and Options*/
+#define PACKET_DUMP_OFFSET 132
+/*Typical length of Packet is TCP ACK 40 Bytes*/
+#define PACKET_DUMP_LEN   50
+#define PACKET_DUMP_REQUIRED_LEN 232
     ParseInfo p(&pktDecoder);
     int ret = pktDecoder.decode(buf, length, p);
     if(ret) {
         LOG(ERROR) << "Error parsing packet " << ret;
         std::stringstream str;
-        int maxPrintLen = (length < 100)? length: 100;
+        int maxPrintLen = (length <= PACKET_DUMP_REQUIRED_LEN)? length: PACKET_DUMP_LEN;
         for(int i =0; i < maxPrintLen; i++) {
             if(i%32 == 0){
                 str << std::endl;
             }
-            str << std::hex << (uint32_t)buf[i] << " ";
+            if(length <= PACKET_DUMP_REQUIRED_LEN) {
+                str << std::hex << (uint32_t)buf[i] << " ";
+            } else {
+                str << std::hex << (uint32_t)buf[PACKET_DUMP_OFFSET+i] << " ";
+            }
         }
         LOG(ERROR) << str.str();
     } else {

--- a/agent-ovs/ovs/include/PacketLogHandler.h
+++ b/agent-ovs/ovs/include/PacketLogHandler.h
@@ -25,6 +25,8 @@
 #ifndef OPFLEXAGENT_PACKETLOGHANDLER_H_
 #define OPFLEXAGENT_PACKETLOGHANDLER_H_
 
+#define PACKET_EVENT_BUFFER_SIZE 8192
+#define PACKET_CAPTURE_BUFFER_SIZE 12288
 namespace opflexagent {
 
 class PacketLogHandler;
@@ -73,7 +75,7 @@ public:
      */
     void startReceive() {
         serverSocket.async_receive_from(
-            boost::asio::buffer(recv_buffer, 4096), remoteEndpoint,
+            boost::asio::buffer(recv_buffer, PACKET_CAPTURE_BUFFER_SIZE), remoteEndpoint,
             boost::bind(&UdpServer::handleReceive, this,
               boost::asio::placeholders::error,
               boost::asio::placeholders::bytes_transferred));
@@ -98,7 +100,7 @@ private:
     boost::asio::ip::udp::socket serverSocket;
     boost::asio::ip::udp::endpoint localEndpoint;
     boost::asio::ip::udp::endpoint remoteEndpoint;
-    boost::array<unsigned char, 4096> recv_buffer;
+    boost::array<unsigned char, PACKET_CAPTURE_BUFFER_SIZE> recv_buffer;
     std::atomic<bool> stopped;
 };
 
@@ -137,7 +139,7 @@ private:
     PacketLogHandler &pktLogger;
     boost::asio::local::stream_protocol::socket clientSocket;
     boost::asio::local::stream_protocol::endpoint remoteEndpoint;
-    boost::array<unsigned char, 4096> send_buffer;
+    boost::array<unsigned char, PACKET_EVENT_BUFFER_SIZE> send_buffer;
     std::atomic<bool> stopped;
     bool connected;
     unsigned pendingDataLen;


### PR DESCRIPTION
With IPv6 packets, 10 packet events exceed 4k boundary slightly at
4310 bytes, this causes json parsing errors in host-agent, increase to
8k.Also increase packet capture size, incase a jumbo packet is captured
to 12k.
TODO: Will add test coverage

Signed-off-by: Kiran Shastri <shastrinator@gmail.com>