### PR TITLE
Protecting timer with a mutex

### DIFF
--- a/agent-ovs/lib/include/opflexagent/TunnelEpManager.h
+++ b/agent-ovs/lib/include/opflexagent/TunnelEpManager.h
@@ -144,6 +144,7 @@ private:
     boost::asio::io_service& agent_io;
     long timer_interval;
     std::unique_ptr<boost::asio::deadline_timer> timer;
+    std::mutex timer_mutex;
 
     void on_timer(const boost::system::error_code& ec);
 


### PR DESCRIPTION
WARNING: ThreadSanitizer: data race (pid=28641)
  Read of size 1 at 0x7b1000012ad0 by thread T11:
    #8 opflexagent::TunnelEpManager::on_timer(boost::system::error_code const&) lib/TunnelEpManager.cpp:172 (libopflex_agent.so.0+0x243cff)

  Previous write of size 1 at 0x7b1000012ad0 by main thread (mutexes: write M180):
    #4 opflexagent::TunnelEpManager::stop() lib/TunnelEpManager.cpp:88 (libopflex_agent.so.0+0x24393e)
    #5 opflexagent::OVSRenderer::stop() ovs/OVSRenderer.cpp:285 (libopflex_agent_renderer_openvswitch.so+0xcb84b)
    #6 opflexagent::Agent::stop() lib/Agent.cpp:718 (libopflex_agent.so.0+0x2723d8)
    #7 AgentLauncher::run() cmd/opflex_agent.cpp:128 (opflex_agent+0x3a4a7)
    #8 main cmd/opflex_agent.cpp:322 (opflex_agent+0x16dc2)

  Location is heap block of size 64 at 0x7b1000012ac0 allocated by main thread:
    #0 operator new(unsigned long) <null> (libtsan.so.0+0x77cf2)
    #1 opflexagent::TunnelEpManager::start() lib/TunnelEpManager.cpp:75 (libopflex_agent.so.0+0x247908)
    #2 opflexagent::OVSRenderer::start() ovs/OVSRenderer.cpp:119 (libopflex_agent_renderer_openvswitch.so+0xd55cc)
    #3 opflexagent::Agent::start() lib/Agent.cpp:601 (libopflex_agent.so.0+0x2783ea)
    #4 AgentLauncher::run() cmd/opflex_agent.cpp:120 (opflex_agent+0x3a438)
    #5 main cmd/opflex_agent.cpp:322 (opflex_agent+0x16dc2)

  Mutex M180 (0x7fff82ef6dc8) created at:
    #0 pthread_mutex_lock <null> (libtsan.so.0+0x41d5b)
    #1 __gthread_mutex_lock /usr/include/x86_64-linux-gnu/c++/9/bits/gthr-default.h:749 (opflex_agent+0x3a3f0)
    #2 std::mutex::lock() /usr/include/c++/9/bits/std_mutex.h:100 (opflex_agent+0x3a3f0)
    #3 std::unique_lock<std::mutex>::lock() /usr/include/c++/9/bits/unique_lock.h:141 (opflex_agent+0x3a3f0)
    #4 std::unique_lock<std::mutex>::unique_lock(std::mutex&) /usr/include/c++/9/bits/unique_lock.h:71 (opflex_agent+0x3a3f0)
    #5 AgentLauncher::run() cmd/opflex_agent.cpp:115 (opflex_agent+0x3a3f0)
    #6 main cmd/opflex_agent.cpp:322 (opflex_agent+0x16dc2)

  Thread T11 (tid=28681, running) created by main thread at:
    #0 pthread_create <null> (libtsan.so.0+0x2d3be)
    #1 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) <null> (libstdc++.so.6+0xd0b04)
    #2 AgentLauncher::run() cmd/opflex_agent.cpp:120 (opflex_agent+0x3a438)
    #3 main cmd/opflex_agent.cpp:322 (opflex_agent+0x16dc2)

Signed-off-by: Gautam Venkataramanan <gautam.chennai@gmail.com>