### PR TITLE
Revert "Handle dscp config in QosManager."

### DIFF
--- a/agent-ovs/lib/QosManager.cpp
+++ b/agent-ovs/lib/QosManager.cpp
@@ -46,7 +46,6 @@ namespace opflexagent {
         BandwidthLimit::registerListener(framework, &qosUniverseListener);
         EpGroup::registerListener(framework, &qosUniverseListener);
         EpGroupToQosRSrc::registerListener(framework, &qosUniverseListener);
-        DscpMarking::registerListener(framework, &qosUniverseListener);
     }
 
     void QosManager::stop() {
@@ -57,7 +56,6 @@ namespace opflexagent {
         BandwidthLimit::unregisterListener(framework, &qosUniverseListener);
         EpGroup::unregisterListener(framework, &qosUniverseListener);
         EpGroupToQosRSrc::unregisterListener(framework, &qosUniverseListener);
-        DscpMarking::unregisterListener(framework, &qosUniverseListener);
     }
 
 
@@ -79,8 +77,11 @@ namespace opflexagent {
                 vector <shared_ptr<modelgbp::qos::Requirement>> qosVec;
                 config_opt.get()->resolveQosRequirement(qosVec);
                 for (const shared_ptr <modelgbp::qos::Requirement>& qosReq : qosVec) {
-                    LOG(DEBUG) << "creating qos config " << qosReq->getURI();
-                    processQosConfig(qosReq);
+                    auto itr = qosmanager.reqToInterface.find(qosReq->getURI());
+                    if (itr == qosmanager.reqToInterface.end()) {
+                        LOG(DEBUG) << "creating qos config " << qosReq->getURI();
+                        processQosConfig(qosReq);
+                    }
                     qosmanager.notifyUpdate.insert(qosReq->getURI());
                 }
             }
@@ -91,12 +92,15 @@ namespace opflexagent {
                 processQosConfig(qosReqOpt.get());
                 qosmanager.notifyUpdate.insert(uri);
             }
+
         } else if (classId == modelgbp::qos::BandwidthLimit::CLASS_ID){
             optional<shared_ptr<modelgbp::qos::BandwidthLimit>> qosBandwidthOpt =
                 modelgbp::qos::BandwidthLimit::resolve(qosmanager.framework, uri);
+
             if (qosBandwidthOpt){
                 const shared_ptr<modelgbp::qos::BandwidthLimit> &qosBandwidth =
                     qosBandwidthOpt.get();
+
                 LOG(INFO) << "Bandwidth receieved burst: " << qosBandwidth->getBurst()
                     << " rate: "<< qosBandwidth->getRate();
                 processQosConfig(qosBandwidth);
@@ -114,34 +118,11 @@ namespace opflexagent {
                         LOG(INFO) << "EPG-QOS policy updated. EPG: " << uri.toString()
                             << "; Qos: " << reqUriOpt.get().toString();
                         qosmanager.updateEpgPolicyMap(uri, reqUriOpt.get());
-                        qosmanager.notifyUpdate.insert(uri);
                     }
                 }
             }
 
-        } else if (classId == modelgbp::qos::DscpMarking::CLASS_ID) {
-            optional<shared_ptr<modelgbp::qos::DscpMarking>> qosDscpMarkingOpt =
-                modelgbp::qos::DscpMarking::resolve(qosmanager.framework, uri);
-
-            string dscpMarking("QosDscpMarking/");
-            string dscpMarkingUri(uri.toString());
-            dscpMarkingUri.erase(dscpMarkingUri.length()-dscpMarking.size());
-            URI reqUri(dscpMarkingUri);
-            LOG(INFO) << "Dscp-req: " << reqUri;
-
-            qosmanager.notifyUpdate.insert(reqUri);
-            if (qosDscpMarkingOpt){
-                const shared_ptr<modelgbp::qos::DscpMarking> &qosDscpMarking =
-                     qosDscpMarkingOpt.get();
-                LOG(INFO) << "DscpMarking: " << qosDscpMarking->getMark().get();
-                if (qosDscpMarking->isMarkSet()) {
-                    processQosConfig(qosDscpMarking);
-                }
-            } else {
-                qosmanager.reqToDscp.erase(reqUri);
-            }
-        }
-        else if (classId == modelgbp::gbp::EpGroupToQosRSrc::CLASS_ID) {
+        } else if (classId == modelgbp::gbp::EpGroupToQosRSrc::CLASS_ID) {
             optional<shared_ptr<modelgbp::gbp::EpGroupToQosRSrc>> epgRs =
                 modelgbp::gbp::EpGroupToQosRSrc::resolve(qosmanager.framework, uri);
             if (!epgRs) {
@@ -213,7 +194,7 @@ namespace opflexagent {
                 const URI epg = egUri.get();
                 interfaceToEpg.insert(make_pair(interface, epg));
                 addEntry(interface, epg, epgToInterface);
-                LOG(DEBUG) << "epg found for interface: " << epg;
+                LOG(INFO) << "epg found for interface: " << epg;
             }
             notifyListeners(interface, "Both");
         }
@@ -232,12 +213,6 @@ namespace opflexagent {
 
     void QosManager::notifyListeners(const string& interface, const string& direction) {
         lock_guard<mutex> guard1(listener_mutex);
-
-        if (direction == BOTH) {
-            for (QosListener *listener : qosListeners) {
-                listener->dscpQosUpdated(interface);
-            }
-        }
 
         if (direction == EGRESS || direction == BOTH){
             for (QosListener *listener : qosListeners) {
@@ -263,20 +238,6 @@ namespace opflexagent {
             }
         }
     }
-
-    int QosManager::getDscpMarking(const string& interface) const {
-        lock_guard<recursive_mutex> guard1(qos_mutex);
-        auto itr = interfaceToReq.find(interface);
-        if (itr != interfaceToReq.end()){
-            URI reqUri = itr->second;
-            auto itr2 = reqToDscp.find(reqUri);
-            if (itr2 != reqToDscp.end()){
-                return itr2->second;
-            }
-        }
-        return 0;
-    }
-
 
     optional<shared_ptr<QosConfigState>>
         QosManager::getQosConfigState(const URI& uri) const {
@@ -342,21 +303,6 @@ namespace opflexagent {
         }
 
 
-    void QosManager::updateQosConfigState(const shared_ptr<modelgbp::qos::DscpMarking>& qosconfig) {
-        lock_guard<recursive_mutex> guard(opflexagent::QosManager::qos_mutex);
-
-        string dscpMarking("QosDscpMarking/");
-        string dscpMarkingUri(qosconfig->getURI().toString());
-        dscpMarkingUri.erase(dscpMarkingUri.length()-dscpMarking.size());
-
-        URI reqUri(dscpMarkingUri);
-        reqToDscp.erase(reqUri);
-
-        uint8_t dscp = qosconfig->getMark().get();
-        reqToDscp.insert(make_pair(reqUri, dscp));
-    }
-
-
     void QosManager::updateQosConfigState(const shared_ptr<modelgbp::qos::BandwidthLimit>& qosconfig) {
         lock_guard<recursive_mutex> guard(opflexagent::QosManager::qos_mutex);
         LOG(INFO) << "BandwidthLimitUri: " << qosconfig->getURI().toString();
@@ -382,11 +328,6 @@ namespace opflexagent {
         lock_guard<recursive_mutex> guard(opflexagent::QosManager::qos_mutex);
         LOG(INFO) << "Requirement URI: " << qosconfig->getURI().toString();
 
-        optional<shared_ptr<modelgbp::qos::DscpMarking> > dscpMarking =
-            qosconfig->resolveQosDscpMarking();
-        if (dscpMarking){
-            updateQosConfigState(dscpMarking.get());
-        }
         optional<shared_ptr<modelgbp::qos::RequirementToEgressRSrc> > rsEgress =
             qosconfig->resolveQosRequirementToEgressRSrc();
         optional<URI> egressUri;
@@ -425,10 +366,6 @@ namespace opflexagent {
     }
 
     void QosManager::QosUniverseListener::processQosConfig(const shared_ptr<modelgbp::qos::BandwidthLimit>& qosconfig) {
-        qosmanager.updateQosConfigState(qosconfig);
-    }
-
-   void QosManager::QosUniverseListener::processQosConfig(const shared_ptr<modelgbp::qos::DscpMarking>& qosconfig) {
         qosmanager.updateQosConfigState(qosconfig);
     }
 

--- a/agent-ovs/lib/include/opflexagent/QosListener.h
+++ b/agent-ovs/lib/include/opflexagent/QosListener.h
@@ -46,12 +46,6 @@ public:
       * @param interface is name of the interface.
       */
      virtual void egressQosUpdated(const string& interface) {}
-
-     /**
-      * Called when dscp qos paramaters are updated.
-      * @param interface is name of the interface.
-      */
-     virtual void dscpQosUpdated(const string& interface) {}
 };
 }
 #endif // OPFLEX_QOSLISTENER_H

--- a/agent-ovs/lib/include/opflexagent/QosManager.h
+++ b/agent-ovs/lib/include/opflexagent/QosManager.h
@@ -80,13 +80,6 @@ public:
     boost::optional<shared_ptr<QosConfigState>> getQosConfigState(const URI& uri) const;
 
     /**
-     * get dscp value with interface as the key.
-     * @param[in] interface interface name.
-     * @return integer value of dscp.
-     */
-    int getDscpMarking(const string& interface) const;
-
-    /**
      * get shared ptr to egress or ingress qosConfigState
      * @param[in] interface Name of the interface
      * @param[in] egress flag to determine direction
@@ -120,11 +113,6 @@ public:
      */
     void updateQosConfigState(const shared_ptr<modelgbp::qos::BandwidthLimit>& requirement);
 
-    /**
-     * update qosConfigState for a DscpMarking object.
-     * @param[in] qosconfig shared ptr to DscpMarking object.
-     */
-    void updateQosConfigState(const shared_ptr<modelgbp::qos::DscpMarking>& qosconfig);
 
     /**
      * update interfaces for a requirement to its ingress and egress policies.
@@ -352,17 +340,11 @@ public:
           */
          void updateInterfaces(const URI& updatedUri, const string& dir, const unordered_map<URI, unordered_set<string>>& policyMap);
 
-         /**
-          * process bandwidth update
-          * @param[in] requirementConfig shared pointer to a BandwidthLimit object
-          */
-         void processQosConfig(const shared_ptr<modelgbp::qos::BandwidthLimit>& requirementConfig);
-
-         /**
-          * process dscpMarking update
-          * @param[in] qosConfig shared pointer to a DscpMarking object
-          */
-         void processQosConfig(const shared_ptr<modelgbp::qos::DscpMarking>& qosConfig);
+	 /**
+	  * process bandwidth update
+	  * @param[in] requirementConfig shared pointer to a BandwidthLimit object
+	  */
+	 void processQosConfig(const shared_ptr<modelgbp::qos::BandwidthLimit>& requirementConfig);
 
     private:
         QosManager& qosmanager;
@@ -406,8 +388,6 @@ private:
 
     unordered_map<URI, shared_ptr<QosConfigState>> bwToConfig;
     unordered_map<URI, pair<boost::optional<URI>, boost::optional<URI> > > reqToPol;
-
-    unordered_map<URI, uint8_t> reqToDscp;
 
     unordered_set<URI> notifyUpdate;
     unordered_set<URI> notifyDelete;

--- a/agent-ovs/lib/test/QosManager_test.cpp
+++ b/agent-ovs/lib/test/QosManager_test.cpp
@@ -54,13 +54,6 @@ class QosFixture : public BaseFixture {
             reqRs->setTargetRequirement("test","req1");
 
             mutator3.commit();
-
-            Mutator mutator4(framework, "framework");
-            dscpCfg = reqCfg->addQosDscpMarking();
-            dscpCfg->setMark(28);
-            mutator4.commit();
-
-
             fs::create_directory(temp);
         }
 
@@ -71,7 +64,6 @@ class QosFixture : public BaseFixture {
         shared_ptr<policy::Space> pSpace;
         shared_ptr<qos::BandwidthLimit> qosCfg;
         shared_ptr<qos::Requirement> reqCfg;
-        shared_ptr<qos::DscpMarking> dscpCfg;
         shared_ptr<qos::RequirementToEgressRSrc> egressRs;
         shared_ptr<gbp::EpGroup> epg;
         shared_ptr<gbp::EpGroupToQosRSrc> reqRs;
@@ -101,14 +93,7 @@ static bool checkQosBurst(boost::optional<shared_ptr<QosConfigState>> pQos,
     LOG(DEBUG) << "checkQosBurst " << pQos.get()->getBurst();
     return pQos.get()->getBurst() == pQosCfg->getBurst();
 }
-static bool checkQosDscpMarking(uint8_t dscpMarking,
-                                   shared_ptr<qos::DscpMarking>& pQosDscpMarking) {
-    if (!pQosDscpMarking)
-        return false;
 
-    LOG(DEBUG) << "checkQosDscpMarking " << dscpMarking;
-    return dscpMarking == pQosDscpMarking->getMark().get();
-}
 
 static bool checkInterfaceCache(QosManager &qosmanager) {
     std::lock_guard<std::recursive_mutex> guard1(opflexagent::QosManager::qos_mutex);
@@ -232,23 +217,11 @@ BOOST_FIXTURE_TEST_CASE( verify_artifacts, QosFixture ) {
             temp.string());
     watcher.start();
 
-    WAIT_FOR(checkQosDscpMarking(agent.getQosManager().getDscpMarking("veth0-acc"), dscpCfg), 2000);
     WAIT_FOR(checkQos(agent.getQosManager().getQosConfigState(qosCfg->getURI()),
                 qosCfg->getURI()), 500);
     WAIT_FOR(checkQosRate(agent.getQosManager().getQosConfigState(qosCfg->getURI()), qosCfg), 500);
     WAIT_FOR(checkQosBurst(agent.getQosManager().getQosConfigState(qosCfg->getURI()), qosCfg), 500);
     WAIT_FOR(checkInterfaceCache(agent.getQosManager()), 500);
-
-    Mutator mutator1(framework, "framework");
-    const URI& dscpUri = dscpCfg->getURI();
-    dscpCfg->setMark(18);
-    mutator1.commit();
-    WAIT_FOR(checkQosDscpMarking(agent.getQosManager().getDscpMarking("veth0-acc"), dscpCfg), 2500);
-
-    Mutator mutator2(framework, "framework");
-    dscpCfg->remove();
-    mutator2.commit();
-    WAIT_FOR(!qos::DscpMarking::resolve(framework, dscpUri), 500);
 
     fs::ofstream os2(path1);
     os2 << "{"

--- a/agent-ovs/ovs/ActionBuilder.cpp
+++ b/agent-ovs/ovs/ActionBuilder.cpp
@@ -202,11 +202,6 @@ ActionBuilder& ActionBuilder::setVlanVid(uint16_t vlan) {
     return *this;
 }
 
-ActionBuilder& ActionBuilder::setDscp(uint8_t dscp) {
-    act_mod_nw_tos(buf, dscp);
-    return *this;
-}
-
 ActionBuilder& ActionBuilder::popVlan() {
     act_pop_vlan(buf);
     return *this;

--- a/agent-ovs/ovs/include/AccessFlowManager.h
+++ b/agent-ovs/ovs/include/AccessFlowManager.h
@@ -36,7 +36,6 @@ class AccessFlowManager : public EndpointListener,
                           public PolicyListener,
                           public SwitchStateHandler,
                           public ExtraConfigListener,
-                          public QosListener,
                           private boost::noncopyable {
 public:
     /**
@@ -91,9 +90,6 @@ public:
     /* Interface: EndpointListener */
     virtual void endpointUpdated(const std::string& uuid);
     virtual void secGroupSetUpdated(const EndpointListener::uri_set_t& secGrps);
-
-    /*Interface: QosListener */
-    virtual void dscpQosUpdated(const string& interface);
 
     /* Interface: LearningBridgeListener */
     virtual void lbIfaceUpdated(const std::string& uuid);
@@ -164,7 +160,6 @@ private:
     void handlePortStatusUpdate(const std::string& portName, uint32_t portNo);
     void handleSecGrpSetUpdate(const EndpointListener::uri_set_t& secGrps,
                                const std::string& secGrpsId);
-    void handleDscpQosUpdate(const string& interface);
 
     Agent& agent;
     SwitchManager& switchManager;

--- a/agent-ovs/ovs/include/ActionBuilder.h
+++ b/agent-ovs/ovs/include/ActionBuilder.h
@@ -260,13 +260,6 @@ public:
     ActionBuilder& setVlanVid(uint16_t vlan);
 
     /**
-     * Set the ip_dscp field
-     * @param dscp the dscp mark to set
-     * @return this action builder for chaining
-     */
-    ActionBuilder& setDscp(uint8_t dscp);
-
-    /**
      * Pop a VLAN tag from the packet
      * @return this action builder for chaining
      */

--- a/agent-ovs/ovs/include/ovs-shim.h
+++ b/agent-ovs/ovs/include/ovs-shim.h
@@ -189,11 +189,6 @@ extern "C" {
     void act_set_vlan_vid(struct ofpbuf* buf, uint16_t vlan);
 
     /**
-     * set dscp mark
-     */
-    void act_mod_nw_tos(struct ofpbuf* buf, uint8_t dscp);
-
-    /**
      * pop vlan
      */
     void act_pop_vlan(struct ofpbuf* buf);

--- a/agent-ovs/ovs/ovs-shim.c
+++ b/agent-ovs/ovs/ovs-shim.c
@@ -247,16 +247,6 @@ void act_set_vlan_vid(struct ofpbuf* buf, uint16_t vlan) {
 
 }
 
-void act_mod_nw_tos(struct ofpbuf* buf, uint8_t dscp) {
-    struct ofpact_dscp* act = ofpact_put_SET_IP_DSCP(buf);
-    /*
-     * mark needs to be bit shifted 2 left to not overwrite the
-     * lower 2 bits of type of service packet header.
-     * source: man ovs-ofctl (/mod_nw_tos)
-     */
-    act->dscp = (dscp << 2);
-}
-
 void act_pop_vlan(struct ofpbuf* buf) {
     /* ugly hack to avoid the fact that there's no way in the API to
        make a pop vlan action */

--- a/agent-ovs/ovs/test/include/FlowManagerFixture.h
+++ b/agent-ovs/ovs/test/include/FlowManagerFixture.h
@@ -261,7 +261,6 @@ public:
     Bldr& pushVlan() { a("push_vlan:0x8100"); return *this; }
     Bldr& popVlan() { a("pop_vlan"); return *this; }
     Bldr& setVlan(uint16_t v) { a("set_vlan_vid", str(v)); return *this; }
-    Bldr& setDscp(uint8_t v) { a("mod_nw_tos", str(v)); return *this; }
     Bldr& inport() { a("IN_PORT"); return *this; }
     Bldr& controller(uint16_t len) {
         a("CONTROLLER", str(len)); return *this;
@@ -285,9 +284,6 @@ public:
     Bldr& polApplied() { a("write_metadata", "0x100/0x100"); return *this; }
     Bldr& resubmit(uint8_t t) {
         a() << "resubmit(," << str(t) << ")"; return *this;
-    }
-    Bldr& resubmit(uint8_t p, uint8_t t) {
-        a() << "resubmit("<< str(p) << "," << str(t) << ")"; return *this;
     }
     Bldr& dropLog(uint32_t table_id , uint32_t reason = NO_MATCH);
 


### PR DESCRIPTION
Reverts noironetworks/opflex#258
One of the tests is failing inconsistently. 
2020-Sep-26 22:18:11.074616] [info] [lib/QosManager.cpp:383:updateQosConfigState] Requirement URI: /PolicyUniverse/PolicySpace/test/QosRequirement/req1/
[2020-Sep-26 22:18:11.074783] [info] [lib/QosManager.cpp:400:updateQosConfigState] Egress URI: /PolicyUniverse/PolicySpace/test/QosBandwidthLimit/testQos/
lib/test/QosManager_test.cpp(246): error: in "QosManager_test/verify_artifacts": check (checkQosDscpMarking(agent.getQosManager().getDscpMarking("veth0-acc"), dscpCfg)) has failed.
 Please fix this and resubmit