### PR TITLE
CSR integration

### DIFF
--- a/agent-ovs/ovs/FlowConstants.cpp
+++ b/agent-ovs/ovs/FlowConstants.cpp
@@ -47,6 +47,9 @@ const uint64_t TUNNEL = 0x4;
 const uint64_t FLOOD = 0x5;
 const uint64_t REMOTE_TUNNEL = 0x7;
 const uint64_t HOST_ACCESS = 0x8;
+const uint64_t REMOTE_TUNNEL_PROXY = 0x9;
+const uint64_t REMOTE_TUNNEL_BOUNCE_TO_CSR = 0xa;
+const uint64_t REMOTE_TUNNEL_BOUNCE_TO_NODE = 0xb;
 
 } // namespace out
 

--- a/agent-ovs/ovs/include/FlowConstants.h
+++ b/agent-ovs/ovs/include/FlowConstants.h
@@ -154,6 +154,20 @@ extern const uint64_t REMOTE_TUNNEL;
  */
 extern const uint64_t HOST_ACCESS;
 
+/**
+ * Remote tunnel to a proxy
+ */
+extern const uint64_t REMOTE_TUNNEL_PROXY;
+
+/**
+ * Bounce to a remote tunnel on same port as input to CSR
+ */
+extern const uint64_t REMOTE_TUNNEL_BOUNCE_TO_CSR;
+
+/**
+ * Bounce to a remote tunnel on same port as input to node
+ */
+extern const uint64_t REMOTE_TUNNEL_BOUNCE_TO_NODE;
 } // namespace out
 
 

--- a/agent-ovs/ovs/test/IntFlowManager_test.cpp
+++ b/agent-ovs/ovs/test/IntFlowManager_test.cpp
@@ -2714,14 +2714,14 @@ void BaseIntFlowManagerFixture::initExpRemoteEp() {
              .go(POL).done());
         ADDF(Bldr().table(RT).priority(500).ip().reg(RD, 1)
              .isEthDst(rmac).isIpDst("1.3.5.7")
-             .actions().load(DEPG, vnid)
-             .load(OUTPORT, tunDst.to_v4().to_ulong())
+             .actions().load(OUTPORT, tunDst.to_v4().to_ulong())
+             .load(DEPG, vnid)
              .mdAct(opflexagent::flow::meta::out::REMOTE_TUNNEL)
              .go(POL).done());
         ADDF(Bldr().table(RT).priority(500).ip().reg(RD, 1)
              .isEthDst(rmac).isIpDst("2.4.6.8")
-             .actions().load(DEPG, vnid)
-             .load(OUTPORT, tunDst.to_v4().to_ulong())
+             .actions().load(OUTPORT, tunDst.to_v4().to_ulong())
+             .load(DEPG, vnid)
              .mdAct(opflexagent::flow::meta::out::REMOTE_TUNNEL)
              .go(POL).done());
         ADDF(Bldr().table(BR).priority(40).arp()

--- a/genie/MODEL/SPECIFIC/EPR/inventory.mdl
+++ b/genie/MODEL/SPECIFIC/EPR/inventory.mdl
@@ -165,11 +165,6 @@ module[inv]
         member[ip; type=address/IP]
         # Prefix length for if IP address is a subnet
         member[prefixLen; type=scalar/UInt8]
-        # In case of subnet the next-hop IP address
-        member[nextHopIP; type=address/IP]
-        # In case of subnet the next-hop MAC
-        member[nextHopMac; type=address/MAC]
-
     }
 
     class[IpMapping;
@@ -449,6 +444,12 @@ module[inv]
         # mac address of the end-point
         member[mac; type=address/MAC]
 
+        # proxy mac address to reach the end-point(s)
+        member[proxyMac; type=address/MAC]
+
+        # true if this node participates in csr bounce
+        member[addBounce; type=scalar/UInt8]
+
         # Next hop remote tunnel endpoint
         member[nextHopTunnel; type=address/IP]
 
@@ -459,6 +460,25 @@ module[inv]
             to[class=gbp/EpGroup;
                 cardinality=many;
                 ]
+        }
+    }
+
+    # Remote ep with multiple next hops
+    class[NextHopLink;
+          super=gbp/BaseNextHop;
+          concrete;
+          ]
+    {
+        contained
+        {
+            parent[class=inv/RemoteInventoryEp]
+        }
+        named
+        {
+            parent[class=*;]
+            {
+                component[member=ip]
+            }
         }
     }
 }


### PR DESCRIPTION
- CSR is a proxy vxlan gateway to on-prem with limited number of tunnels
- depending on the max tunnels, n nodes will have connectivity to csr
- each would load balance across the CSRs in that list
- the list comes as a remote-ep with nextHopLinks
- Nodes with no access to CSR use the same remote-ep format but
  their next hop links will be list of nodes with CSR access
- The node with CSR access will bounce the traffic to the CSR using
  its own load balancing algorithm
- In the reverse direction the node will bounce the traffic back to
  the node which hosts the pod (based on the inner dest ip)
- The CSR does not know which node has which pod, so it uses ECMP
  to send return traffic to one of the nodes it has tunnel with.
- This node will process the packet like it belonged to it and when
  it does not find the local pod in the route table the packet
  will be looked up against the remote ep registry and bounced.
- Hence we only match on CSR Mac and inner ip address since outer
  dest ip match does not tell us if the traffic is within the cluster
  or not.
- The reverse direction flows currently leverage the remote ep
  registry so they know which pod is on which node
- (This might be replaced in future with a subnet based approach
   since it results in fewer flows)
- CSR tunnel id is different from the EPG, so although the policy
   uses the EPG the tunnel id will be derived from the overlay-vrf id
- All of this assumes the CSR Mac is well known and is same across
  remote eps since we use it in lot of the match criterion

Signed-off-by: Madhu Challa <challa@gmail.com>