### PR TITLE
Revert openshift hack to dup untagged packets

### DIFF
--- a/agent-ovs/lib/FSEndpointSource.cpp
+++ b/agent-ovs/lib/FSEndpointSource.cpp
@@ -116,7 +116,6 @@ void FSEndpointSource::updated(const fs::path& filePath) {
     static const std::string SNAT_UUIDS("snat-uuids");
     static const std::string ACTIVE_ACTIVE_AAP("active-active-aap");
     static const std::string EP_DISABLE_ADV("disable-adv");
-    static const std::string EP_ACCESS_ALLOW_UNTAGGED("access-allow-untagged");
 
     static const std::string NEUTRON_NW("neutron-network");
 
@@ -476,11 +475,6 @@ void FSEndpointSource::updated(const fs::path& filePath) {
             properties.get_optional<bool>(EP_DISABLE_ADV);
         if (disableAdv)
             newep.setDisableAdv(disableAdv.get());
-
-        optional<bool> accessAllowUntagged =
-            properties.get_optional<bool>(EP_ACCESS_ALLOW_UNTAGGED);
-        if (accessAllowUntagged)
-            newep.setAccessAllowUntagged(accessAllowUntagged.get());
 
         optional<bool> provider_vlan =
                 properties.get_optional<bool>(EP_PROVIDER_VLAN_FLAG);

--- a/agent-ovs/lib/FSExternalEndpointSource.cpp
+++ b/agent-ovs/lib/FSExternalEndpointSource.cpp
@@ -90,7 +90,6 @@ void FSExternalEndpointSource::updated(const fs::path& filePath) {
     static const std::string DHCP_T2("t2");
     static const std::string DHCP_PREFERRED_LIFETIME("preferred-lifetime");
     static const std::string DHCP_VALID_LIFETIME("valid-lifetime");
-    static const std::string EP_ACCESS_ALLOW_UNTAGGED("access-allow-untagged");
 
     try {
         using boost::property_tree::ptree;
@@ -302,11 +301,6 @@ void FSExternalEndpointSource::updated(const fs::path& filePath) {
 
             newep.setDHCPv6Config(c);
         }
-
-        optional<bool> accessAllowUntagged =
-            properties.get_optional<bool>(EP_ACCESS_ALLOW_UNTAGGED);
-        if (accessAllowUntagged)
-            newep.setAccessAllowUntagged(accessAllowUntagged.get());
 
         ep_map_t::const_iterator it = knownEps.find(pathstr);
         if (it != knownEps.end()) {

--- a/agent-ovs/lib/include/opflexagent/Endpoint.h
+++ b/agent-ovs/lib/include/opflexagent/Endpoint.h
@@ -38,8 +38,7 @@ public:
      * Default constructor for containers
      */
     Endpoint() : promiscuousMode(false), discoveryProxyMode(false), natMode(false),
-                 external(false), aapModeAA(false), disableAdv(false),
-                 accessAllowUntagged(false), extEncap(0) {
+                 external(false), aapModeAA(false), disableAdv(false), extEncap(0) {
 #ifdef HAVE_PROMETHEUS_SUPPORT
         annotateEpName = false;
         attr_hash = 0;
@@ -55,8 +54,7 @@ public:
      */
     explicit Endpoint(const std::string& uuid_)
         : uuid(uuid_), promiscuousMode(false), discoveryProxyMode(false), natMode(false),
-          external(false), aapModeAA(false), disableAdv(false),
-          accessAllowUntagged(false), extEncap(0) {
+          external(false), aapModeAA(false), disableAdv(false), extEncap(0) {
 #ifdef HAVE_PROMETHEUS_SUPPORT
         annotateEpName = false;
         attr_hash = 0;
@@ -485,28 +483,6 @@ public:
     */
     bool isDisableAdv() const {
         return disableAdv;
-    }
-
-    /**
-      * Set if access vlan should also allow untagged
-      * traffic like Openshift bootstrap use case
-      *
-      * @param accessAllowUntagged the new value of
-      * accessAllowUntagged flag
-      */
-    void setAccessAllowUntagged(bool accessAllowUntagged) {
-        this->accessAllowUntagged = accessAllowUntagged;
-    }
-
-    /**
-      * Get the current value of accessAllowUntagged flag
-      * for this endpoint
-      *
-      * @return true if untagged traffic should also be allowed
-      * else return false
-      */
-    bool isAccessAllowUntagged() const {
-        return accessAllowUntagged;
     }
 
     /**
@@ -1330,7 +1306,6 @@ private:
     bool external;
     bool aapModeAA;
     bool disableAdv;
-    bool accessAllowUntagged;
     attr_map_t attributes;
 #ifdef HAVE_PROMETHEUS_SUPPORT
     bool annotateEpName;

--- a/agent-ovs/ovs/AccessFlowManager.cpp
+++ b/agent-ovs/ovs/AccessFlowManager.cpp
@@ -180,18 +180,11 @@ static FlowEntryPtr flowEmptySecGroup(uint32_t emptySecGrpSetId) {
     return noSecGrp.build();
 }
 
-static uint64_t getPushVlanMeta(std::shared_ptr<const Endpoint>& ep) {
-    return ep->isAccessAllowUntagged() ?
-        flow::meta::access_out::UNTAGGED_AND_PUSH_VLAN :
-        flow::meta::access_out::PUSH_VLAN;
-}
-
-static void flowBypassDhcpRequest(FlowEntryList& el, bool v4,
-                                  bool skip_pop_vlan, uint32_t inport,
+static void flowBypassDhcpRequest(FlowEntryList& el, bool v4, uint32_t inport,
                                   uint32_t outport,
                                   std::shared_ptr<const Endpoint>& ep ) {
     FlowBuilder fb;
-    if (ep->getAccessIfaceVlan() && !skip_pop_vlan) {
+    if (ep->getAccessIfaceVlan()) {
         fb.priority(201).inPort(inport);
     } else {
         fb.priority(200).inPort(inport);
@@ -200,14 +193,11 @@ static void flowBypassDhcpRequest(FlowEntryList& el, bool v4,
     flowutils::match_dhcp_req(fb, v4);
     fb.action().reg(MFF_REG7, outport);
 
-    if (ep->getAccessIfaceVlan() && !skip_pop_vlan) {
+    if (ep->getAccessIfaceVlan()) {
         fb.vlan(ep->getAccessIfaceVlan().get());
         fb.action().metadata(flow::meta::access_out::POP_VLAN,
                              flow::meta::out::MASK);
     }
-
-    if (skip_pop_vlan)
-        fb.tci(0, 0x1fff);
 
     fb.action().go(AccessFlowManager::OUT_TABLE_ID);
     fb.build(el);
@@ -215,11 +205,10 @@ static void flowBypassDhcpRequest(FlowEntryList& el, bool v4,
 
 static void flowBypassFloatingIP(FlowEntryList& el, uint32_t inport,
                                  uint32_t outport, bool in,
-                                 bool skip_pop_vlan,
                                  address& floatingIp,
                                  std::shared_ptr<const Endpoint>& ep ) {
     FlowBuilder fb;
-    if (ep->getAccessIfaceVlan() && !skip_pop_vlan) {
+    if (ep->getAccessIfaceVlan()) {
         fb.priority(201).inPort(inport);
     } else {
         fb.priority(200).inPort(inport);
@@ -238,11 +227,12 @@ static void flowBypassFloatingIP(FlowEntryList& el, uint32_t inport,
     }
 
     fb.action().reg(MFF_REG7, outport);
-    if (ep->getAccessIfaceVlan() && !skip_pop_vlan) {
+    if (ep->getAccessIfaceVlan()) {
         if (in) {
             fb.action()
                 .reg(MFF_REG5, ep->getAccessIfaceVlan().get())
-                .metadata(getPushVlanMeta(ep), flow::meta::out::MASK);
+                .metadata(flow::meta::access_out::PUSH_VLAN,
+                          flow::meta::out::MASK);
         } else {
             fb.vlan(ep->getAccessIfaceVlan().get());
             fb.action()
@@ -250,9 +240,6 @@ static void flowBypassFloatingIP(FlowEntryList& el, uint32_t inport,
                           flow::meta::out::MASK);
         }
     }
-
-    if (skip_pop_vlan && !in)
-        fb.tci(0, 0x1fff);
 
     fb.action().go(AccessFlowManager::OUT_TABLE_ID);
     fb.build(el);
@@ -275,22 +262,6 @@ void AccessFlowManager::createStaticFlows() {
             .metadata(flow::meta::access_out::PUSH_VLAN,
                       flow::meta::out::MASK)
             .action()
-            .pushVlan().regMove(MFF_REG5, MFF_VLAN_VID).outputReg(MFF_REG7)
-            .parent().build(outFlows);
-        /*
-         * The packet is replicated for a specical case of
-         * Openshift bootstrap that does not use vlan 4094
-         * This is ugly but they do not have iproute2/tc
-         * installed to do this in a cleaner way
-         * This duplication only happens when endpoint
-         * file has "access-interface-vlan" attr
-         */
-        FlowBuilder()
-            .priority(1)
-            .metadata(flow::meta::access_out::UNTAGGED_AND_PUSH_VLAN,
-                      flow::meta::out::MASK)
-            .action()
-            .outputReg(MFF_REG7)
             .pushVlan().regMove(MFF_REG5, MFF_VLAN_VID).outputReg(MFF_REG7)
             .parent().build(outFlows);
         outFlows.push_back(flowutils::default_out_flow());
@@ -414,47 +385,16 @@ void AccessFlowManager::handleEndpointUpdate(const string& uuid) {
         }
 
         /*
-         * We allow without tags to handle Openshift bootstrap
-         */
-        if (ep->isAccessAllowUntagged() && ep->getAccessIfaceVlan()) {
-            FlowBuilder inSkipVlan;
-
-            inSkipVlan.priority(99).inPort(accessPort)
-                      .tci(0, 0x1fff);
-            if (zoneId != static_cast<uint16_t>(-1))
-                inSkipVlan.action()
-                    .reg(MFF_REG6, zoneId);
-
-            inSkipVlan.action()
-                .reg(MFF_REG0, secGrpSetId)
-                .reg(MFF_REG7, uplinkPort)
-                .go(SEC_GROUP_OUT_TABLE_ID);
-            inSkipVlan.build(el);
-        }
-
-        /*
          * Allow DHCP request to bypass the access bridge policy when
          * virtual DHCP is enabled.
-         * We allow both with / without tags to handle Openshift
-         * bootstrap
          */
         optional<Endpoint::DHCPv4Config> v4c = ep->getDHCPv4Config();
-        if (v4c) {
-            flowBypassDhcpRequest(el, true, false, accessPort,
-                                  uplinkPort, ep);
-            if (ep->isAccessAllowUntagged() && ep->getAccessIfaceVlan())
-                flowBypassDhcpRequest(el, true, true, accessPort,
-                                      uplinkPort, ep);
-        }
+        if (v4c)
+            flowBypassDhcpRequest(el, true, accessPort, uplinkPort, ep);
 
         optional<Endpoint::DHCPv6Config> v6c = ep->getDHCPv6Config();
-        if(v6c) {
-            flowBypassDhcpRequest(el, false, false, accessPort,
-                                  uplinkPort, ep);
-            if (ep->isAccessAllowUntagged() && ep->getAccessIfaceVlan())
-                flowBypassDhcpRequest(el, false, true, accessPort,
-                                      uplinkPort, ep);
-        }
+        if(v6c)
+            flowBypassDhcpRequest(el, false, accessPort, uplinkPort, ep);
 
         {
             FlowBuilder out;
@@ -469,7 +409,8 @@ void AccessFlowManager::handleEndpointUpdate(const string& uuid) {
             if (ep->getAccessIfaceVlan()) {
                 out.action()
                     .reg(MFF_REG5, ep->getAccessIfaceVlan().get())
-                    .metadata(getPushVlanMeta(ep), flow::meta::out::MASK);
+                    .metadata(flow::meta::access_out::PUSH_VLAN,
+                              flow::meta::out::MASK);
             }
             out.action().go(SEC_GROUP_IN_TABLE_ID);
             out.build(el);
@@ -511,19 +452,9 @@ void AccessFlowManager::handleEndpointUpdate(const string& uuid) {
                 if (floatingIp.is_unspecified()) continue;
             }
             flowBypassFloatingIP(el, accessPort, uplinkPort, false,
-                                 false, floatingIp, ep);
+                                 floatingIp, ep);
             flowBypassFloatingIP(el, uplinkPort, accessPort, true,
-                                 false, floatingIp, ep);
-            /*
-             * We allow both with / without tags to handle Openshift
-             * bootstrap
-             */
-            if (ep->isAccessAllowUntagged() && ep->getAccessIfaceVlan()) {
-                flowBypassFloatingIP(el, accessPort, uplinkPort, false,
-                                     true, floatingIp, ep);
-                flowBypassFloatingIP(el, uplinkPort, accessPort, true,
-                                     true, floatingIp, ep);
-            }
+                                 floatingIp, ep);
         }
     }
     switchManager.writeFlow(uuid, GROUP_MAP_TABLE_ID, el);

--- a/agent-ovs/ovs/PacketInHandler.cpp
+++ b/agent-ovs/ovs/PacketInHandler.cpp
@@ -149,10 +149,7 @@ static void send_packet_out(Agent& agent,
     string iface;
     opt_output_act_t outActions =
         tunnelOutActions(intFlowManager, egUri, out_port);
-    opt_output_act_t outActionsSkipVlan;
     SwitchConnection* conn = intConn;
-    ep_ptr ep;
-    bool send_untagged = false;
 
     try {
         if (out_port == OFPP_IN_PORT)
@@ -171,7 +168,7 @@ static void send_packet_out(Agent& agent,
             LOG(WARNING) << "Multiple possible endpoints for output packet "
                          << " on " << iface;
 
-        ep = agent.getEndpointManager().getEndpoint(*eps.begin());
+        ep_ptr ep = agent.getEndpointManager().getEndpoint(*eps.begin());
         if (ep && ep->getAccessInterface() && ep->getAccessUplinkInterface()) {
             if (!accConn || !accPortMapper) {
                 return;
@@ -186,9 +183,6 @@ static void send_packet_out(Agent& agent,
                 out_port = accPort;
 
                 if (ep->getAccessIfaceVlan()) {
-                    outActionsSkipVlan = outActions;
-                    if (ep->isAccessAllowUntagged())
-                        send_untagged = true;
                     outActions = [&ep](ActionBuilder& ab) {
                         ab.pushVlan();
                         ab.setVlanVid(ep->getAccessIfaceVlan().get());
@@ -201,11 +195,6 @@ static void send_packet_out(Agent& agent,
     }
 
     send_packet_out(conn, b, proto, in_port, out_port, outActions);
-    /*
-     * Openshift bootstrap does not support vlans, so make a copy
-     */
-    if (send_untagged)
-        send_packet_out(conn, b, proto, in_port, out_port, outActionsSkipVlan);
 }
 
 /**

--- a/agent-ovs/ovs/include/FlowConstants.h
+++ b/agent-ovs/ovs/include/FlowConstants.h
@@ -183,11 +183,6 @@ const uint64_t POP_VLAN = 0x1;
  */
 const uint64_t PUSH_VLAN = 0x2;
 
-/**
- * Replicate the packet both untagged followed by tagged
- */
-const uint64_t UNTAGGED_AND_PUSH_VLAN = 0x3;
-
 } // namespace access
 
 } // namespace meta

--- a/agent-ovs/ovs/test/AccessFlowManager_test.cpp
+++ b/agent-ovs/ovs/test/AccessFlowManager_test.cpp
@@ -477,11 +477,7 @@ void AccessFlowManagerFixture::initExpStatic() {
          .actions().out(OUTPORT).done());
     ADDF(Bldr().table(OUT).priority(1)
          .isMdAct(opflexagent::flow::meta::access_out::PUSH_VLAN)
-         .actions().pushVlan().move(FD12, VLAN).out(OUTPORT).done());
-    ADDF(Bldr().table(OUT).priority(1)
-         .isMdAct(opflexagent::flow::meta::access_out::UNTAGGED_AND_PUSH_VLAN)
-         .actions().out(OUTPORT).pushVlan()
-         .move(FD12, VLAN).out(OUTPORT).done());
+          .actions().pushVlan().move(FD12, VLAN).out(OUTPORT).done());
     ADDF(Bldr().table(OUT).priority(1)
          .isMdAct(opflexagent::flow::meta::access_out::POP_VLAN)
          .isVlanTci("0x1000/0x1000")
@@ -517,15 +513,6 @@ void AccessFlowManagerFixture::initExpDhcpEp(shared_ptr<Endpoint>& ep) {
              .load(OUTPORT, uplink)
              .mdAct(opflexagent::flow::meta::access_out::POP_VLAN)
              .go(OUT).done());
-        if (ep->isAccessAllowUntagged() && ep->getAccessIfaceVlan()) {
-            ADDF(Bldr()
-                 .table(GRP).priority(200).udp().in(access)
-                 .isVlanTci("0x0000/0x1fff")
-                 .isTpSrc(68).isTpDst(67)
-                 .actions()
-                 .load(OUTPORT, uplink)
-                 .go(OUT).done());
-        }
     }
     if (ep->getDHCPv6Config()) {
         ADDF(Bldr()
@@ -536,15 +523,6 @@ void AccessFlowManagerFixture::initExpDhcpEp(shared_ptr<Endpoint>& ep) {
              .load(OUTPORT, uplink)
              .mdAct(opflexagent::flow::meta::access_out::POP_VLAN)
              .go(OUT).done());
-        if (ep->isAccessAllowUntagged() && ep->getAccessIfaceVlan()) {
-            ADDF(Bldr()
-                 .table(GRP).priority(200).udp6().in(access)
-                 .isVlanTci("0x0000/0x1fff")
-                 .isTpSrc(546).isTpDst(547)
-                 .actions()
-                 .load(OUTPORT, uplink)
-                 .go(OUT).done());
-        }
     }
 }
 
@@ -563,14 +541,6 @@ void AccessFlowManagerFixture::initExpEp(shared_ptr<Endpoint>& ep) {
              .load(OUTPORT, uplink)
              .mdAct(opflexagent::flow::meta::access_out::POP_VLAN)
              .go(OUT_POL).done());
-        if (ep->isAccessAllowUntagged()) {
-            ADDF(Bldr().table(GRP).priority(99).in(access)
-                 .isVlanTci("0x0000/0x1fff")
-                 .actions()
-                 .load(RD, zoneId).load(SEPG, 1)
-                 .load(OUTPORT, uplink)
-                 .go(OUT_POL).done());
-        }
         ADDF(Bldr().table(GRP).priority(100).in(uplink)
              .actions().load(RD, zoneId).load(SEPG, 1).load(OUTPORT, access)
              .load(FD, ep->getAccessIfaceVlan().get())


### PR DESCRIPTION
This commit reverts

- commit 656ae3e5801e0b3b470d00a08f6ac643d7930f44
Author: Madhu Challa <challa@gmail.com>
Date:   Wed Apr 29 22:27:38 2020 -0700
    Add a new flag access-allow-untagged

- commit 0b36f41be40b4ca4c9d2e82cdb844d12986543a6
commit 0b36f41be40b4ca4c9d2e82cdb844d12986543a6
Author: Madhu Challa <challa@gmail.com>
Date:   Fri Feb 28 16:28:08 2020 -0800
    Permit untagged traffic for access-interface-vlan

These are no longer needed for openshift to work.

Signed-off-by: Madhu Challa <challa@gmail.com>