### PR TITLE
Fix buffer truncation issue

### DIFF
--- a/agent-ovs/ovs/include/PacketLogHandler.h
+++ b/agent-ovs/ovs/include/PacketLogHandler.h
@@ -25,6 +25,8 @@
 #ifndef OPFLEXAGENT_PACKETLOGHANDLER_H_
 #define OPFLEXAGENT_PACKETLOGHANDLER_H_
 
+#define PACKET_EVENT_BUFFER_SIZE 8192
+#define PACKET_CAPTURE_BUFFER_SIZE 12288
 namespace opflexagent {
 
 class PacketLogHandler;
@@ -73,7 +75,7 @@ public:
      */
     void startReceive() {
         serverSocket.async_receive_from(
-            boost::asio::buffer(recv_buffer, 4096), remoteEndpoint,
+            boost::asio::buffer(recv_buffer, PACKET_CAPTURE_BUFFER_SIZE), remoteEndpoint,
             boost::bind(&UdpServer::handleReceive, this,
               boost::asio::placeholders::error,
               boost::asio::placeholders::bytes_transferred));
@@ -99,8 +101,8 @@ private:
     boost::asio::ip::udp::socket serverSocket;
     boost::asio::ip::udp::endpoint localEndpoint;
     boost::asio::ip::udp::endpoint remoteEndpoint;
-    boost::array<unsigned char, 4096> recv_buffer;
-    bool stopped;
+    boost::array<unsigned char, PACKET_CAPTURE_BUFFER_SIZE> recv_buffer;
+    std::atomic<bool> stopped;
 };
 
 /**
@@ -138,8 +140,8 @@ private:
     PacketLogHandler &pktLogger;
     boost::asio::local::stream_protocol::socket clientSocket;
     boost::asio::local::stream_protocol::endpoint remoteEndpoint;
-    boost::array<unsigned char, 4096> send_buffer;
-    bool stopped;
+    boost::array<unsigned char, PACKET_EVENT_BUFFER_SIZE> send_buffer;
+    std::atomic<bool> stopped;
     bool connected;
     unsigned pendingDataLen;
     static const unsigned maxEventsPerBuffer=10;


### PR DESCRIPTION
With IPv6 packets, 10 packet events exceed 4k boundary slightly at
4310 bytes, this causes json parsing errors in host-agent, increase to
8k.Also increase packet capture size, incase a jumbo packet is captured
to 12k.
TODO: Will add test coverage

Signed-off-by: Kiran Shastri <shastrinator@gmail.com>
(cherry picked from commit d58d5f6259cf40ed704eaf12198d5a508b02322b)