### PR TITLE
Bypass secgrp when backend reaches its service

### DIFF
--- a/agent-ovs/lib/FSEndpointSource.cpp
+++ b/agent-ovs/lib/FSEndpointSource.cpp
@@ -63,6 +63,7 @@ void FSEndpointSource::updated(const fs::path& filePath) {
     static const std::string EP_MAC("mac");
     static const std::string EP_IP("ip");
     static const std::string EP_ANYCAST_RETURN_IP("anycast-return-ip");
+    static const std::string EP_SERVICE_IP("service-ip");
     static const std::string EP_VIRTUAL_IP("virtual-ip");
     static const std::string EP_GROUP("endpoint-group");
     static const std::string POLICY_SPACE_NAME("policy-space-name");
@@ -143,6 +144,12 @@ void FSEndpointSource::updated(const fs::path& filePath) {
         if (anycastReturnIps) {
             for (const ptree::value_type &v : anycastReturnIps.get())
                 newep.addAnycastReturnIP(v.second.data());
+        }
+        optional<ptree&> serviceIps =
+            properties.get_child_optional(EP_SERVICE_IP);
+        if (serviceIps) {
+            for (const ptree::value_type &v : serviceIps.get())
+                newep.addServiceIP(v.second.data());
         }
         optional<ptree&> virtualIps =
             properties.get_child_optional(EP_VIRTUAL_IP);

--- a/agent-ovs/lib/include/opflexagent/Endpoint.h
+++ b/agent-ovs/lib/include/opflexagent/Endpoint.h
@@ -196,6 +196,24 @@ public:
     }
 
     /**
+     * Get the list of Service IPs this endpoint is backend for
+     *
+     * @return the list of IP addresses
+     */
+    const std::unordered_set<std::string>& getServiceIPs() const {
+        return serviceIps;
+    }
+
+    /**
+     * Associate this endpoint with a Service IP
+     *
+     * @param ip the IP address to add
+     */
+    void addServiceIP(const std::string& ip) {
+        this->serviceIps.insert(ip);
+    }
+
+    /**
      * A MAC/IP address pair representing a virtual IP that can be
      * claimed by the endpoint by sending a gratuitous ARP.
      */
@@ -1310,6 +1328,7 @@ private:
     boost::optional<opflex::modb::MAC> mac;
     std::unordered_set<std::string> ips;
     std::unordered_set<std::string> anycastReturnIps;
+    std::unordered_set<std::string> serviceIps;
     virt_ip_set virtualIps;
     boost::optional<std::string> egMappingAlias;
     boost::optional<opflex::modb::URI> egURI;

--- a/agent-ovs/ovs/include/AccessFlowManager.h
+++ b/agent-ovs/ovs/include/AccessFlowManager.h
@@ -128,6 +128,11 @@ public:
          */
         DROP_LOG_TABLE_ID,
         /**
+         * bypass loopback flows from service backends to service
+         * from security group checks
+         */
+        SERVICE_BYPASS_TABLE_ID,
+        /**
          * Map packets to a security group and set their destination
          * port after applying policy
          */

--- a/agent-ovs/ovs/test/AccessFlowManager_test.cpp
+++ b/agent-ovs/ovs/test/AccessFlowManager_test.cpp
@@ -230,7 +230,7 @@ BOOST_FIXTURE_TEST_CASE(learningBridge, AccessFlowManagerFixture) {
 
 #define ADDF(flow) addExpFlowEntry(expTables, flow)
 enum TABLE {
-    DROP_LOG=0, GRP = 1, IN_POL = 2, OUT_POL = 3, OUT = 4, EXP_DROP=5
+    DROP_LOG=0, SVC_BYPASS = 1, GRP = 2, IN_POL = 3, OUT_POL = 4, OUT = 5, EXP_DROP=6
 };
 
 enum CaptureReason {
@@ -492,8 +492,10 @@ void AccessFlowManagerFixture::initExpStatic() {
     ADDF(Bldr().table(IN_POL).priority(PolicyManager::MAX_POLICY_RULE_PRIORITY)
          .reg(SEPG, 1).actions().go(OUT).done());
     ADDF(Bldr().table(DROP_LOG).priority(0)
+            .actions().go(SVC_BYPASS).done());
+    ADDF(Bldr().table(SVC_BYPASS).priority(1)
             .actions().go(GRP).done());
-    for(int i=GRP; i<=OUT; i++) {
+    for(int i=SVC_BYPASS; i<=OUT; i++) {
         ADDF(Bldr().table(i).priority(0)
         .cookie(ovs_ntohll(opflexagent::flow::cookie::TABLE_DROP_FLOW))
         .flags(OFPUTIL_FF_SEND_FLOW_REM).priority(0)
@@ -708,11 +710,11 @@ uint16_t AccessFlowManagerFixture::initExpSecGrp2(uint32_t setId) {
          .actions().go(OUT).done());
     ADDF(Bldr(SEND_FLOW_REM).table(IN_POL).priority(prio - 128)
          .isCtState("-trk").tcp().reg(SEPG, setId)
-         .actions().ct("table=1,zone=NXM_NX_REG6[0..15]").done());
+         .actions().ct("table=2,zone=NXM_NX_REG6[0..15]").done());
     ADDF(Bldr(SEND_FLOW_REM).table(OUT_POL).priority(prio - 128).cookie(ruleId)
          .isCtState("-trk")
          .tcp().reg(SEPG, setId).isTpDst(22)
-         .actions().ct("table=1,zone=NXM_NX_REG6[0..15]").done());
+         .actions().ct("table=2,zone=NXM_NX_REG6[0..15]").done());
     ADDF(Bldr(SEND_FLOW_REM).table(OUT_POL).priority(prio - 128).cookie(ruleId)
          .isCtState("+est+trk")
          .tcp().reg(SEPG, setId).isTpDst(22)


### PR DESCRIPTION
- Connection tracking in security groups will drop the mirrored
  ingress packet unless ingress rules are configured and its non
  intuitive to add ingress allow for just this case.
- Bypass done via a separate table right after drop log table=0
  whenever the src and dst pairs match service ip and its backend ip
- This is done so that later conntrack code can skip this table
  when recirculating and secondly we only need to populate output
  register for this case.
- In order to avoid the complexity of subscribing to service updates
  and the ordering of svc and ep updates a new section is added
  to the EP file "service-ip" an array of services the ep is
  a backend to.
- We use these ips to populate the flows with a uuid of the ep
  that will change as the ep file changes.
- Host agent will populate this section when an ep is a backend
  to a service

New flows for this bypass table look like this:

 cookie=0x0, duration=237.465s, table=1, n_packets=23, n_bytes=2652, priority=10,ip,in_port="pa-vethd3b789d9",nw_src=10.100.25.118,nw_dst=11.3.56.67 actions=load:0x5->NXM_NX_REG7[],goto_table:5
 cookie=0x0, duration=237.464s, table=1, n_packets=23, n_bytes=2652, priority=10,ip,in_port=vethd3b789d9,nw_src=11.3.56.67,nw_dst=10.100.25.118 actions=load:0x3->NXM_NX_REG7[],goto_table:5
 cookie=0x0, duration=509.304s, table=1, n_packets=155, n_bytes=15895, priority=1 actions=goto_table:2
 cookie=0x4000000000000000, duration=509.304s, table=1, n_packets=0, n_bytes=0, send_flow_rem priority=0 actions=move:NXM_NX_REG0[]->NXM_NX_TUN_METADATA0[0..31],move:NXM_NX_REG1[]->NXM_NX_TUN_METADATA1[0..31],move:NXM_NX_REG2[]->NXM_NX_TUN_METADATA2[0..31],move:NXM_NX_REG3[]->NXM_NX_TUN_METADATA3[0..31],move:NXM_NX_REG4[]->NXM_NX_TUN_METADATA4[0..31],move:NXM_NX_REG5[]->NXM_NX_TUN_METADATA5[0..31],move:NXM_NX_REG6[]->NXM_NX_TUN_METADATA6[0..31],move:NXM_NX_REG7[]->NXM_NX_TUN_METADATA7[0..31],move:NXM_NX_CT_STATE[]->NXM_NX_TUN_METADATA8[0..31],move:NXM_NX_CT_ZONE[]->NXM_NX_TUN_METADATA9[0..15],move:NXM_NX_CT_MARK[]->NXM_NX_TUN_METADATA10[0..31],move:NXM_NX_CT_LABEL[]->NXM_NX_TUN_METADATA11[0..127],set_field:0x1->tun_metadata12,set_field:0->tun_metadata13,goto_table:6

Signed-off-by: Madhu Challa <challa@gmail.com>