### PR TITLE
Sorting the classifiers on contracts with same range

### DIFF
--- a/agent-ovs/lib/PolicyManager.cpp
+++ b/agent-ovs/lib/PolicyManager.cpp
@@ -1054,6 +1054,42 @@ void resolveRemoteSubnets(OFFramework& framework,
     }
 }
 
+void sortOrder(vector<shared_ptr<modelgbp::gbpe::L24Classifier>>& classifiers) {
+     using modelgbp::gbpe::L24Classifier;
+     PriorityComparator<shared_ptr<L24Classifier> > classifierPrioComp;
+     vector<shared_ptr<L24Classifier>>::iterator begin = classifiers.begin();
+     vector<shared_ptr<L24Classifier>>::iterator end = classifiers.begin();
+     std::pair<vector<shared_ptr<L24Classifier>>::iterator, vector<shared_ptr<L24Classifier>>::iterator> range;
+     int set=0;
+
+     for (auto it = classifiers.begin(); it != classifiers.end(); it ++){
+         const shared_ptr<L24Classifier>& currClsr = *it;
+         if (*it != *(--classifiers.end())){
+             const shared_ptr<L24Classifier>& nextClsr = *(it+1) ;
+             if (currClsr->getOrder(0) == nextClsr->getOrder(0)) {
+                if (set == 0){
+                   begin = it;
+                   set = 1;
+                }
+                end = it+1;
+                if (*end == *(--classifiers.end())){
+                   range = std::make_pair(begin, end);
+                   stable_sort(range.first, range.second+1, classifierPrioComp);
+                   set = 0;
+                }
+
+             } else  {
+                   if (end != classifiers.begin()){
+                      range = std::make_pair(begin, end);
+                      stable_sort(range.first, range.second+1, classifierPrioComp);
+                      set = 0;
+                   }
+               }
+         }
+
+      }
+}
+
 template <typename Parent, typename Subject, typename Rule>
 static bool updatePolicyRules(OFFramework& framework,
                               const URI& parentURI, bool& notFound,
@@ -1167,6 +1203,7 @@ static bool updatePolicyRules(OFFramework& framework,
                 }
             }
 
+            sortOrder(classifiers);
             uint16_t clsPrio = 0;
             for (const shared_ptr<L24Classifier>& c : classifiers) {
                 newRules.push_back(std::

--- a/agent-ovs/lib/include/opflexagent/PolicyManager.h
+++ b/agent-ovs/lib/include/opflexagent/PolicyManager.h
@@ -16,6 +16,8 @@
 #include <opflexagent/PolicyListener.h>
 #include <opflexagent/Network.h>
 #include <opflexagent/TaskQueue.h>
+#include <opflexagent/logging.h>
+#include <boost/algorithm/string/config.hpp>
 
 #include <boost/noncopyable.hpp>
 #include <boost/asio/io_service.hpp>
@@ -1394,6 +1396,45 @@ struct OrderComparator {
         return lhs->getOrder(std::numeric_limits<uint32_t>::max()) <
             rhs->getOrder(std::numeric_limits<uint32_t>::max());
     }
+};
+
+/**
+ * Comparator for sorting classifier objects based on the priorities 
+ * assigned to the members of classifiers
+ */
+
+template<typename T>
+struct PriorityComparator {
+
+    bool operator()(const T& lhs, const T& rhs) {
+        LOG(INFO) << "inside stable sort";
+        LOG(INFO) << lhs;
+        LOG(INFO) << rhs;
+        if (lhs->isTcpFlagsSet() > rhs->isTcpFlagsSet()) { return true; }
+        if (lhs->isTcpFlagsSet() < rhs->isTcpFlagsSet()) { return false; }
+
+        if ((lhs->isDFromPortSet() && lhs->isSFromPortSet()) > (rhs->isDFromPortSet() && rhs->isSFromPortSet() )) { return true; }
+        if ((lhs->isDFromPortSet() && lhs->isSFromPortSet()) < (rhs->isDFromPortSet() && rhs->isSFromPortSet())) { return false; }
+
+        if (lhs->isDFromPortSet() > rhs->isDFromPortSet()) { return true; }
+        if (lhs->isDFromPortSet() < rhs->isDFromPortSet()) { return false; }
+
+        if (lhs->isSFromPortSet() > rhs->isSFromPortSet()) { return true; }
+        if (lhs->isSFromPortSet() < rhs->isSFromPortSet()) { return false; }
+
+        if (lhs->isProtSet() > rhs->isProtSet()) { return true; }
+        if (lhs->isProtSet() < rhs->isProtSet()) { return false; }
+
+        if (lhs->isFragmentFlagsSet() < rhs->isFragmentFlagsSet()) { return true; }
+        if (lhs->isFragmentFlagsSet() > rhs->isFragmentFlagsSet()) { return false; }
+
+        int x = lhs->getURI().toString().compare(rhs->getURI().toString());
+
+        if (x > 0 ) { return true; }
+        if (x < 0 ) { return false; }
+
+    return false;
+}
 };
 
 } /* namespace opflexagent */

--- a/agent-ovs/lib/include/opflexagent/PolicyManager.h
+++ b/agent-ovs/lib/include/opflexagent/PolicyManager.h
@@ -16,8 +16,6 @@
 #include <opflexagent/PolicyListener.h>
 #include <opflexagent/Network.h>
 #include <opflexagent/TaskQueue.h>
-#include <opflexagent/logging.h>
-#include <boost/algorithm/string/config.hpp>
 
 #include <boost/noncopyable.hpp>
 #include <boost/asio/io_service.hpp>
@@ -1407,9 +1405,6 @@ template<typename T>
 struct PriorityComparator {
 
     bool operator()(const T& lhs, const T& rhs) {
-        LOG(INFO) << "inside stable sort";
-        LOG(INFO) << lhs;
-        LOG(INFO) << rhs;
         if (lhs->isTcpFlagsSet() > rhs->isTcpFlagsSet()) { return true; }
         if (lhs->isTcpFlagsSet() < rhs->isTcpFlagsSet()) { return false; }
 

--- a/agent-ovs/lib/include/opflexagent/test/ModbFixture.h
+++ b/agent-ovs/lib/include/opflexagent/test/ModbFixture.h
@@ -90,7 +90,24 @@ public:
     std::shared_ptr<modelgbp::gbpe::L24Classifier> classifier9;
     std::shared_ptr<modelgbp::gbpe::L24Classifier> classifier10;
 
+     // order 10
+    std::shared_ptr<modelgbp::gbpe::L24Classifier> classifier11;
+    std::shared_ptr<modelgbp::gbpe::L24Classifier> classifier12;
+    std::shared_ptr<modelgbp::gbpe::L24Classifier> classifier13;
+    std::shared_ptr<modelgbp::gbpe::L24Classifier> classifier14;
     std::shared_ptr<modelgbp::gbp::AllowDenyAction> action1;
+       // order 20
+    std::shared_ptr<modelgbp::gbpe::L24Classifier> classifier15;
+    std::shared_ptr<modelgbp::gbpe::L24Classifier> classifier16;
+    std::shared_ptr<modelgbp::gbpe::L24Classifier> classifier17;
+
+    //order 30
+    std::shared_ptr<modelgbp::gbpe::L24Classifier> classifier18;
+
+    //order 40
+    std::shared_ptr<modelgbp::gbpe::L24Classifier> classifier19;
+    std::shared_ptr<modelgbp::gbpe::L24Classifier> classifier20;
+
     std::shared_ptr<modelgbp::gbp::LogAction> action2;
 
     std::shared_ptr<modelgbp::gbp::AllowDenyAction> action3;
@@ -100,6 +117,12 @@ public:
     std::shared_ptr<modelgbp::gbp::Contract> con2;
     std::shared_ptr<modelgbp::gbp::Contract> con3;
     std::shared_ptr<modelgbp::gbp::Contract> con4;
+    std::shared_ptr<modelgbp::gbp::Contract> con5;
+    std::shared_ptr<modelgbp::gbp::Contract> con6;
+    std::shared_ptr<modelgbp::gbp::Contract> con7;
+    std::shared_ptr<modelgbp::gbp::Contract> con8;
+    std::shared_ptr<modelgbp::gbp::Contract> con9;
+    std::shared_ptr<modelgbp::gbp::Contract> con10;
     std::string policyOwner;
 protected:
 
@@ -317,6 +340,53 @@ protected:
             .setDFromPort(22)
             .setConnectionTracking(ConnTrackEnumT::CONST_REFLEXIVE);
 
+        classifier11 = space->addGbpeL24Classifier("classifier11");
+        classifier11->setOrder(10).setEtherT(l2::EtherTypeEnumT::CONST_IPV4)
+            .setProt(6 /* TCP */)
+            .setSFromPort(22)
+            .setTcpFlags(l4::TcpFlagsEnumT::CONST_ESTABLISHED);
+
+        classifier12 = space->addGbpeL24Classifier("classifier12");
+        classifier12->setOrder(10).setEtherT(l2::EtherTypeEnumT::CONST_IPV4)
+            .setProt(6 /* TCP */).setDFromPort(80).setSFromPort(80);
+
+        classifier13 = space->addGbpeL24Classifier("classifier13");
+        classifier13->setOrder(10).setEtherT(l2::EtherTypeEnumT::CONST_IPV4)
+            .setProt(6 /* TCP */).setSFromPort(22);
+
+        classifier14 = space->addGbpeL24Classifier("classifier14");
+        classifier14->setOrder(10).setEtherT(l2::EtherTypeEnumT::CONST_IPV4)
+            .setProt(6 /* TCP */)
+            .setConnectionTracking(ConnTrackEnumT::CONST_REFLEXIVE);
+
+        classifier15 = space->addGbpeL24Classifier("classifier15");
+        classifier15->setOrder(20).setEtherT(l2::EtherTypeEnumT::CONST_IPV4)
+                    .setProt(6 /* TCP */).setSFromPort(22);
+
+        classifier16 = space->addGbpeL24Classifier("classifier16");
+        classifier16->setOrder(20).setEtherT(l2::EtherTypeEnumT::CONST_IPV4)
+                     .setProt(6 /* TCP */)
+                     .setSFromPort(22)
+                     .setTcpFlags(l4::TcpFlagsEnumT::CONST_ESTABLISHED);
+
+        classifier17 = space->addGbpeL24Classifier("classifier17");
+        classifier17->setOrder(20).setEtherT(l2::EtherTypeEnumT::CONST_IPV4)
+                      .setProt(6 /* TCP */).setDFromPort(80);
+
+        classifier18 = space->addGbpeL24Classifier("classifier18");
+        classifier18->setOrder(30).setEtherT(l2::EtherTypeEnumT::CONST_IPV4)
+                      .setProt(6 /* TCP */).setDFromPort(80)
+                      .setSFromPort(22);
+
+        classifier19 = space->addGbpeL24Classifier("classifier19");
+        classifier19->setOrder(40).setEtherT(l2::EtherTypeEnumT::CONST_IPV4)
+                      .setProt(6 /* TCP */).setDFromPort(80);
+
+        classifier20 = space->addGbpeL24Classifier("classifier20");
+        classifier20->setOrder(40).setEtherT(l2::EtherTypeEnumT::CONST_IPV4)
+                      .setProt(6 /* TCP */).setDFromPort(80)
+                      .setSFromPort(22);
+
         con1 = space->addGbpContract("contract1");
         con1->addGbpSubject("1_subject1")->addGbpRule("1_1_rule1")
             ->setDirection(DirectionEnumT::CONST_IN).setOrder(100)
@@ -418,6 +488,163 @@ protected:
 
         epg0->addGbpEpGroupToProvContractRSrc(con4->getURI().toString());
         epg1->addGbpEpGroupToConsContractRSrc(con4->getURI().toString()); 
+
+        con5 = space->addGbpContract("contract5");
+        con5->addGbpSubject("5_subject1")->addGbpRule("5_rule1")
+            ->setOrder(300)
+            .setDirection(DirectionEnumT::CONST_IN)
+            .addGbpRuleToClassifierRSrc(classifier11->getURI().toString())
+            ->setTargetL24Classifier(classifier11->getURI());
+        con5->addGbpSubject("5_subject1")->addGbpRule("5_rule1")
+            ->addGbpRuleToClassifierRSrc(classifier12->getURI().toString())
+           ->setTargetL24Classifier(classifier12->getURI());
+        con5->addGbpSubject("5_subject1")->addGbpRule("5_rule1")
+            ->addGbpRuleToClassifierRSrc(classifier13->getURI().toString())
+            ->setTargetL24Classifier(classifier13->getURI());
+        con5->addGbpSubject("5_subject1")->addGbpRule("5_rule1")
+            ->addGbpRuleToActionRSrcAllowDenyAction(action3->getURI().toString())
+            ->setTargetAllowDenyAction(action3->getURI());
+        con5->addGbpSubject("5_subject1")->addGbpRule("5_rule1")
+            ->addGbpRuleToClassifierRSrc(classifier14->getURI().toString())
+            ->setTargetL24Classifier(classifier14->getURI());
+        con5->addGbpSubject("5_subject1")->addGbpRule("5_rule1")
+            ->addGbpRuleToActionRSrcAllowDenyAction(action3->getURI().toString())
+            ->setTargetAllowDenyAction(action3->getURI());
+        con5->addGbpSubject("5_subject1")->addGbpRule("5_rule1")
+            ->addGbpRuleToActionRSrcLogAction(action4->getURI().toString())
+            ->setTargetLogAction(action4->getURI());
+
+        epg0->addGbpEpGroupToProvContractRSrc(con5->getURI().toString());
+        epg1->addGbpEpGroupToConsContractRSrc(con5->getURI().toString());
+      
+        con6 = space->addGbpContract("contract6");
+        con6->addGbpSubject("6_subject1")->addGbpRule("6_rule1")
+             ->setOrder(400)
+             .setDirection(DirectionEnumT::CONST_OUT)
+             .addGbpRuleToClassifierRSrc(classifier11->getURI().toString())
+             ->setTargetL24Classifier(classifier11->getURI());
+        con6->addGbpSubject("6_subject1")->addGbpRule("6_rule1")
+             ->addGbpRuleToClassifierRSrc(classifier12->getURI().toString())
+            ->setTargetL24Classifier(classifier12->getURI());
+        con6->addGbpSubject("6_subject1")->addGbpRule("6_rule1")
+             ->addGbpRuleToClassifierRSrc(classifier13->getURI().toString())
+             ->setTargetL24Classifier(classifier13->getURI());
+        con6->addGbpSubject("6_subject1")->addGbpRule("6_rule1")
+             ->addGbpRuleToClassifierRSrc(classifier14->getURI().toString())
+            ->setTargetL24Classifier(classifier14->getURI());
+        con6->addGbpSubject("6_subject1")->addGbpRule("6_rule1")
+             ->addGbpRuleToClassifierRSrc(classifier15->getURI().toString())
+             ->setTargetL24Classifier(classifier15->getURI());
+        con6->addGbpSubject("6_subject1")->addGbpRule("6_rule1")
+             ->addGbpRuleToClassifierRSrc(classifier16->getURI().toString())
+             ->setTargetL24Classifier(classifier16->getURI());
+        con6->addGbpSubject("6_subject1")->addGbpRule("6_rule1")
+             ->addGbpRuleToActionRSrcAllowDenyAction(action3->getURI().toString())
+             ->setTargetAllowDenyAction(action3->getURI());
+        con6->addGbpSubject("6_subject1")->addGbpRule("6_rule1")
+             ->addGbpRuleToActionRSrcLogAction(action4->getURI().toString())
+             ->setTargetLogAction(action4->getURI());
+
+        epg0->addGbpEpGroupToProvContractRSrc(con6->getURI().toString());
+        epg1->addGbpEpGroupToConsContractRSrc(con6->getURI().toString());
+   
+        con7 = space->addGbpContract("contract7");
+        con7->addGbpSubject("7_subject1")->addGbpRule("7_rule1")
+             ->setOrder(500)
+             .setDirection(DirectionEnumT::CONST_OUT)
+             .addGbpRuleToClassifierRSrc(classifier11->getURI().toString())
+             ->setTargetL24Classifier(classifier11->getURI());
+        con7->addGbpSubject("7_subject1")->addGbpRule("7_rule1")
+             ->addGbpRuleToClassifierRSrc(classifier15->getURI().toString())
+            ->setTargetL24Classifier(classifier15->getURI());
+        con7->addGbpSubject("7_subject1")->addGbpRule("7_rule1")
+             ->addGbpRuleToClassifierRSrc(classifier16->getURI().toString())
+             ->setTargetL24Classifier(classifier16->getURI());
+        con7->addGbpSubject("7_subject1")->addGbpRule("7_rule1")
+             ->addGbpRuleToActionRSrcAllowDenyAction(action3->getURI().toString())
+             ->setTargetAllowDenyAction(action3->getURI());
+        con7->addGbpSubject("7_subject1")->addGbpRule("7_rule1")
+             ->addGbpRuleToActionRSrcLogAction(action4->getURI().toString())
+             ->setTargetLogAction(action4->getURI());
+
+        epg0->addGbpEpGroupToProvContractRSrc(con7->getURI().toString());
+        epg1->addGbpEpGroupToConsContractRSrc(con7->getURI().toString());
+
+        con8 = space->addGbpContract("contract8");
+        con8->addGbpSubject("8_subject1")->addGbpRule("8_rule1")
+             ->setOrder(600)
+             .setDirection(DirectionEnumT::CONST_IN)
+             .addGbpRuleToClassifierRSrc(classifier11->getURI().toString())
+             ->setTargetL24Classifier(classifier11->getURI());
+        con8->addGbpSubject("8_subject1")->addGbpRule("8_rule1")
+             ->addGbpRuleToClassifierRSrc(classifier15->getURI().toString())
+             ->setTargetL24Classifier(classifier15->getURI());
+        con8->addGbpSubject("8_subject1")->addGbpRule("8_rule1")
+             ->addGbpRuleToClassifierRSrc(classifier16->getURI().toString())
+             ->setTargetL24Classifier(classifier16->getURI());
+        con8->addGbpSubject("8_subject1")->addGbpRule("8_rule1")
+             ->addGbpRuleToClassifierRSrc(classifier18->getURI().toString())
+             ->setTargetL24Classifier(classifier18->getURI());
+        con8->addGbpSubject("8_subject1")->addGbpRule("8_rule1")
+             ->addGbpRuleToActionRSrcAllowDenyAction(action3->getURI().toString())
+             ->setTargetAllowDenyAction(action3->getURI());
+        con8->addGbpSubject("8_subject1")->addGbpRule("8_rule1")
+             ->addGbpRuleToActionRSrcLogAction(action4->getURI().toString())
+            ->setTargetLogAction(action4->getURI());
+        epg2->addGbpEpGroupToProvContractRSrc(con8->getURI().toString());
+        epg3->addGbpEpGroupToConsContractRSrc(con8->getURI().toString());
+
+        con9 = space->addGbpContract("contract9");
+        con9->addGbpSubject("9_subject1")->addGbpRule("9_rule1")
+             ->setOrder(700)
+             .setDirection(DirectionEnumT::CONST_IN)
+             .addGbpRuleToClassifierRSrc(classifier11->getURI().toString())
+             ->setTargetL24Classifier(classifier11->getURI());
+        con9->addGbpSubject("9_subject1")->addGbpRule("9_rule1")
+             ->addGbpRuleToClassifierRSrc(classifier15->getURI().toString())
+             ->setTargetL24Classifier(classifier15->getURI());
+        con9->addGbpSubject("9_subject1")->addGbpRule("9_rule1")
+             ->addGbpRuleToClassifierRSrc(classifier16->getURI().toString())
+             ->setTargetL24Classifier(classifier16->getURI());
+        con9->addGbpSubject("9_subject1")->addGbpRule("9_rule1")
+             ->addGbpRuleToClassifierRSrc(classifier18->getURI().toString())
+             ->setTargetL24Classifier(classifier18->getURI());
+        con9->addGbpSubject("9_subject1")->addGbpRule("9_rule1")
+             ->addGbpRuleToClassifierRSrc(classifier19->getURI().toString())
+             ->setTargetL24Classifier(classifier19->getURI());
+        con9->addGbpSubject("9_subject1")->addGbpRule("9_rule1")
+             ->addGbpRuleToClassifierRSrc(classifier20->getURI().toString())
+             ->setTargetL24Classifier(classifier20->getURI());
+        con9->addGbpSubject("9_subject1")->addGbpRule("9_rule1")
+             ->addGbpRuleToActionRSrcAllowDenyAction(action3->getURI().toString())
+             ->setTargetAllowDenyAction(action3->getURI());
+        con9->addGbpSubject("9_subject1")->addGbpRule("9_rule1")
+             ->addGbpRuleToActionRSrcLogAction(action4->getURI().toString())
+             ->setTargetLogAction(action4->getURI());
+        epg2->addGbpEpGroupToProvContractRSrc(con9->getURI().toString());
+        epg3->addGbpEpGroupToConsContractRSrc(con9->getURI().toString());
+
+
+        con10 = space->addGbpContract("contract10");
+        con10->addGbpSubject("10_subject1")->addGbpRule("10_rule1")
+             ->setOrder(800)
+             .setDirection(DirectionEnumT::CONST_IN)
+             .addGbpRuleToClassifierRSrc(classifier11->getURI().toString())
+             ->setTargetL24Classifier(classifier11->getURI());
+        con10->addGbpSubject("10_subject1")->addGbpRule("10_rule1")
+             ->addGbpRuleToClassifierRSrc(classifier15->getURI().toString())
+             ->setTargetL24Classifier(classifier15->getURI());
+        con10->addGbpSubject("10_subject1")->addGbpRule("10_rule1")
+             ->addGbpRuleToClassifierRSrc(classifier18->getURI().toString())
+             ->setTargetL24Classifier(classifier18->getURI());
+        con10->addGbpSubject("10_subject1")->addGbpRule("10_rule1")
+             ->addGbpRuleToActionRSrcAllowDenyAction(action3->getURI().toString())
+             ->setTargetAllowDenyAction(action3->getURI());
+        con10->addGbpSubject("10_subject1")->addGbpRule("10_rule1")
+             ->addGbpRuleToActionRSrcLogAction(action4->getURI().toString())
+             ->setTargetLogAction(action4->getURI());
+       epg2->addGbpEpGroupToProvContractRSrc(con10->getURI().toString());
+       epg3->addGbpEpGroupToConsContractRSrc(con10->getURI().toString());
 
         mutator.commit();
     }

--- a/agent-ovs/ovs/test/IntFlowManager_test.cpp
+++ b/agent-ovs/ovs/test/IntFlowManager_test.cpp
@@ -173,6 +173,17 @@ public:
     /** Initialize contract 4 flows */
     void initExpCon4();
 
+    void initExpCon5();
+
+    void initExpCon6();
+
+    void initExpCon7();
+   
+    void initExpCon8();
+   
+    void initExpCon9();
+  
+    void initExpCon10();
     /** Initialize subnet-scoped flow entries */
     void initSubnets(PolicyManager::subnet_vector_t& sns,
                      uint32_t bdId = 1, uint32_t rdId = 1);
@@ -917,7 +928,135 @@ BOOST_FIXTURE_TEST_CASE(conn_deny, VxlanIntFlowManagerFixture) {
     WAIT_FOR_TABLES("con4", 500);
 }
 
+BOOST_FIXTURE_TEST_CASE(clsrorder_1, VxlanIntFlowManagerFixture) {
+    setConnected();
+    createPolicyObjects();
 
+    PolicyManager::uri_set_t egs;
+    WAIT_FOR_DO(egs.size() == 1, 1000, egs.clear();
+    policyMgr.getContractProviders(con5->getURI(), egs));
+    egs.clear();
+    WAIT_FOR_DO(egs.size() == 1, 500, egs.clear();
+    policyMgr.getContractConsumers(con5->getURI(), egs));
+    PolicyManager::rule_list_t rules;
+    WAIT_FOR_DO(rules.size() == 4, 500, rules.clear();
+    policyMgr.getContractRules(con5->getURI(), rules));
+
+    /* add con5 */
+    intFlowManager.contractUpdated(con5->getURI());
+    initExpStatic();
+    initExpCon5();
+    WAIT_FOR_TABLES("con5", 500);
+
+}
+
+BOOST_FIXTURE_TEST_CASE(clsrorder_2, VxlanIntFlowManagerFixture) {
+    setConnected();
+    createPolicyObjects();
+
+    PolicyManager::uri_set_t egs;
+    WAIT_FOR_DO(egs.size() == 1, 1000, egs.clear();
+    policyMgr.getContractProviders(con6->getURI(), egs));
+    egs.clear();
+    WAIT_FOR_DO(egs.size() == 1, 500, egs.clear();
+    policyMgr.getContractConsumers(con6->getURI(), egs));
+    PolicyManager::rule_list_t rules;
+    WAIT_FOR_DO(rules.size() == 6, 500, rules.clear();
+    policyMgr.getContractRules(con6->getURI(), rules));
+
+    /* add con6 */
+    intFlowManager.contractUpdated(con6->getURI());
+    initExpStatic();
+    initExpCon6();
+    WAIT_FOR_TABLES("con6", 500);
+}
+
+BOOST_FIXTURE_TEST_CASE(clsrorder_3, VxlanIntFlowManagerFixture) {
+    setConnected();
+   createPolicyObjects();
+
+    PolicyManager::uri_set_t egs;
+    WAIT_FOR_DO(egs.size() == 1, 1000, egs.clear();
+    policyMgr.getContractProviders(con7->getURI(), egs));
+    egs.clear();
+    WAIT_FOR_DO(egs.size() == 1, 500, egs.clear();
+    policyMgr.getContractConsumers(con7->getURI(), egs));
+    PolicyManager::rule_list_t rules;
+    WAIT_FOR_DO(rules.size() == 3, 500, rules.clear();
+    policyMgr.getContractRules(con7->getURI(), rules));
+
+    /* add con7 */
+    intFlowManager.contractUpdated(con7->getURI());
+    initExpStatic();
+    initExpCon7();
+    WAIT_FOR_TABLES("con7", 500);
+}
+
+
+BOOST_FIXTURE_TEST_CASE(clsrorder_4, VxlanIntFlowManagerFixture) {
+    setConnected();
+    createPolicyObjects();
+
+    PolicyManager::uri_set_t egs;
+    WAIT_FOR_DO(egs.size() == 1, 1000, egs.clear();
+    policyMgr.getContractProviders(con8->getURI(), egs));
+    egs.clear();
+    WAIT_FOR_DO(egs.size() == 1, 500, egs.clear();
+    policyMgr.getContractConsumers(con8->getURI(), egs));
+    PolicyManager::rule_list_t rules;
+    WAIT_FOR_DO(rules.size() == 4, 500, rules.clear();
+    policyMgr.getContractRules(con8->getURI(), rules));
+
+     /* add con8 */
+    intFlowManager.contractUpdated(con8->getURI());
+    initExpStatic();
+    initExpCon8();
+    WAIT_FOR_TABLES("con8", 500);
+}
+
+BOOST_FIXTURE_TEST_CASE(clsrorder_5, VxlanIntFlowManagerFixture) {
+    setConnected();
+    createPolicyObjects();
+
+    PolicyManager::uri_set_t egs;
+    WAIT_FOR_DO(egs.size() == 1, 1000, egs.clear();
+    policyMgr.getContractProviders(con9->getURI(), egs));
+    egs.clear();
+    WAIT_FOR_DO(egs.size() == 1, 500, egs.clear();
+    policyMgr.getContractConsumers(con9->getURI(), egs));
+    PolicyManager::rule_list_t rules;
+    WAIT_FOR_DO(rules.size() == 6, 500, rules.clear();
+    policyMgr.getContractRules(con9->getURI(), rules));
+
+    /* add con9 */
+    intFlowManager.contractUpdated(con9->getURI());
+    initExpStatic();
+    initExpCon9();
+    WAIT_FOR_TABLES("con9", 500);
+
+}
+
+BOOST_FIXTURE_TEST_CASE(clsrorder_6, VxlanIntFlowManagerFixture) {
+    setConnected();
+    createPolicyObjects();
+
+    PolicyManager::uri_set_t egs;
+    WAIT_FOR_DO(egs.size() == 1, 1000, egs.clear();
+    policyMgr.getContractProviders(con10->getURI(), egs));
+    egs.clear();
+    WAIT_FOR_DO(egs.size() == 1, 500, egs.clear();
+    policyMgr.getContractConsumers(con10->getURI(), egs));
+    PolicyManager::rule_list_t rules;
+    WAIT_FOR_DO(rules.size() == 3, 500, rules.clear();
+    policyMgr.getContractRules(con10->getURI(), rules));
+
+    /* add con10 */
+    intFlowManager.contractUpdated(con10->getURI());
+    initExpStatic();
+    initExpCon10();
+    WAIT_FOR_TABLES("con10", 500);
+
+}
 void BaseIntFlowManagerFixture::connectTest() {
     exec.ignoredFlowMods.insert(FlowEdit::ADD);
     exec.Expect(FlowEdit::DEL, fe_connect_1);
@@ -2549,6 +2688,267 @@ void BaseIntFlowManagerFixture::initExpCon4() {
                  .cookie(clsr2_cookie).arp()
                  .reg(SEPG, epg0_vnid).reg(DEPG, epg1_vnid)
                  .actions().dropLog(POL, POLICY_DENY, clsr2_cookie).go(EXP_DROPLOG).done());
+
+}
+
+void BaseIntFlowManagerFixture::initExpCon5() {
+    uint32_t epg0_vnid = policyMgr.getVnidForGroup(epg0->getURI()).get();
+    uint32_t epg1_vnid = policyMgr.getVnidForGroup(epg1->getURI()).get();
+    uint16_t prio = PolicyManager::MAX_POLICY_RULE_PRIORITY;
+    PolicyManager::uri_set_t ps, cs;
+
+    const opflex::modb::URI& ruleURI_11 = classifier11->getURI();
+    uint32_t clsr11_cookie = intFlowManager.getId(
+                             classifier11->getClassId(), ruleURI_11);
+    const opflex::modb::URI& ruleURI_12 = classifier12->getURI();
+    uint32_t clsr12_cookie = intFlowManager.getId(
+                             classifier12->getClassId(), ruleURI_12);
+    const opflex::modb::URI& ruleURI_13 = classifier13->getURI();
+    uint32_t clsr13_cookie = intFlowManager.getId(
+                             classifier13->getClassId(), ruleURI_13);
+    const opflex::modb::URI& ruleURI_14 = classifier14->getURI();
+    uint32_t clsr14_cookie = intFlowManager.getId(
+                             classifier14->getClassId(), ruleURI_14);
+
+    ADDF(Bldr(SEND_FLOW_REM).table(POL)
+                 .priority(prio)
+                 .cookie(clsr11_cookie).tcp()
+                 .reg(SEPG, epg1_vnid).reg(DEPG, epg0_vnid)
+                 .actions().dropLog(POL, POLICY_DENY,clsr11_cookie).go(EXP_DROPLOG).done());
+    ADDF(Bldr(SEND_FLOW_REM).table(POL)
+                 .priority(prio-1)
+                 .cookie(clsr12_cookie).tcp()
+                 .reg(SEPG, epg1_vnid).reg(DEPG, epg0_vnid)
+                 .actions().dropLog(POL, POLICY_DENY,clsr12_cookie).go(EXP_DROPLOG).done());
+   ADDF(Bldr(SEND_FLOW_REM).table(POL)
+                 .priority(prio-2)
+                 .cookie(clsr13_cookie).tcp()
+                 .reg(SEPG, epg1_vnid).reg(DEPG, epg0_vnid)
+                 .actions().dropLog(POL, POLICY_DENY,clsr13_cookie).go(EXP_DROPLOG).done());
+   ADDF(Bldr(SEND_FLOW_REM).table(POL)
+                 .priority(prio-3)
+                 .cookie(clsr14_cookie).tcp()
+                 .reg(SEPG, epg1_vnid).reg(DEPG, epg0_vnid)
+                 .actions().dropLog(POL, POLICY_DENY, clsr14_cookie).go(EXP_DROPLOG).done());
+
+}
+
+void BaseIntFlowManagerFixture::initExpCon6() {
+    uint32_t epg0_vnid = policyMgr.getVnidForGroup(epg0->getURI()).get();
+    uint32_t epg1_vnid = policyMgr.getVnidForGroup(epg1->getURI()).get();
+    uint16_t prio = PolicyManager::MAX_POLICY_RULE_PRIORITY;
+    PolicyManager::uri_set_t ps, cs;
+
+    const opflex::modb::URI& ruleURI_11 = classifier11->getURI();
+    uint32_t clsr11_cookie = intFlowManager.getId(
+                             classifier11->getClassId(), ruleURI_11);
+    const opflex::modb::URI& ruleURI_12 = classifier12->getURI();
+    uint32_t clsr12_cookie = intFlowManager.getId(
+                             classifier12->getClassId(), ruleURI_12);
+    const opflex::modb::URI& ruleURI_13 = classifier13->getURI();
+    uint32_t clsr13_cookie = intFlowManager.getId(
+                             classifier13->getClassId(), ruleURI_13);
+    const opflex::modb::URI& ruleURI_14 = classifier14->getURI();
+    uint32_t clsr14_cookie = intFlowManager.getId(
+                             classifier14->getClassId(), ruleURI_14);
+    const opflex::modb::URI& ruleURI_15 = classifier15->getURI();
+    uint32_t clsr15_cookie = intFlowManager.getId(
+                             classifier15->getClassId(), ruleURI_15);
+    const opflex::modb::URI& ruleURI_16 = classifier16->getURI();
+    uint32_t clsr16_cookie = intFlowManager.getId(
+                             classifier16->getClassId(), ruleURI_16);
+
+    ADDF(Bldr(SEND_FLOW_REM).table(POL)
+                 .priority(prio)
+                 .cookie(clsr11_cookie).tcp()
+                 .reg(SEPG, epg0_vnid).reg(DEPG, epg1_vnid)
+                 .actions().dropLog(POL, POLICY_DENY, clsr11_cookie).go(EXP_DROPLOG).done());
+    ADDF(Bldr(SEND_FLOW_REM).table(POL)
+                 .priority(prio-1)
+                 .cookie(clsr12_cookie).tcp()
+                 .reg(SEPG, epg0_vnid).reg(DEPG, epg1_vnid)
+                 .actions().dropLog(POL, POLICY_DENY, clsr12_cookie).go(EXP_DROPLOG).done());
+   ADDF(Bldr(SEND_FLOW_REM).table(POL)
+                 .priority(prio-2)
+                 .cookie(clsr13_cookie).tcp()
+                 .reg(SEPG, epg0_vnid).reg(DEPG, epg1_vnid)
+                 .actions().dropLog(POL, POLICY_DENY, clsr13_cookie).go(EXP_DROPLOG).done());
+   ADDF(Bldr(SEND_FLOW_REM).table(POL)
+                 .priority(prio-3)
+                 .cookie(clsr14_cookie).tcp()
+                 .reg(SEPG, epg0_vnid).reg(DEPG, epg1_vnid)
+                 .actions().dropLog(POL, POLICY_DENY, clsr14_cookie).go(EXP_DROPLOG).done());
+   ADDF(Bldr(SEND_FLOW_REM).table(POL)
+                 .priority(prio-4)
+                 .cookie(clsr16_cookie).tcp()
+                 .reg(SEPG, epg0_vnid).reg(DEPG, epg1_vnid)
+                 .actions().dropLog(POL, POLICY_DENY, clsr16_cookie).go(EXP_DROPLOG).done());
+   ADDF(Bldr(SEND_FLOW_REM).table(POL)
+                 .priority(prio-5)
+                 .cookie(clsr15_cookie).tcp()
+                 .reg(SEPG, epg0_vnid).reg(DEPG, epg1_vnid)
+                 .actions().dropLog(POL, POLICY_DENY, clsr15_cookie).go(EXP_DROPLOG).done());
+
+}
+
+void BaseIntFlowManagerFixture::initExpCon7() {
+    uint32_t epg0_vnid = policyMgr.getVnidForGroup(epg0->getURI()).get();
+    uint32_t epg1_vnid = policyMgr.getVnidForGroup(epg1->getURI()).get();
+    uint16_t prio = PolicyManager::MAX_POLICY_RULE_PRIORITY;
+    PolicyManager::uri_set_t ps, cs;
+
+    const opflex::modb::URI& ruleURI_11 = classifier11->getURI();
+    uint32_t clsr11_cookie = intFlowManager.getId(
+                             classifier11->getClassId(), ruleURI_11);
+    const opflex::modb::URI& ruleURI_15 = classifier15->getURI();
+    uint32_t clsr15_cookie = intFlowManager.getId(
+                             classifier15->getClassId(), ruleURI_15);
+    const opflex::modb::URI& ruleURI_16 = classifier16->getURI();
+    uint32_t clsr16_cookie = intFlowManager.getId(
+                             classifier16->getClassId(), ruleURI_16); 
+    ADDF(Bldr(SEND_FLOW_REM).table(POL)
+                 .priority(prio)
+                 .cookie(clsr11_cookie).tcp()
+                 .reg(SEPG, epg0_vnid).reg(DEPG, epg1_vnid)
+                 .actions().dropLog(POL, POLICY_DENY, clsr11_cookie).go(EXP_DROPLOG).done());
+    ADDF(Bldr(SEND_FLOW_REM).table(POL)
+                 .priority(prio-1)
+                 .cookie(clsr16_cookie).tcp()
+                 .reg(SEPG, epg0_vnid).reg(DEPG, epg1_vnid)
+                 .actions().dropLog(POL, POLICY_DENY, clsr16_cookie).go(EXP_DROPLOG).done());
+   ADDF(Bldr(SEND_FLOW_REM).table(POL)
+                 .priority(prio-2)
+                 .cookie(clsr15_cookie).tcp()
+                 .reg(SEPG, epg0_vnid).reg(DEPG, epg1_vnid)
+                 .actions().dropLog(POL, POLICY_DENY, clsr15_cookie).go(EXP_DROPLOG).done());
+}
+
+void BaseIntFlowManagerFixture::initExpCon8() {
+    uint32_t epg0_vnid = policyMgr.getVnidForGroup(epg2->getURI()).get();
+    uint32_t epg1_vnid = policyMgr.getVnidForGroup(epg3->getURI()).get();
+    uint16_t prio = PolicyManager::MAX_POLICY_RULE_PRIORITY;
+    PolicyManager::uri_set_t ps, cs;
+
+    const opflex::modb::URI& ruleURI_11 = classifier11->getURI();
+    uint32_t clsr11_cookie = intFlowManager.getId(
+                             classifier11->getClassId(), ruleURI_11);
+    const opflex::modb::URI& ruleURI_15 = classifier15->getURI();
+    uint32_t clsr15_cookie = intFlowManager.getId(
+                             classifier15->getClassId(), ruleURI_15);
+    const opflex::modb::URI& ruleURI_16 = classifier16->getURI();
+    uint32_t clsr16_cookie = intFlowManager.getId(
+                             classifier16->getClassId(), ruleURI_16);
+    const opflex::modb::URI& ruleURI_18 = classifier18->getURI();
+    uint32_t clsr18_cookie = intFlowManager.getId(
+                             classifier18->getClassId(), ruleURI_18);
+    ADDF(Bldr(SEND_FLOW_REM).table(POL)
+                 .priority(prio)
+                 .cookie(clsr11_cookie).tcp()
+                 .reg(SEPG, epg1_vnid).reg(DEPG, epg0_vnid)
+                 .actions().dropLog(POL, POLICY_DENY, clsr11_cookie).go(EXP_DROPLOG).done());
+    ADDF(Bldr(SEND_FLOW_REM).table(POL)
+                 .priority(prio-1)
+                 .cookie(clsr16_cookie).tcp()
+                 .reg(SEPG, epg1_vnid).reg(DEPG, epg0_vnid)
+                 .actions().dropLog(POL, POLICY_DENY, clsr16_cookie).go(EXP_DROPLOG).done());
+   ADDF(Bldr(SEND_FLOW_REM).table(POL)
+                 .priority(prio-2)
+                 .cookie(clsr15_cookie).tcp()
+                 .reg(SEPG, epg1_vnid).reg(DEPG, epg0_vnid)
+                 .actions().dropLog(POL, POLICY_DENY, clsr15_cookie).go(EXP_DROPLOG).done());
+   ADDF(Bldr(SEND_FLOW_REM).table(POL)
+                 .priority(prio-3)
+                 .cookie(clsr18_cookie).tcp()
+                 .reg(SEPG, epg1_vnid).reg(DEPG, epg0_vnid)
+                 .actions().dropLog(POL, POLICY_DENY, clsr18_cookie).go(EXP_DROPLOG).done());
+}
+
+void BaseIntFlowManagerFixture::initExpCon9() {
+    uint32_t epg0_vnid = policyMgr.getVnidForGroup(epg2->getURI()).get();
+    uint32_t epg1_vnid = policyMgr.getVnidForGroup(epg3->getURI()).get();
+    uint16_t prio = PolicyManager::MAX_POLICY_RULE_PRIORITY;
+    PolicyManager::uri_set_t ps, cs;
+
+    const opflex::modb::URI& ruleURI_11 = classifier11->getURI();
+    uint32_t clsr11_cookie = intFlowManager.getId(
+                             classifier11->getClassId(), ruleURI_11);
+    const opflex::modb::URI& ruleURI_15 = classifier15->getURI();
+    uint32_t clsr15_cookie = intFlowManager.getId(
+                             classifier15->getClassId(), ruleURI_15);
+    const opflex::modb::URI& ruleURI_16 = classifier16->getURI();
+    uint32_t clsr16_cookie = intFlowManager.getId(
+                             classifier16->getClassId(), ruleURI_16);
+    const opflex::modb::URI& ruleURI_18 = classifier18->getURI();
+    uint32_t clsr18_cookie = intFlowManager.getId(
+                             classifier18->getClassId(), ruleURI_18);
+    const opflex::modb::URI& ruleURI_19 = classifier19->getURI();
+    uint32_t clsr19_cookie = intFlowManager.getId(
+                             classifier19->getClassId(), ruleURI_19);
+    const opflex::modb::URI& ruleURI_20 = classifier20->getURI();
+    uint32_t clsr20_cookie = intFlowManager.getId(
+                             classifier20->getClassId(), ruleURI_20);
+    ADDF(Bldr(SEND_FLOW_REM).table(POL)
+                 .priority(prio)
+                 .cookie(clsr11_cookie).tcp()
+                 .reg(SEPG, epg1_vnid).reg(DEPG, epg0_vnid)
+                 .actions().dropLog(POL, POLICY_DENY, clsr11_cookie).go(EXP_DROPLOG).done());
+    ADDF(Bldr(SEND_FLOW_REM).table(POL)
+                 .priority(prio-1)
+                 .cookie(clsr16_cookie).tcp()
+                 .reg(SEPG, epg1_vnid).reg(DEPG, epg0_vnid)
+                 .actions().dropLog(POL, POLICY_DENY, clsr16_cookie).go(EXP_DROPLOG).done());
+   ADDF(Bldr(SEND_FLOW_REM).table(POL)
+                 .priority(prio-2)
+                 .cookie(clsr15_cookie).tcp()
+                 .reg(SEPG, epg1_vnid).reg(DEPG, epg0_vnid)
+                 .actions().dropLog(POL, POLICY_DENY, clsr15_cookie).go(EXP_DROPLOG).done());
+   ADDF(Bldr(SEND_FLOW_REM).table(POL)
+                 .priority(prio-3)
+                 .cookie(clsr18_cookie).tcp()
+                 .reg(SEPG, epg1_vnid).reg(DEPG, epg0_vnid)
+                 .actions().dropLog(POL, POLICY_DENY, clsr18_cookie).go(EXP_DROPLOG).done());
+  ADDF(Bldr(SEND_FLOW_REM).table(POL)
+                 .priority(prio-4)
+                 .cookie(clsr20_cookie).tcp()
+                 .reg(SEPG, epg1_vnid).reg(DEPG, epg0_vnid)
+                 .actions().dropLog(POL, POLICY_DENY, clsr20_cookie).go(EXP_DROPLOG).done());
+   ADDF(Bldr(SEND_FLOW_REM).table(POL)
+                 .priority(prio-5)
+                 .cookie(clsr19_cookie).tcp()
+                 .reg(SEPG, epg1_vnid).reg(DEPG, epg0_vnid)
+                 .actions().dropLog(POL, POLICY_DENY, clsr19_cookie).go(EXP_DROPLOG).done());
+}
+
+void BaseIntFlowManagerFixture::initExpCon10() {
+    uint32_t epg0_vnid = policyMgr.getVnidForGroup(epg2->getURI()).get();
+    uint32_t epg1_vnid = policyMgr.getVnidForGroup(epg3->getURI()).get();
+    uint16_t prio = PolicyManager::MAX_POLICY_RULE_PRIORITY;
+    PolicyManager::uri_set_t ps, cs;
+
+    const opflex::modb::URI& ruleURI_11 = classifier11->getURI();
+    uint32_t clsr11_cookie = intFlowManager.getId(
+                             classifier11->getClassId(), ruleURI_11);
+    const opflex::modb::URI& ruleURI_15 = classifier15->getURI();
+    uint32_t clsr15_cookie = intFlowManager.getId(
+                             classifier15->getClassId(), ruleURI_15);
+    const opflex::modb::URI& ruleURI_18 = classifier18->getURI();
+    uint32_t clsr18_cookie = intFlowManager.getId(
+                             classifier18->getClassId(), ruleURI_18);
+    ADDF(Bldr(SEND_FLOW_REM).table(POL)
+                 .priority(prio)
+                 .cookie(clsr11_cookie).tcp()
+                 .reg(SEPG, epg1_vnid).reg(DEPG, epg0_vnid)
+                 .actions().dropLog(POL, POLICY_DENY, clsr11_cookie).go(EXP_DROPLOG).done());
+    ADDF(Bldr(SEND_FLOW_REM).table(POL)
+                 .priority(prio-1)
+                 .cookie(clsr15_cookie).tcp()
+                 .reg(SEPG, epg1_vnid).reg(DEPG, epg0_vnid)
+                 .actions().dropLog(POL, POLICY_DENY, clsr15_cookie).go(EXP_DROPLOG).done());
+    ADDF(Bldr(SEND_FLOW_REM).table(POL)
+                 .priority(prio-2)
+                 .cookie(clsr18_cookie).tcp()
+                 .reg(SEPG, epg1_vnid).reg(DEPG, epg0_vnid)
+                 .actions().dropLog(POL, POLICY_DENY, clsr18_cookie).go(EXP_DROPLOG).done());
 
 }
 // Initialize flows related to IP address mapping/NAT


### PR DESCRIPTION
First commit has the model changes for ordering the classifiers within a rule. The priorities are assigned to the classifiers with reference to leaf side expectations. If any corner cases are not covered, let me know.

