### PR TITLE
Protecting all remaining deadline timers

### DIFF
--- a/agent-ovs/ovs/JsonRpcRenderer.cpp
+++ b/agent-ovs/ovs/JsonRpcRenderer.cpp
@@ -23,6 +23,7 @@ namespace opflexagent {
 
     void JsonRpcRenderer::stop() {
         if (timerStarted) {
+            const std::lock_guard<std::mutex> guard(timer_mutex);
             timerStarted = false;
             connection_timer->cancel();
         }
@@ -37,6 +38,7 @@ namespace opflexagent {
         // If connection fails, a timer is started to retry and
         // back off at periodic intervals.
         if (timerStarted) {
+            const std::lock_guard<std::mutex> guard(timer_mutex);
             LOG(DEBUG) << "Canceling timer";
             connection_timer->cancel();
             timerStarted = false;

--- a/agent-ovs/ovs/NetFlowRenderer.cpp
+++ b/agent-ovs/ovs/NetFlowRenderer.cpp
@@ -38,6 +38,7 @@ namespace opflexagent {
 
     void NetFlowRenderer::exporterDeleted(const shared_ptr<ExporterConfigState>& expSt) {
         if (!connect()) {
+            const std::lock_guard<std::mutex> guard(timer_mutex);
             LOG(DEBUG) << "failed to connect, retry in " << CONNECTION_RETRY << " seconds";
             // connection failed, start a timer to try again
             connection_timer.reset(new deadline_timer(agent.getAgentIOService(),
@@ -60,6 +61,7 @@ namespace opflexagent {
 
     void NetFlowRenderer::handleNetFlowUpdate(const opflex::modb::URI& netFlowURI) {
         if (!connect()) {
+            const std::lock_guard<std::mutex> guard(timer_mutex);
             LOG(DEBUG) << "OVSDB connection not ready, retry in " << CONNECTION_RETRY << " seconds";
             // connection failed, start a timer to try again
 
@@ -234,6 +236,7 @@ namespace opflexagent {
     void NetFlowRenderer::updateConnectCb(const boost::system::error_code& ec, const opflex::modb::URI& spanURI) {
         LOG(DEBUG) << "timer update cb";
         if (ec) {
+            const std::lock_guard<std::mutex> guard(timer_mutex);
             LOG(WARNING) << "reset timer";
             connection_timer.reset();
             return;
@@ -244,6 +247,7 @@ namespace opflexagent {
     void NetFlowRenderer::delConnectCb(const boost::system::error_code& ec,
                                        shared_ptr<ExporterConfigState>& expSt) {
         if (ec) {
+            const std::lock_guard<std::mutex> guard(timer_mutex);
             LOG(WARNING) << "reset timer";
             connection_timer.reset();
             return;

--- a/agent-ovs/ovs/QosRenderer.cpp
+++ b/agent-ovs/ovs/QosRenderer.cpp
@@ -45,6 +45,7 @@ namespace opflexagent {
     void QosRenderer::qosDeleted(const string& interface) {
         LOG(DEBUG) << "Process QosDeleted for interface " << interface;
         if (!connect()) {
+            const std::lock_guard<std::mutex> guard(timer_mutex);
             LOG(DEBUG) << "failed to connect, retry in " << CONNECTION_RETRY << " seconds";
             connection_timer.reset(new deadline_timer(agent.getAgentIOService(),
                         boost::posix_time::seconds(CONNECTION_RETRY)));
@@ -77,6 +78,7 @@ namespace opflexagent {
         QosManager &qosMgr = agent.getQosManager();
 
         if (!connect()) {
+            const std::lock_guard<std::mutex> guard(timer_mutex);
             LOG(DEBUG) << "failed to connect, retry in " << CONNECTION_RETRY << " seconds";
 
             connection_timer.reset(new deadline_timer(agent.getAgentIOService(),
@@ -108,6 +110,7 @@ namespace opflexagent {
         QosManager &qosMgr = agent.getQosManager();
 
         if (!connect()) {
+            const std::lock_guard<std::mutex> guard(timer_mutex);
             LOG(DEBUG) << "failed to connect, retry in " << CONNECTION_RETRY << " seconds";
 
             connection_timer.reset(new deadline_timer(agent.getAgentIOService(),
@@ -138,6 +141,7 @@ namespace opflexagent {
             const string& interface) {
         LOG(DEBUG) << "timer update cb";
         if (ec) {
+            const std::lock_guard<std::mutex> guard(timer_mutex);
             LOG(WARNING) << "reset timer";
             connection_timer.reset();
             return;
@@ -150,6 +154,7 @@ namespace opflexagent {
     void QosRenderer::delConnectCb(const boost::system::error_code& ec,
             const string& interface) {
         if (ec) {
+            const std::lock_guard<std::mutex> guard(timer_mutex);
             connection_timer.reset();
             return;
         }

--- a/agent-ovs/ovs/SpanRenderer.cpp
+++ b/agent-ovs/ovs/SpanRenderer.cpp
@@ -39,6 +39,7 @@ namespace opflexagent {
 
     void SpanRenderer::spanDeleted(const shared_ptr<SessionState>& seSt) {
         if (!connect()) {
+            const std::lock_guard<std::mutex> guard(timer_mutex);
             LOG(DEBUG) << "OVSDB connection not ready, retry in " << CONNECTION_RETRY << " seconds";
             // connection failed, start a timer to try again
             connection_timer.reset(new deadline_timer(agent.getAgentIOService(),
@@ -55,6 +56,7 @@ namespace opflexagent {
             const opflex::modb::URI& spanURI) {
         LOG(DEBUG) << "timer update cb";
         if (ec) {
+            const std::lock_guard<std::mutex> guard(timer_mutex);
             LOG(WARNING) << "reset timer";
             connection_timer.reset();
             return;
@@ -64,6 +66,7 @@ namespace opflexagent {
 
     void SpanRenderer::delConnectPtrCb(const boost::system::error_code& ec, const shared_ptr<SessionState>& pSt) {
         if (ec) {
+            const std::lock_guard<std::mutex> guard(timer_mutex);
             LOG(WARNING) << "reset timer";
             connection_timer.reset();
             return;
@@ -111,6 +114,7 @@ namespace opflexagent {
 
     void SpanRenderer::handleSpanUpdate(const opflex::modb::URI& spanURI) {
         if (!connect()) {
+            const std::lock_guard<std::mutex> guard(timer_mutex);
             LOG(DEBUG) << "OVSDB connection not ready, retry in " << CONNECTION_RETRY << " seconds";
             // connection failed, start a timer to try again
             connection_timer.reset(new deadline_timer(agent.getAgentIOService(),

--- a/agent-ovs/ovs/include/JsonRpcRenderer.h
+++ b/agent-ovs/ovs/include/JsonRpcRenderer.h
@@ -14,6 +14,7 @@
 #define OPFLEX_JSONRPCRENDERER_H
 
 #include <atomic>
+#include <mutex>
 #include <boost/asio.hpp>
 #include <opflexagent/Agent.h>
 #include "OvsdbConnection.h"
@@ -71,6 +72,10 @@ protected:
      * timer for connection timeouts
      */
     std::shared_ptr<boost::asio::deadline_timer> connection_timer;
+    /**
+     * mutex to protect connection_timer
+     */
+    std::mutex timer_mutex;
     /**
      * retry interval in seconds
      */

--- a/agent-ovs/ovs/include/OVSRenderer.h
+++ b/agent-ovs/ovs/include/OVSRenderer.h
@@ -28,6 +28,8 @@
 #include "PacketLogHandler.h"
 #include "QosRenderer.h"
 
+#include <mutex>
+
 #pragma once
 #ifndef OPFLEXAGENT_OVSRENDERER_H
 #define OPFLEXAGENT_OVSRENDERER_H
@@ -142,6 +144,7 @@ private:
      */
     void onCleanupTimer(const boost::system::error_code& ec);
     std::unique_ptr<boost::asio::deadline_timer> cleanupTimer;
+    std::mutex timer_mutex;
 
     /**
      * Start packet logger

--- a/agent-ovs/ovs/include/SwitchManager.h
+++ b/agent-ovs/ovs/include/SwitchManager.h
@@ -25,6 +25,7 @@
 
 #include <string>
 #include <memory>
+#include <mutex>
 
 namespace opflexagent {
 
@@ -285,6 +286,7 @@ private:
     void handleConnection(SwitchConnection *sw);
     void onConnectTimer(const boost::system::error_code& ec);
     std::unique_ptr<boost::asio::deadline_timer> connectTimer;
+    std::recursive_mutex timer_mutex;
     long connectDelayMs;
 
     // sync state


### PR DESCRIPTION
WARNING: ThreadSanitizer: data race (pid=4830)
  Read of size 1 at 0x7b100000e050 by thread T11:
    #7 opflexagent::SwitchManager::onConnectTimer(boost::system::error_code const&) ovs/SwitchManager.cpp:162 (libopflex_agent_renderer_openvswitch.so+0x1c4aa4)
    #13 operator() lib/Agent.cpp:605 (libopflex_agent.so.0+0x2755d9)

  Previous write of size 1 at 0x7b100000e050 by main thread (mutexes: write M180):
    #4 opflexagent::SwitchManager::stop() ovs/SwitchManager.cpp:72 (libopflex_agent_renderer_openvswitch.so+0x1c4a06)
    #5 opflexagent::OVSRenderer::stop() ovs/OVSRenderer.cpp:274 (libopflex_agent_renderer_openvswitch.so+0xcbdda)
    #6 opflexagent::Agent::stop() lib/Agent.cpp:718 (libopflex_agent.so.0+0x273508)
    #7 AgentLauncher::run() cmd/opflex_agent.cpp:128 (opflex_agent+0x3a4a7)
    #8 main cmd/opflex_agent.cpp:322 (opflex_agent+0x16dc2)

  Location is heap block of size 64 at 0x7b100000e040 allocated by thread T2:
    #0 operator new(unsigned long) <null> (libtsan.so.0+0x77cf2)
    #1 opflexagent::SwitchManager::enableSync() ovs/SwitchManager.cpp:110 (libopflex_agent_renderer_openvswitch.so+0x1c5212)
    #2 opflexagent::IntFlowManager::configUpdated(opflex::modb::URI const&) ovs/IntFlowManager.cpp:523 (libopflex_agent_renderer_openvswitch.so+0x14ee12)
    #3 opflexagent::PolicyManager::notifyConfig(opflex::modb::URI const&) lib/PolicyManager.cpp:234 (libopflex_agent.so.0+0x11ee01)
    #4 opflexagent::PolicyManager::ConfigListener::objectUpdated(unsigned long, opflex::modb::URI const&) lib/PolicyManager.cpp:2862 (libopflex_agent.so.0+0x11ee8a)
    #5 opflex::modb::ObjectStore::NotifQueueProc::processItem(opflex::modb::URI const&, boost::any const&) /home/noiro/work/opflex/libopflex/modb/ObjectStore.cpp:77 (libopflex.so.0+0xaf77a)
    #6 opflex::modb::URIQueue::proc_async_func(uv_async_s*) /home/noiro/work/opflex/libopflex/modb/URIQueue.cpp:48 (libopflex.so.0+0x8df71)

  Mutex M180 (0x7fff97118cf8) created at:
    #0 pthread_mutex_lock <null> (libtsan.so.0+0x41d5b)
    #1 __gthread_mutex_lock /usr/include/x86_64-linux-gnu/c++/9/bits/gthr-default.h:749 (opflex_agent+0x3a3f0)
    #2 std::mutex::lock() /usr/include/c++/9/bits/std_mutex.h:100 (opflex_agent+0x3a3f0)
    #3 std::unique_lock<std::mutex>::lock() /usr/include/c++/9/bits/unique_lock.h:141 (opflex_agent+0x3a3f0)
    #4 std::unique_lock<std::mutex>::unique_lock(std::mutex&) /usr/include/c++/9/bits/unique_lock.h:71 (opflex_agent+0x3a3f0)
    #5 AgentLauncher::run() cmd/opflex_agent.cpp:115 (opflex_agent+0x3a3f0)
    #6 main cmd/opflex_agent.cpp:322 (opflex_agent+0x16dc2)

  Thread T11 (tid=4849, running) created by main thread at:
    #0 pthread_create <null> (libtsan.so.0+0x2d3be)
    #1 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) <null> (libstdc++.so.6+0xd0b04)
    #2 AgentLauncher::run() cmd/opflex_agent.cpp:120 (opflex_agent+0x3a438)
    #3 main cmd/opflex_agent.cpp:322 (opflex_agent+0x16dc2)

  Thread T2 (tid=4840, running) created by main thread at:
    #0 pthread_create <null> (libtsan.so.0+0x2d3be)
    #1 uv_thread_create <null> (libuv.so.1+0x17cc0)
    #2 opflex::modb::URIQueue::start() /home/noiro/work/opflex/libopflex/modb/URIQueue.cpp:73 (libopflex.so.0+0x8e4f1)
    #3 opflex::modb::ObjectStore::start() /home/noiro/work/opflex/libopflex/modb/ObjectStore.cpp:87 (libopflex.so.0+0xaecbe)
    #4 opflex::ofcore::OFFramework::start() /home/noiro/work/opflex/libopflex/ofcore/OFFramework.cpp:121 (libopflex.so.0+0x190a4f)
    #5 opflexagent::Agent::start() lib/Agent.cpp:576 (libopflex_agent.so.0+0x27918c)
    #6 AgentLauncher::run() cmd/opflex_agent.cpp:120 (opflex_agent+0x3a438)
    #7 main cmd/opflex_agent.cpp:322 (opflex_agent+0x16dc2)

Signed-off-by: Gautam Venkataramanan <gautam.chennai@gmail.com>