### PR TITLE
Disable Tunnel advertisements in overlay mode

### DIFF
--- a/agent-ovs/ovs/AdvertManager.cpp
+++ b/agent-ovs/ovs/AdvertManager.cpp
@@ -646,9 +646,9 @@ void AdvertManager::sendTunnelEpRarp(const string& uuid) {
     string uplinkIface;
     intFlowManager.getTunnelEpManager().getUplinkIface(uplinkIface);
     sa_ll.sll_ifindex = if_nametoindex(uplinkIface.c_str());
-    if(sa_ll.sll_ifindex < 0) {
+    if(sa_ll.sll_ifindex == 0) {
         LOG(ERROR) << "Failed to get ifindex by name " << uplinkIface <<
-                ": " << sa_ll.sll_ifindex;
+                ": " << strerror(errno);
         return;
     }
     memset(sa_ll.sll_addr, 0xff, ETH_ALEN);
@@ -703,9 +703,9 @@ void AdvertManager::sendTunnelEpGarp(const string& uuid) {
     string uplinkIface;
     intFlowManager.getTunnelEpManager().getUplinkIface(uplinkIface);
     sa_ll.sll_ifindex = if_nametoindex(uplinkIface.c_str());
-    if(sa_ll.sll_ifindex < 0) {
+    if(sa_ll.sll_ifindex == 0) {
         LOG(ERROR) << "Failed to get ifindex by name " << uplinkIface <<
-                ": " << sa_ll.sll_ifindex;
+                ": " << strerror(errno);
         return;
     }
     memset(sa_ll.sll_addr, 0xff, ETH_ALEN);

--- a/agent-ovs/ovs/IntFlowManager.cpp
+++ b/agent-ovs/ovs/IntFlowManager.cpp
@@ -344,7 +344,14 @@ void IntFlowManager::endpointUpdated(const std::string& uuid) {
     if (stopping) return;
 
     if(tunnelEpManager.isTunnelEp(uuid)){
-        advertManager.scheduleTunnelEpAdv(uuid);
+        string uplinkIface;
+        tunnelEpManager.getUplinkIface(uplinkIface);
+        if(!uplinkIface.empty()) {
+            advertManager.scheduleTunnelEpAdv(uuid);
+        } else {
+            // This is true in the cloud case
+            LOG(INFO) << "Configured uplink is empty.Not starting Tunnel advertisements";
+        }
         return;
     }
     advertManager.scheduleEndpointAdv(uuid);


### PR DESCRIPTION
Since we dont have a flag for overlay mode in opflex-agent,
turn off tunnel-advertisements based on missing uplink config.
Fix error in checking return value of if_nametoifindex syscall.

Signed-off-by: Kiran Shastri <shastrinator@gmail.com>