### PR TITLE
Addressing dup svc metrics seen in OpenShift on OpenStack

### DIFF
--- a/agent-ovs/lib/include/opflexagent/PrometheusManager.h
+++ b/agent-ovs/lib/include/opflexagent/PrometheusManager.h
@@ -763,6 +763,7 @@ private:
     // func to create gauge for SvcTargetCounter given metric type,
     // uuid of svc-target & attr map of ep
     void createDynamicGaugeSvcTarget(SVC_TARGET_METRICS metric,
+                                     const string& key,
                                      const string& uuid,
                                      const string& nhip,
         const unordered_map<string, string>& svc_attr_map,
@@ -789,6 +790,7 @@ private:
     //Utility apis
     // Create a label map that can be used for annotation, given the ep attr map
     static const map<string,string> createLabelMapFromSvcTargetAttr(
+                                                          const string& svc_uuid,
                                                           const string& nhip,
                            const unordered_map<string, string>&  svc_attr_map,
                            const unordered_map<string, string>&  ep_attr_map,
@@ -877,6 +879,7 @@ private:
     //Utility apis
     // Create a label map that can be used for annotation, given the svc attr map
     static const map<string,string> createLabelMapFromSvcAttr(
+                           const string& uuid,
                            const unordered_map<string, string>&  svc_attr_map,
                            bool isNodePort);
     /* End of SvcCounter related apis and state */

--- a/agent-ovs/lib/test/ServiceManager_test.cpp
+++ b/agent-ovs/lib/test/ServiceManager_test.cpp
@@ -317,11 +317,11 @@ void ServiceManagerFixture::checkServicePromMetrics (bool isAdd, bool isExternal
 
     string str, str2;
     if (isUpdate) {
-        str = "name=\"nginx\",scope=\"" + scope + "\"";
-        str2 = "name=\"nginx\",scope=\"nodePort\"";
+        str = "name=\"nginx\",scope=\"" + scope + "\",uuid=\"" + as.getUUID() + "\"";
+        str2 = "name=\"nginx\",scope=\"nodePort\",uuid=\"nodeport-" + as.getUUID() + "\"";
     } else {
-        str = "name=\"coredns\",namespace=\"kube-system\",scope=\"" + scope + "\"";
-        str2 = "name=\"coredns\",namespace=\"kube-system\",scope=\"nodePort\"";
+        str = "name=\"coredns\",namespace=\"kube-system\",scope=\"" + scope + "\",uuid=\"" + as.getUUID() + "\"";
+        str2 = "name=\"coredns\",namespace=\"kube-system\",scope=\"nodePort\",uuid=\"nodeport-" + as.getUUID() + "\"";
     }
 
     pos = output.find("opflex_svc_rx_bytes{" + str + "} 0.000000");
@@ -370,11 +370,11 @@ void ServiceManagerFixture::checkServiceTargetPromMetrics (bool isAdd,
 
     string str, str2;
     if (isUpdate) {
-        str = "\",svc_name=\"nginx\",svc_scope=\"" + scope + "\"} 0.000000";
-        str2 = "\",svc_name=\"nginx\",svc_scope=\"nodePort\"} 0.000000";
+        str = "\",svc_name=\"nginx\",svc_scope=\"" + scope + "\",svc_uuid=\"" + as.getUUID() + "\"} 0.000000";
+        str2 = "\",svc_name=\"nginx\",svc_scope=\"nodePort\",svc_uuid=\"nodeport-" + as.getUUID() + "\"} 0.000000";
     } else {
-        str = "\",svc_name=\"coredns\",svc_namespace=\"kube-system\",svc_scope=\"" + scope + "\"} 0.000000";
-        str2 = "\",svc_name=\"coredns\",svc_namespace=\"kube-system\",svc_scope=\"nodePort\"} 0.000000";
+        str = "\",svc_name=\"coredns\",svc_namespace=\"kube-system\",svc_scope=\"" + scope + "\",svc_uuid=\"" + as.getUUID() + "\"} 0.000000";
+        str2 = "\",svc_name=\"coredns\",svc_namespace=\"kube-system\",svc_scope=\"nodePort\",svc_uuid=\"nodeport-" + as.getUUID() + "\"} 0.000000";
     }
 
     pos = output.find("opflex_svc_target_rx_bytes{ip=\""+ip+str);

--- a/agent-ovs/ovs/test/ServiceStatsManager_test.cpp
+++ b/agent-ovs/ovs/test/ServiceStatsManager_test.cpp
@@ -874,17 +874,18 @@ void ServiceStatsManagerFixture::checkSvcTgtPromMetrics (uint64_t pkts,
     const string& output = BaseFixture::getOutputFromCommand(cmd);
     size_t pos = std::string::npos;
     const string& scope = isNodePort?"nodePort":"cluster";
+    const string& uuid = isNodePort?"nodeport-"+as.getUUID():as.getUUID();
     const string& s_rx_bytes = "opflex_svc_rx_bytes{name=\"coredns\"" \
-                               ",namespace=\"kube-system\",scope=\"" + scope + "\"} "
+                               ",namespace=\"kube-system\",scope=\"" + scope + "\",uuid=\"" + uuid + "\"} "
                             + std::to_string(bytes) + ".000000";
     const string& s_rx_pkts = "opflex_svc_rx_packets{name=\"coredns\"" \
-                              ",namespace=\"kube-system\",scope=\"" + scope + "\"} "
+                              ",namespace=\"kube-system\",scope=\"" + scope + "\",uuid=\"" + uuid + "\"} "
                             + std::to_string(pkts) + ".000000";
     const string& s_tx_bytes = "opflex_svc_tx_bytes{name=\"coredns\"" \
-                               ",namespace=\"kube-system\",scope=\"" + scope + "\"} "
+                               ",namespace=\"kube-system\",scope=\"" + scope + "\",uuid=\"" + uuid + "\"} "
                             + std::to_string(bytes) + ".000000";
     const string& s_tx_pkts = "opflex_svc_tx_packets{name=\"coredns\"" \
-                              ",namespace=\"kube-system\",scope=\"" + scope + "\"} "
+                              ",namespace=\"kube-system\",scope=\"" + scope + "\",uuid=\"" + uuid + "\"} "
                             + std::to_string(pkts) + ".000000";
     pos = output.find(s_rx_bytes);
     BOOST_CHECK_NE(pos, std::string::npos);
@@ -897,7 +898,7 @@ void ServiceStatsManagerFixture::checkSvcTgtPromMetrics (uint64_t pkts,
 
     const string& ep_attr = "ep_name=\"coredns\",ep_namespace=\"default\",";
     const string& s_ann = "\",svc_name=\"coredns\",svc_namespace=\"kube-system\"" \
-                          ",svc_scope=\"" + scope + "\"} ";
+                          ",svc_scope=\"" + scope + "\",svc_uuid=\"" + uuid + "\"} ";
     string rx_bytes, rx_pkts, tx_bytes, tx_pkts;
     if (ip == "10.20.44.2" || ip == "2001:db8::2") {
         rx_bytes = "opflex_svc_target_rx_bytes{" + ep_attr + "ip=\"";

--- a/agent-ovs/server/ServerPrometheusManager.cpp
+++ b/agent-ovs/server/ServerPrometheusManager.cpp
@@ -192,7 +192,7 @@ void ServerPrometheusManager::createDynamicGaugeOFAgent (OFAGENT_METRICS metric,
 
     auto& gauge = gauge_ofagent_family_ptr[metric]->Add({{"agent", agent}});
     if (gauge_check.is_dup(&gauge)) {
-        LOG(ERROR) << "duplicate ofagent dyn gauge family"
+        LOG(WARNING) << "duplicate ofagent dyn gauge family"
                    << " metric: " << metric
                    << " agent: " << agent;
         return;
@@ -347,12 +347,12 @@ void ServerPrometheusManager::addNUpdateOFAgentStats (const std::string& agent,
             metric_opt = stats->getStateReportErrs();
             break;
         default:
-            LOG(ERROR) << "Unhandled ofagent metric: " << metric;
+            LOG(WARNING) << "Unhandled ofagent metric: " << metric;
         }
         if (metric_opt && pgauge)
             pgauge->Set(static_cast<double>(metric_opt.get()));
         if (!pgauge) {
-            LOG(ERROR) << "Invalid ofagent update agent: " << agent;
+            LOG(WARNING) << "Invalid ofagent update agent: " << agent;
             break;
         }
     }


### PR DESCRIPTION
- svc metrics get annotated with name, namespace and scope. multiple svc files get created with these same annotations but with varying service-ip.
- tagging svc metrics with uuid to avoid the clash. (not using svc-ip since service mapping is a list and there could be multiple service ips within a service file)
- reducing duplicate metric logging per family instead of each metric in the family
- changing ERROR to WARNING within PrometheusManager
- make check integration

Sample metrics:
# HELP opflex_svc_rx_packets service ingress/rx packets
# TYPE opflex_svc_rx_packets gauge
opflex_svc_rx_packets{name="kube-dns",namespace="kube-system",scope="cluster",uuid="dc3b8d25-92b8-4b98-bbf6-1d4e0317b00f"} 0.000000
opflex_svc_rx_packets{name="kubernetes",namespace="default",scope="cluster",uuid="0cc822c8-ec23-43e2-870d-627083117ff0"} 0.000000
opflex_svc_rx_packets{name="redis-master",namespace="default",scope="cluster",uuid="fec2f9ee-f7c5-4f7d-8881-6f0e549c644c"} 0.000000
opflex_svc_rx_packets{name="redis-master",namespace="default",scope="ext",uuid="fec2f9ee-f7c5-4f7d-8881-6f0e549c644c-external"} 0.000000
# HELP opflex_svc_target_rx_packets cluster service target ingress/rx packets
# TYPE opflex_svc_target_rx_packets gauge
opflex_svc_target_rx_packets{ep_name="coredns_5",ep_namespace="kube_system",ip="10.0.0.2",svc_name="redis-master",svc_namespace="default",svc_scope="ext",svc_uuid="fec2f9ee-f7c5-4f7d-8881-6f0e549c644c-external"} 0.000000
opflex_svc_target_rx_packets{ip="10.2.0.66",svc_name="kube-dns",svc_namespace="kube-system",svc_scope="cluster",svc_uuid="dc3b8d25-92b8-4b98-bbf6-1d4e0317b00f"} 0.000000
opflex_svc_target_rx_packets{ip="192.168.17.2",svc_name="kubernetes",svc_namespace="default",svc_scope="cluster",svc_uuid="0cc822c8-ec23-43e2-870d-627083117ff0"} 0.000000
opflex_svc_target_rx_packets{ep_name="coredns_5",ep_namespace="kube_system",ip="10.0.0.2",svc_name="redis-master",svc_namespace="default",svc_scope="cluster",svc_uuid="fec2f9ee-f7c5-4f7d-8881-6f0e549c644c"} 0.000000
opflex_svc_target_rx_packets{ip="10.2.0.130",svc_name="kube-dns",svc_namespace="kube-system",svc_scope="cluster",svc_uuid="dc3b8d25-92b8-4b98-bbf6-1d4e0317b00f"} 0.000000

Signed-off-by: Gautam Venkataramanan <gautam.chennai@gmail.com>