### PR TITLE
Addressing dup svc metrics seen in OpenShift on OpenStack

### DIFF
--- a/agent-ovs/lib/include/opflexagent/PrometheusManager.h
+++ b/agent-ovs/lib/include/opflexagent/PrometheusManager.h
@@ -538,6 +538,7 @@ private:
     // func to create gauge for SvcTargetCounter given metric type,
     // uuid of svc-target & attr map of ep
     void createDynamicGaugeSvcTarget(SVC_TARGET_METRICS metric,
+                                     const string& key,
                                      const string& uuid,
                                      const string& nhip,
         const unordered_map<string, string>& svc_attr_map,
@@ -564,6 +565,7 @@ private:
     //Utility apis
     // Create a label map that can be used for annotation, given the ep attr map
     static const map<string,string> createLabelMapFromSvcTargetAttr(
+                                                          const string& svc_uuid,
                                                           const string& nhip,
                            const unordered_map<string, string>&  svc_attr_map,
                            const unordered_map<string, string>&  ep_attr_map,
@@ -652,6 +654,7 @@ private:
     //Utility apis
     // Create a label map that can be used for annotation, given the svc attr map
     static const map<string,string> createLabelMapFromSvcAttr(
+                           const string& uuid,
                            const unordered_map<string, string>&  svc_attr_map,
                            bool isNodePort);
     /* End of SvcCounter related apis and state */

--- a/agent-ovs/lib/test/ServiceManager_test.cpp
+++ b/agent-ovs/lib/test/ServiceManager_test.cpp
@@ -319,11 +319,11 @@ void ServiceManagerFixture::checkServicePromMetrics (bool isAdd, bool isExternal
 
     string str, str2;
     if (isUpdate) {
-        str = "name=\"nginx\",scope=\"" + scope + "\"";
-        str2 = "name=\"nginx\",scope=\"nodePort\"";
+        str = "name=\"nginx\",scope=\"" + scope + "\",uuid=\"" + as.getUUID() + "\"";
+        str2 = "name=\"nginx\",scope=\"nodePort\",uuid=\"nodeport-" + as.getUUID() + "\"";
     } else {
-        str = "name=\"coredns\",namespace=\"kube-system\",scope=\"" + scope + "\"";
-        str2 = "name=\"coredns\",namespace=\"kube-system\",scope=\"nodePort\"";
+        str = "name=\"coredns\",namespace=\"kube-system\",scope=\"" + scope + "\",uuid=\"" + as.getUUID() + "\"";
+        str2 = "name=\"coredns\",namespace=\"kube-system\",scope=\"nodePort\",uuid=\"nodeport-" + as.getUUID() + "\"";
     }
 
     pos = output.find("opflex_svc_rx_bytes{" + str + "} 0.000000");
@@ -372,11 +372,11 @@ void ServiceManagerFixture::checkServiceTargetPromMetrics (bool isAdd,
 
     string str, str2;
     if (isUpdate) {
-        str = "\",svc_name=\"nginx\",svc_scope=\"" + scope + "\"} 0.000000";
-        str2 = "\",svc_name=\"nginx\",svc_scope=\"nodePort\"} 0.000000";
+        str = "\",svc_name=\"nginx\",svc_scope=\"" + scope + "\",svc_uuid=\"" + as.getUUID() + "\"} 0.000000";
+        str2 = "\",svc_name=\"nginx\",svc_scope=\"nodePort\",svc_uuid=\"nodeport-" + as.getUUID() + "\"} 0.000000";
     } else {
-        str = "\",svc_name=\"coredns\",svc_namespace=\"kube-system\",svc_scope=\"" + scope + "\"} 0.000000";
-        str2 = "\",svc_name=\"coredns\",svc_namespace=\"kube-system\",svc_scope=\"nodePort\"} 0.000000";
+        str = "\",svc_name=\"coredns\",svc_namespace=\"kube-system\",svc_scope=\"" + scope + "\",svc_uuid=\"" + as.getUUID() + "\"} 0.000000";
+        str2 = "\",svc_name=\"coredns\",svc_namespace=\"kube-system\",svc_scope=\"nodePort\",svc_uuid=\"nodeport-" + as.getUUID() + "\"} 0.000000";
     }
 
     pos = output.find("opflex_svc_target_rx_bytes{ip=\""+ip+str);

--- a/agent-ovs/ovs/test/ServiceStatsManager_test.cpp
+++ b/agent-ovs/ovs/test/ServiceStatsManager_test.cpp
@@ -861,17 +861,18 @@ void ServiceStatsManagerFixture::checkSvcTgtPromMetrics (uint64_t pkts,
     const string& output = BaseFixture::getOutputFromCommand(cmd);
     size_t pos = std::string::npos;
     const string& scope = isNodePort?"nodePort":"cluster";
+    const string& uuid = isNodePort?"nodeport-"+as.getUUID():as.getUUID();
     const string& s_rx_bytes = "opflex_svc_rx_bytes{name=\"coredns\"" \
-                               ",namespace=\"kube-system\",scope=\"" + scope + "\"} "
+                               ",namespace=\"kube-system\",scope=\"" + scope + "\",uuid=\"" + uuid + "\"} "
                             + boost::lexical_cast<std::string>(bytes) + ".000000";
     const string& s_rx_pkts = "opflex_svc_rx_packets{name=\"coredns\"" \
-                              ",namespace=\"kube-system\",scope=\"" + scope + "\"} "
+                              ",namespace=\"kube-system\",scope=\"" + scope + "\",uuid=\"" + uuid + "\"} "
                             + boost::lexical_cast<std::string>(pkts) + ".000000";
     const string& s_tx_bytes = "opflex_svc_tx_bytes{name=\"coredns\"" \
-                               ",namespace=\"kube-system\",scope=\"" + scope + "\"} "
+                               ",namespace=\"kube-system\",scope=\"" + scope + "\",uuid=\"" + uuid + "\"} "
                             + boost::lexical_cast<std::string>(bytes) + ".000000";
     const string& s_tx_pkts = "opflex_svc_tx_packets{name=\"coredns\"" \
-                              ",namespace=\"kube-system\",scope=\"" + scope + "\"} "
+                              ",namespace=\"kube-system\",scope=\"" + scope + "\",uuid=\"" + uuid + "\"} "
                             + boost::lexical_cast<std::string>(pkts) + ".000000";
     pos = output.find(s_rx_bytes);
     BOOST_CHECK_NE(pos, std::string::npos);
@@ -884,7 +885,7 @@ void ServiceStatsManagerFixture::checkSvcTgtPromMetrics (uint64_t pkts,
 
     const string& ep_attr = "ep_name=\"coredns\",ep_namespace=\"default\",";
     const string& s_ann = "\",svc_name=\"coredns\",svc_namespace=\"kube-system\"" \
-                          ",svc_scope=\"" + scope + "\"} ";
+                          ",svc_scope=\"" + scope + "\",svc_uuid=\"" + uuid + "\"} ";
     string rx_bytes, rx_pkts, tx_bytes, tx_pkts;
     if (ip == "10.20.44.2" || ip == "2001:db8::2") {
         rx_bytes = "opflex_svc_target_rx_bytes{" + ep_attr + "ip=\"";


### PR DESCRIPTION
- svc metrics get annotated with name, namespace and scope. multiple svc files get created with these same annotations but with varying service-ip.
- tagging svc metrics with uuid to avoid the clash. (not using svc-ip since service mapping is a list and there could be multiple service ips within a service file)
- reducing duplicate metric logging per family instead of each metric in the family
- changing ERROR to WARNING within PrometheusManager
- make check integration

Signed-off-by: Gautam Venkataramanan <gautam.chennai@gmail.com>