### PR TITLE
FSEndpointSource: Read qos-policy as a dict.

### DIFF
--- a/agent-ovs/lib/FSEndpointSource.cpp
+++ b/agent-ovs/lib/FSEndpointSource.cpp
@@ -214,20 +214,18 @@ void FSEndpointSource::updated(const fs::path& filePath) {
         optional<ptree&> qosPol =
             properties.get_child_optional(QOS_POLICY);
         if (qosPol){
-            for (const ptree::value_type &v : qosPol.get()) {
-                optional<string> qosPolicySpace =
-                    v.second.get_optional<string>(SEC_GROUP_POLICY_SPACE);
-                optional<string> qosPolicyName =
-                    v.second.get_optional<string>(SEC_GROUP_NAME);
-                if (qosPolicyName && qosPolicySpace) {
-                    newep.setQosPolicy(opflex::modb::URIBuilder()
-                            .addElement("PolicyUniverse")
-                            .addElement("PolicySpace")
-                            .addElement(qosPolicySpace.get())
-                            .addElement("QosRequirement")
-                            .addElement(qosPolicyName.get())
-                            .build());
-                }
+            optional<string> qosPolicySpace =
+                qosPol.get().get_optional<string>(SEC_GROUP_POLICY_SPACE);
+            optional<string> qosPolicyName =
+                qosPol.get().get_optional<string>(SEC_GROUP_NAME);
+            if (qosPolicyName && qosPolicySpace) {
+                newep.setQosPolicy(opflex::modb::URIBuilder()
+                        .addElement("PolicyUniverse")
+                        .addElement("PolicySpace")
+                        .addElement(qosPolicySpace.get())
+                        .addElement("QosRequirement")
+                        .addElement(qosPolicyName.get())
+                        .build());
             }
         }
 

--- a/agent-ovs/lib/test/EndpointManager_test.cpp
+++ b/agent-ovs/lib/test/EndpointManager_test.cpp
@@ -596,9 +596,8 @@ BOOST_FIXTURE_TEST_CASE( fssource, FSEndpointFixture ) {
        << "\"attributes\":{"
        << "\"attr1\":\"value1\",\"attr2\":\"value2\""
        << "},"
-       <<"\"qos-policy\":["
+       <<"\"qos-policy\":"
        <<"{\"policy-space\":\"sg1-space1\",\"name\":\"bw-limiter\"}"
-       <<"]"
        << "}" << std::endl;
     os.close();
 
@@ -752,9 +751,8 @@ BOOST_FIXTURE_TEST_CASE( fssource, FSEndpointFixture ) {
        << "\"security-group\":["
        << "{\"policy-space\":\"sg1-space1\",\"name\":\"sg1\"}"
        << "],"
-       << "\"qos-policy\":["
-       << "{\"policy-space\":\"sg1-space1\",\"name\":\"bw-limiter\"}"
-       << "],"
+       << "\"qos-policy\":"
+       << "{\"policy-space\":\"sg1-space1\",\"name\":\"bw-limiter\"},"
        << "\"attributes\":{"
        << "\"vm-name\":\"acc-veth0\""
        << "}"

--- a/agent-ovs/lib/test/QosManager_test.cpp
+++ b/agent-ovs/lib/test/QosManager_test.cpp
@@ -206,9 +206,8 @@ BOOST_FIXTURE_TEST_CASE( verify_artifacts, QosFixture ) {
         << "\"attributes\":{"
         << "\"attr1\":\"value1\",\"attr2\":\"value2\""
         << "},"
-        <<"\"qos-policy\":["
+        <<"\"qos-policy\":"
         <<"{\"policy-space\":\"test\",\"name\":\"req1\"}"
-        <<"]"
         << "}" << std::endl;
     os.close();
 


### PR DESCRIPTION
Per ep, there can be only 1 qos  policy. FSEndpointSource should  read qos-policy as 1 dictionary instead of list of dictionaries. 