### PR TITLE
Remove OFAgent/ServerStats objects from MoDB when connection is removed

### DIFF
--- a/agent-ovs/lib/include/opflexagent/PrometheusManager.h
+++ b/agent-ovs/lib/include/opflexagent/PrometheusManager.h
@@ -239,11 +239,16 @@ public:
     /**
      * Create OFAgentStats metric family if its not present.
      * Update OFAgentStats metric family if its already present
-     * @param agent   the opflex peer; typically the peerIp:port
-     * @param stats   opflex stats corresponding to the peer
+     * @param agent   the opflex agent; typically the agentIp:port
+     * @param stats   opflex stats corresponding to the agent
      */
     void addNUpdateOFAgentStats(const std::string& agent,
                                 const std::shared_ptr<OFServerStats> stats);
+    /**
+     * Remove OFAgentStats metric family given the agent IP+port.
+     * @param agent    the opflex agent; typically the agentIp:port
+     */
+    void removeOFAgentStats(const std::string& agent);
 
 private:
     // Init state
@@ -481,6 +486,11 @@ public:
      */
     void addNUpdateOFPeerStats(const std::string& peer,
                                const std::shared_ptr<OFAgentStats> stats);
+    /**
+     * Remove OFPeerStats metric family given the peer IP+port.
+     * @param peer    the opflex peer; typically the peerIp:port
+     */
+    void removeOFPeerStats(const std::string& peer);
 
 
     /* SvcCounter related APIs */

--- a/agent-ovs/lib/include/opflexagent/test/BaseFixture.h
+++ b/agent-ovs/lib/include/opflexagent/test/BaseFixture.h
@@ -9,6 +9,10 @@
  * and is available at http://www.eclipse.org/legal/epl-v10.html
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include <time.h>
 #include <opflex/ofcore/OFFramework.h>
 #include <opflex/ofcore/OFConstants.h>
@@ -88,6 +92,23 @@ typedef opflex::ofcore::OFConstants::OpflexElementMode opflex_elem_t;
         }
         return output;
     }
+
+#ifdef HAVE_PROMETHEUS_SUPPORT
+    /**
+     * Function to check if given position of metric is expected or not
+     * in the prometheus curl output
+     *
+     * @param isAdd    flag to indicate if metric is added/deleted
+     * @param pos      expected position of metric in curl output
+     */
+    static inline void expPosition (bool isAdd, const size_t& pos)
+    {
+        if (isAdd)
+            BOOST_CHECK_NE(pos, std::string::npos);
+        else
+            BOOST_CHECK_EQUAL(pos, std::string::npos);
+    }
+#endif
 
     /**
      * A framework object

--- a/agent-ovs/lib/test/ServiceManager_test.cpp
+++ b/agent-ovs/lib/test/ServiceManager_test.cpp
@@ -303,14 +303,6 @@ void ServiceManagerFixture::checkServiceState (bool isCreate)
 }
 
 #ifdef HAVE_PROMETHEUS_SUPPORT
-static inline void expPosition (bool isAdd, const size_t& pos)
-{
-    if (isAdd)
-        BOOST_CHECK_NE(pos, std::string::npos);
-    else
-        BOOST_CHECK_EQUAL(pos, std::string::npos);
-}
-
 // Check prom dyn gauge service metrics
 void ServiceManagerFixture::checkServicePromMetrics (bool isAdd, bool isExternal, bool isUpdate)
 {
@@ -333,32 +325,32 @@ void ServiceManagerFixture::checkServicePromMetrics (bool isAdd, bool isExternal
     }
 
     pos = output.find("opflex_svc_rx_bytes{" + str + "} 0.000000");
-    expPosition(isAdd, pos);
+    BaseFixture::expPosition(isAdd, pos);
     pos = output.find("opflex_svc_rx_packets{" + str + "} 0.000000");
-    expPosition(isAdd, pos);
+    BaseFixture::expPosition(isAdd, pos);
     pos = output.find("opflex_svc_tx_bytes{" + str + "} 0.000000");
-    expPosition(isAdd, pos);
+    BaseFixture::expPosition(isAdd, pos);
     pos = output.find("opflex_svc_tx_packets{" + str + "} 0.000000");
-    expPosition(isAdd, pos);
+    BaseFixture::expPosition(isAdd, pos);
 
     if (isExternal || !as.isNodePort()) {
         pos = output.find("opflex_svc_rx_bytes{" + str2 + "} 0.000000");
-        expPosition(false, pos);
+        BaseFixture::expPosition(false, pos);
         pos = output.find("opflex_svc_rx_packets{" + str2 + "} 0.000000");
-        expPosition(false, pos);
+        BaseFixture::expPosition(false, pos);
         pos = output.find("opflex_svc_tx_bytes{" + str2 + "} 0.000000");
-        expPosition(false, pos);
+        BaseFixture::expPosition(false, pos);
         pos = output.find("opflex_svc_tx_packets{" + str2 + "} 0.000000");
-        expPosition(false, pos);
+        BaseFixture::expPosition(false, pos);
     } else {
         pos = output.find("opflex_svc_rx_bytes{" + str2 + "} 0.000000");
-        expPosition(isAdd, pos);
+        BaseFixture::expPosition(isAdd, pos);
         pos = output.find("opflex_svc_rx_packets{" + str2 + "} 0.000000");
-        expPosition(isAdd, pos);
+        BaseFixture::expPosition(isAdd, pos);
         pos = output.find("opflex_svc_tx_bytes{" + str2 + "} 0.000000");
-        expPosition(isAdd, pos);
+        BaseFixture::expPosition(isAdd, pos);
         pos = output.find("opflex_svc_tx_packets{" + str2 + "} 0.000000");
-        expPosition(isAdd, pos);
+        BaseFixture::expPosition(isAdd, pos);
     }
 }
 // Check prom dyn gauge service target metrics
@@ -386,32 +378,32 @@ void ServiceManagerFixture::checkServiceTargetPromMetrics (bool isAdd,
     }
 
     pos = output.find("opflex_svc_target_rx_bytes{ip=\""+ip+str);
-    expPosition(isAdd, pos);
+    BaseFixture::expPosition(isAdd, pos);
     pos = output.find("opflex_svc_target_rx_packets{ip=\""+ip+str);
-    expPosition(isAdd, pos);
+    BaseFixture::expPosition(isAdd, pos);
     pos = output.find("opflex_svc_target_tx_bytes{ip=\""+ip+str);
-    expPosition(isAdd, pos);
+    BaseFixture::expPosition(isAdd, pos);
     pos = output.find("opflex_svc_target_tx_packets{ip=\""+ip+str);
-    expPosition(isAdd, pos);
+    BaseFixture::expPosition(isAdd, pos);
 
     if (isExternal || !as.isNodePort()) {
         pos = output.find("opflex_svc_target_rx_bytes{ip=\""+ip+str2);
-        expPosition(false, pos);
+        BaseFixture::expPosition(false, pos);
         pos = output.find("opflex_svc_target_rx_packets{ip=\""+ip+str2);
-        expPosition(false, pos);
+        BaseFixture::expPosition(false, pos);
         pos = output.find("opflex_svc_target_tx_bytes{ip=\""+ip+str2);
-        expPosition(false, pos);
+        BaseFixture::expPosition(false, pos);
         pos = output.find("opflex_svc_target_tx_packets{ip=\""+ip+str2);
-        expPosition(false, pos);
+        BaseFixture::expPosition(false, pos);
     } else {
         pos = output.find("opflex_svc_target_rx_bytes{ip=\""+ip+str2);
-        expPosition(isAdd, pos);
+        BaseFixture::expPosition(isAdd, pos);
         pos = output.find("opflex_svc_target_rx_packets{ip=\""+ip+str2);
-        expPosition(isAdd, pos);
+        BaseFixture::expPosition(isAdd, pos);
         pos = output.find("opflex_svc_target_tx_bytes{ip=\""+ip+str2);
-        expPosition(isAdd, pos);
+        BaseFixture::expPosition(isAdd, pos);
         pos = output.find("opflex_svc_target_tx_packets{ip=\""+ip+str2);
-        expPosition(isAdd, pos);
+        BaseFixture::expPosition(isAdd, pos);
     }
 }
 #endif

--- a/agent-ovs/ovs/test/ContractStatsManager_test.cpp
+++ b/agent-ovs/ovs/test/ContractStatsManager_test.cpp
@@ -93,7 +93,7 @@ public:
                             bool isTx=false) override;
     void verifyRdDropPromMetrics(uint32_t pkts, uint32_t bytes);
     void updateOFPeerStats(std::shared_ptr<OFAgentStats> opflexStats);
-    void verifyOFPeerMetrics(const std::string& peer, uint32_t count);
+    void verifyOFPeerMetrics(const std::string& peer, uint32_t count, bool del);
 #endif
     IntFlowManager  intFlowManager;
     MockContractStatsManager contractStatsManager;
@@ -123,7 +123,7 @@ updateOFPeerStats (std::shared_ptr<OFAgentStats> opflexStats)
 }
 
 void ContractStatsManagerFixture::
-verifyOFPeerMetrics (const std::string& peer, uint32_t count)
+verifyOFPeerMetrics (const std::string& peer, uint32_t count, bool del)
 {
     const std::string& output = BaseFixture::getOutputFromCommand(cmd);
     size_t pos = std::string::npos;
@@ -133,90 +133,90 @@ verifyOFPeerMetrics (const std::string& peer, uint32_t count)
     const std::string& ident_req = "opflex_peer_identity_req_count{peer=\""
                                    + peer + "\"} " + val1;
     pos = output.find(ident_req);
-    BOOST_CHECK_NE(pos, std::string::npos);
+    BaseFixture::expPosition(!del, pos);
     const std::string ident_resp = "opflex_peer_identity_resp_count{peer=\""
                                    + peer + "\"} " + val1;
     pos = output.find(ident_resp);
-    BOOST_CHECK_NE(pos, std::string::npos);
+    BaseFixture::expPosition(!del, pos);
     const std::string ident_err = "opflex_peer_identity_err_count{peer=\""
                                    + peer + "\"} " + val2;
     pos = output.find(ident_err);
-    BOOST_CHECK_NE(pos, std::string::npos);
+    BaseFixture::expPosition(!del, pos);
 
     const std::string& res_req = "opflex_peer_policy_resolve_req_count{peer=\""
                                    + peer + "\"} " + val1;
     pos = output.find(res_req);
-    BOOST_CHECK_NE(pos, std::string::npos);
+    BaseFixture::expPosition(!del, pos);
     const std::string& res_resp = "opflex_peer_policy_resolve_resp_count{peer=\""
                                    + peer + "\"} " + val1;
     pos = output.find(res_resp);
-    BOOST_CHECK_NE(pos, std::string::npos);
+    BaseFixture::expPosition(!del, pos);
     const std::string& res_err = "opflex_peer_policy_resolve_err_count{peer=\""
                                    + peer + "\"} " + val2;
     pos = output.find(res_err);
-    BOOST_CHECK_NE(pos, std::string::npos);
+    BaseFixture::expPosition(!del, pos);
 
     const std::string& unres_req = "opflex_peer_policy_unresolve_req_count{peer=\""
                                    + peer + "\"} " + val1;
     pos = output.find(unres_req);
-    BOOST_CHECK_NE(pos, std::string::npos);
+    BaseFixture::expPosition(!del, pos);
     const std::string& unres_resp = "opflex_peer_policy_unresolve_resp_count{peer=\""
                                    + peer + "\"} " + val1;
     pos = output.find(unres_resp);
-    BOOST_CHECK_NE(pos, std::string::npos);
+    BaseFixture::expPosition(!del, pos);
     const std::string& unres_err = "opflex_peer_policy_unresolve_err_count{peer=\""
                                    + peer + "\"} " + val2;
     pos = output.find(unres_err);
-    BOOST_CHECK_NE(pos, std::string::npos);
+    BaseFixture::expPosition(!del, pos);
 
     const std::string& pol_upd = "opflex_peer_policy_update_receive_count{peer=\""
                                    + peer + "\"} " + val1;
     pos = output.find(pol_upd);
-    BOOST_CHECK_NE(pos, std::string::npos);
+    BaseFixture::expPosition(!del, pos);
 
     const std::string& epd_req = "opflex_peer_ep_declare_req_count{peer=\""
                                    + peer + "\"} " + val1;
     pos = output.find(epd_req);
-    BOOST_CHECK_NE(pos, std::string::npos);
+    BaseFixture::expPosition(!del, pos);
     const std::string& epd_resp = "opflex_peer_ep_declare_resp_count{peer=\""
                                    + peer + "\"} " + val1;
     pos = output.find(epd_resp);
-    BOOST_CHECK_NE(pos, std::string::npos);
+    BaseFixture::expPosition(!del, pos);
     const std::string& epd_err = "opflex_peer_ep_declare_err_count{peer=\""
                                    + peer + "\"} " + val2;
     pos = output.find(epd_err);
-    BOOST_CHECK_NE(pos, std::string::npos);
+    BaseFixture::expPosition(!del, pos);
 
     const std::string& epud_req = "opflex_peer_ep_undeclare_req_count{peer=\""
                                    + peer + "\"} " + val1;
     pos = output.find(epud_req);
-    BOOST_CHECK_NE(pos, std::string::npos);
+    BaseFixture::expPosition(!del, pos);
     const std::string& epud_resp = "opflex_peer_ep_undeclare_resp_count{peer=\""
                                    + peer + "\"} " + val1;
     pos = output.find(epud_resp);
-    BOOST_CHECK_NE(pos, std::string::npos);
+    BaseFixture::expPosition(!del, pos);
     const std::string& epud_err = "opflex_peer_ep_undeclare_err_count{peer=\""
                                    + peer + "\"} " + val2;
     pos = output.find(epud_err);
-    BOOST_CHECK_NE(pos, std::string::npos);
+    BaseFixture::expPosition(!del, pos);
 
     const std::string& rep_req = "opflex_peer_state_report_req_count{peer=\""
                                    + peer + "\"} " + val1;
     pos = output.find(rep_req);
-    BOOST_CHECK_NE(pos, std::string::npos);
+    BaseFixture::expPosition(!del, pos);
     const std::string& rep_resp = "opflex_peer_state_report_resp_count{peer=\""
                                    + peer + "\"} " + val1;
     pos = output.find(rep_resp);
-    BOOST_CHECK_NE(pos, std::string::npos);
+    BaseFixture::expPosition(!del, pos);
     const std::string& rep_err = "opflex_peer_state_report_err_count{peer=\""
                                    + peer + "\"} " + val2;
     pos = output.find(rep_err);
-    BOOST_CHECK_NE(pos, std::string::npos);
+    BaseFixture::expPosition(!del, pos);
  
     const std::string& unres_count = "opflex_peer_unresolved_policy_count{peer=\""
                                    + peer + "\"} " + val1;
     pos = output.find(unres_count);
-    BOOST_CHECK_NE(pos, std::string::npos);
+    BaseFixture::expPosition(!del, pos);
 }
 
 void ContractStatsManagerFixture::
@@ -624,14 +624,17 @@ BOOST_FIXTURE_TEST_CASE(testOFPeer, ContractStatsManagerFixture) {
     const std::string peer = "127.0.0.1:8009";
 
     updateOFPeerStats(opflexStats);
-    agent.getPrometheusManager().addNUpdateOFPeerStats("127.0.0.1:8009",
+    agent.getPrometheusManager().addNUpdateOFPeerStats(peer,
                                                        opflexStats);
-    verifyOFPeerMetrics(peer, 1);
+    verifyOFPeerMetrics(peer, 1, false);
 
     updateOFPeerStats(opflexStats);
-    agent.getPrometheusManager().addNUpdateOFPeerStats("127.0.0.1:8009",
+    agent.getPrometheusManager().addNUpdateOFPeerStats(peer,
                                                        opflexStats);
-    verifyOFPeerMetrics(peer, 2);
+    verifyOFPeerMetrics(peer, 2, false);
+
+    agent.getPrometheusManager().removeOFPeerStats(peer);
+    verifyOFPeerMetrics(peer, 0, true);
     LOG(DEBUG) << "### OFPeer end";
 }
 #endif

--- a/agent-ovs/server/test/AgentStats_test.cpp
+++ b/agent-ovs/server/test/AgentStats_test.cpp
@@ -52,7 +52,7 @@ public:
 
     void updateOFAgentStats(std::shared_ptr<OFServerStats> opflexStats);
 #ifdef HAVE_PROMETHEUS_SUPPORT
-    void verifyOFAgentMetrics(const std::string& agent, uint32_t count);
+    void verifyOFAgentMetrics(const std::string& agent, uint32_t count, bool del);
     const string cmd = "curl --proxy \"\" --compressed --silent http://127.0.0.1:9632/metrics 2>&1;";
     ServerPrometheusManager prometheusManager;
 #endif
@@ -82,7 +82,7 @@ updateOFAgentStats (std::shared_ptr<OFServerStats> opflexStats)
 
 #ifdef HAVE_PROMETHEUS_SUPPORT
 void AgentStatsFixture::
-verifyOFAgentMetrics (const std::string& agent, uint32_t count)
+verifyOFAgentMetrics (const std::string& agent, uint32_t count, bool del)
 {
     const std::string& output = BaseFixture::getOutputFromCommand(cmd);
     size_t pos = std::string::npos;
@@ -91,80 +91,80 @@ verifyOFAgentMetrics (const std::string& agent, uint32_t count)
     const std::string& ident_req = "opflex_agent_identity_req_count{agent=\""
                                    + agent + "\"} " + val;
     pos = output.find(ident_req);
-    BOOST_CHECK_NE(pos, std::string::npos);
+    BaseFixture::expPosition(!del, pos);
 
     const std::string& pol_upd = "opflex_agent_policy_update_count{agent=\""
                                    + agent + "\"} " + val;
     pos = output.find(pol_upd);
-    BOOST_CHECK_NE(pos, std::string::npos);
+    BaseFixture::expPosition(!del, pos);
 
     const std::string& res_un = "opflex_agent_policy_unavailable_resolve_count{agent=\""
                                    + agent + "\"} " + val;
     pos = output.find(res_un);
-    BOOST_CHECK_NE(pos, std::string::npos);
+    BaseFixture::expPosition(!del, pos);
 
     const std::string& res_req = "opflex_agent_policy_resolve_count{agent=\""
                                    + agent + "\"} " + val;
     pos = output.find(res_req);
-    BOOST_CHECK_NE(pos, std::string::npos);
+    BaseFixture::expPosition(!del, pos);
     const std::string& res_err = "opflex_agent_policy_resolve_err_count{agent=\""
                                    + agent + "\"} " + val;
     pos = output.find(res_err);
-    BOOST_CHECK_NE(pos, std::string::npos);
+    BaseFixture::expPosition(!del, pos);
 
     const std::string& unres_req = "opflex_agent_policy_unresolve_count{agent=\""
                                    + agent + "\"} " + val;
     pos = output.find(unres_req);
-    BOOST_CHECK_NE(pos, std::string::npos);
+    BaseFixture::expPosition(!del, pos);
     const std::string& unres_err = "opflex_agent_policy_unresolve_err_count{agent=\""
                                    + agent + "\"} " + val;
     pos = output.find(unres_err);
-    BOOST_CHECK_NE(pos, std::string::npos);
+    BaseFixture::expPosition(!del, pos);
 
     const std::string& epd_req = "opflex_agent_ep_declare_count{agent=\""
                                    + agent + "\"} " + val;
     pos = output.find(epd_req);
-    BOOST_CHECK_NE(pos, std::string::npos);
+    BaseFixture::expPosition(!del, pos);
     const std::string& epd_err = "opflex_agent_ep_declare_err_count{agent=\""
                                    + agent + "\"} " + val;
     pos = output.find(epd_err);
-    BOOST_CHECK_NE(pos, std::string::npos);
+    BaseFixture::expPosition(!del, pos);
 
     const std::string& epud_req = "opflex_agent_ep_undeclare_count{agent=\""
                                    + agent + "\"} " + val;
     pos = output.find(epud_req);
-    BOOST_CHECK_NE(pos, std::string::npos);
+    BaseFixture::expPosition(!del, pos);
     const std::string& epud_err = "opflex_agent_ep_undeclare_err_count{agent=\""
                                    + agent + "\"} " + val;
     pos = output.find(epud_err);
-    BOOST_CHECK_NE(pos, std::string::npos);
+    BaseFixture::expPosition(!del, pos);
 
     const std::string& epr_req = "opflex_agent_ep_resolve_count{agent=\""
                                    + agent + "\"} " + val;
     pos = output.find(epr_req);
-    BOOST_CHECK_NE(pos, std::string::npos);
+    BaseFixture::expPosition(!del, pos);
     const std::string& epr_err = "opflex_agent_ep_resolve_err_count{agent=\""
                                    + agent + "\"} " + val;
     pos = output.find(epr_err);
-    BOOST_CHECK_NE(pos, std::string::npos);
+    BaseFixture::expPosition(!del, pos);
 
     const std::string& epur_req = "opflex_agent_ep_unresolve_count{agent=\""
                                    + agent + "\"} " + val;
     pos = output.find(epur_req);
-    BOOST_CHECK_NE(pos, std::string::npos);
+    BaseFixture::expPosition(!del, pos);
     const std::string& epur_err = "opflex_agent_ep_unresolve_err_count{agent=\""
                                    + agent + "\"} " + val;
     pos = output.find(epur_err);
-    BOOST_CHECK_NE(pos, std::string::npos);
+    BaseFixture::expPosition(!del, pos);
 
     const std::string& rep_req = "opflex_agent_state_report_count{agent=\""
                                    + agent + "\"} " + val;
     pos = output.find(rep_req);
-    BOOST_CHECK_NE(pos, std::string::npos);
+    BaseFixture::expPosition(!del, pos);
     const std::string& rep_err = "opflex_agent_state_report_err_count{agent=\""
                                    + agent + "\"} " + val;
     pos = output.find(rep_err);
-    BOOST_CHECK_NE(pos, std::string::npos);
+    BaseFixture::expPosition(!del, pos);
 }
 #endif
 
@@ -174,20 +174,23 @@ BOOST_FIXTURE_TEST_CASE(testOFAgent, AgentStatsFixture) {
 
     LOG(DEBUG) << "### OfAgent start";
     std::shared_ptr<OFServerStats> opflexStats = std::make_shared<OFServerStats>();
-    const std::string agent = "127.0.0.1:9999";
+    const std::string& agent = "127.0.0.1:9999";
 
     updateOFAgentStats(opflexStats);
 #ifdef HAVE_PROMETHEUS_SUPPORT
-    prometheusManager.addNUpdateOFAgentStats("127.0.0.1:9999",
+    prometheusManager.addNUpdateOFAgentStats(agent,
                                              opflexStats);
-    verifyOFAgentMetrics(agent, 1);
+    verifyOFAgentMetrics(agent, 1, false);
 #endif
 
     updateOFAgentStats(opflexStats);
 #ifdef HAVE_PROMETHEUS_SUPPORT
-    prometheusManager.addNUpdateOFAgentStats("127.0.0.1:9999",
+    prometheusManager.addNUpdateOFAgentStats(agent,
                                              opflexStats);
-    verifyOFAgentMetrics(agent, 2);
+    verifyOFAgentMetrics(agent, 2, false);
+
+    prometheusManager.removeOFAgentStats(agent);
+    verifyOFAgentMetrics(agent, 0, true);
 #endif
     LOG(DEBUG) << "### OFAgent end";
 }


### PR DESCRIPTION
- Remove these objects from modb and prometheus if these connection stats arent found
- Move one of the apis to BaseFixture so that its reused across agent and server tests
- Make check integration

Signed-off-by: Gautam Venkataramanan <gautam.chennai@gmail.com>