### PR TITLE
Delete Qos and queue entry from ovsdb.

### DIFF
--- a/agent-ovs/ovs/OvsdbConnection.cpp
+++ b/agent-ovs/ovs/OvsdbConnection.cpp
@@ -173,7 +173,6 @@ void populateValues(const Value& value, string& type, map<string, string>& value
                                         mapMemberItr->GetArray()[1].IsArray() &&
                                         mapMemberItr->GetArray()[1].GetArray().Size() == 2) {
                                     uint64_t keyInt = mapMemberItr->GetArray()[0].GetUint64();
-                                    std::string key = mapMemberItr->GetArray()[1].GetArray()[0].GetString();
                                     std::string val = mapMemberItr->GetArray()[1].GetArray()[1].GetString();
                                     values[std::to_string(keyInt)] = val;
                                 }

--- a/agent-ovs/ovs/QosRenderer.cpp
+++ b/agent-ovs/ovs/QosRenderer.cpp
@@ -242,6 +242,32 @@ namespace opflexagent {
     }
 
     void QosRenderer::deleteIngressQos(const string& interface) {
+        string qosUuid;
+        conn->getOvsdbState().getQosUuidForPort(interface, qosUuid);
+
+        if (!qosUuid.empty()) {
+            LOG(INFO) << "found qos-uuid: "<< qosUuid;
+            OvsdbTransactMessage msg0(OvsdbOperation::DELETE, OvsdbTable::QOS);
+            set<tuple<string, OvsdbFunction, string>> conditionSet0;
+            conditionSet0.emplace("_uuid", OvsdbFunction::EQ, qosUuid);
+            msg0.conditions = conditionSet0;
+            const list<OvsdbTransactMessage> qosDelRequest = {msg0};
+            sendAsyncTransactRequests(qosDelRequest);
+        }
+
+        string queueUuid;
+        conn->getOvsdbState().getQueueUuidForQos(qosUuid, queueUuid);
+
+        if (!queueUuid.empty()) {
+            LOG(INFO) << "found queue-uuid: " << queueUuid;
+            OvsdbTransactMessage msg2(OvsdbOperation::DELETE, OvsdbTable::QUEUE);
+            set<tuple<string, OvsdbFunction, string>> conditionSet2;
+            conditionSet2.emplace("_uuid", OvsdbFunction::EQ, queueUuid);
+            msg2.conditions = conditionSet2;
+            const list<OvsdbTransactMessage> queueDelRequest = {msg2};
+            sendAsyncTransactRequests(queueDelRequest);
+        }
+
         OvsdbTransactMessage msg1(OvsdbOperation::UPDATE, OvsdbTable::PORT);
         vector<OvsdbValue> values;
         OvsdbValues emptySet("set", values);

--- a/agent-ovs/ovs/include/OvsdbState.h
+++ b/agent-ovs/ovs/include/OvsdbState.h
@@ -135,6 +135,37 @@ public:
         }
     }
 
+    void getQosUuidForPort(const string& name, string& uuid) {
+        unique_lock<mutex> lock(stateMutex);
+        auto& portRows = ovsdbState[OvsdbTable::PORT];
+        for (auto& row : portRows) {
+            if (row.second.find("name") != row.second.end() &&
+                row.second.find("qos") != row.second.end() &&
+                row.second["name"].getStringValue() == name) {
+                const auto& col = row.second["qos"].getCollectionValue();
+                for(auto it = col.begin(); it!=col.end();it++){
+                    uuid = it->first;
+                }
+            }
+        }
+    }
+
+    void getQueueUuidForQos(const string& qos, string &uuid) {
+        unique_lock<mutex> lock(stateMutex);
+        auto& qosRows = ovsdbState[OvsdbTable::QOS];
+        for (auto& row : qosRows) {
+             if (row.second.find("uuid") != row.second.end() &&
+                 row.second["uuid"].getStringValue() == qos &&
+                 row.second.find("queues") != row.second.end())  {
+                 const auto& col = row.second["queues"].getCollectionValue();
+                 for(auto it = col.begin(); it != col.end(); it++) {
+                     LOG(DEBUG) << "queue: " << it->first << "=" << it->second;
+                     uuid = it->second;
+                 }
+             }
+        }
+    }
+
     /**
      * Get the mirror state
      * @param name mirror name

--- a/agent-ovs/ovs/test/QosRenderer_test.cpp
+++ b/agent-ovs/ovs/test/QosRenderer_test.cpp
@@ -39,10 +39,28 @@ public:
         tableDetails["intf1"] = rowDetails;
         conn->getOvsdbState().fullUpdate(OvsdbTable::INTERFACE, tableDetails);
 
+        OvsdbTableDetails qosTableDetails;
+        OvsdbRowDetails qosRowDetails;
+        uuid = "f53499ff-0f9f-4f05-9e21-e15738bc7149";
+        qosRowDetails["uuid"] = OvsdbValue(uuid);
+        std::map<std::string, std::string> queueMap;
+        queueMap.insert(make_pair("0", "7e35b63f-227b-4c96-b01b-9bd0c0562852"));
+        qosRowDetails["queues"] = OvsdbValue(Dtype::MAP, "map", queueMap);
+        qosTableDetails[uuid] = qosRowDetails;
+        conn->getOvsdbState().fullUpdate(OvsdbTable::QOS, qosTableDetails);
+
+        OvsdbTableDetails portTableDetails;
+        OvsdbRowDetails portRowDetails;
         uuid = "34a18e6b-8748-430c-bf7b-b4c7220b36c0";
-        rowDetails["uuid"] = OvsdbValue(uuid);
-        tableDetails["intf1"] = rowDetails;
-        conn->getOvsdbState().fullUpdate(OvsdbTable::PORT, tableDetails);
+        portRowDetails["uuid"] = OvsdbValue(uuid);
+        std::map<std::string, std::string> qosMap;
+        qosMap["f53499ff-0f9f-4f05-9e21-e15738bc7149"] = "";
+        portRowDetails["qos"] = OvsdbValue(Dtype::MAP, "map", qosMap);
+        const string portName ("intf1");
+        portRowDetails["name"] = OvsdbValue(portName);
+        portTableDetails[uuid] = portRowDetails;
+
+        conn->getOvsdbState().fullUpdate(OvsdbTable::PORT, portTableDetails);
     }
 
     virtual ~QosRendererFixture() {
@@ -53,18 +71,32 @@ public:
     unique_ptr<OvsdbConnection> conn;
 };
 
-bool verifyCreateDestroy(Agent& agent, const shared_ptr<QosRenderer>& qosRenderer) {
-    qosRenderer->updateEgressQosParams("intf1", 3000, 300);
-    qosRenderer->deleteEgressQos("intf1");
+bool verifyCreateDestroy(const shared_ptr<QosRenderer>& qosRenderer, unique_ptr<OvsdbConnection>& conn) {
+    string interface("intf1");
+    qosRenderer->updateEgressQosParams(interface, 3000, 300);
+    qosRenderer->deleteEgressQos(interface);
 
-    qosRenderer->updateIngressQosParams("intf1", 4000, 400);
+    qosRenderer->updateIngressQosParams(interface, 4000, 400);
+    string qosUuid;
+    conn->getOvsdbState().getQosUuidForPort(interface, qosUuid);
+    if (qosUuid.empty()) {
+        LOG(WARNING) << "Could not find qos for interface.";
+        return false;
+    }
+
+    string queueUuid;
+    conn->getOvsdbState().getQueueUuidForQos(qosUuid, queueUuid);
+    if (queueUuid.empty()) {
+        LOG(WARNING) << "Could not find queue for qos.";
+        return false;
+    }
+
     qosRenderer->deleteIngressQos("intf1");
-
     return true;
 }
 
 BOOST_FIXTURE_TEST_CASE( verify_createdestroy, QosRendererFixture ) {
-    BOOST_CHECK_EQUAL(true, verifyCreateDestroy(agent, qosRenderer));
+    BOOST_CHECK_EQUAL(true, verifyCreateDestroy(qosRenderer, conn));
 }
 BOOST_AUTO_TEST_SUITE_END()
 


### PR DESCRIPTION
Unreferenced  QoS and Queue records are not automatically destroyed. This change set takes care of deleting existing  qos/queue entry before creating new records.
Reference: http://www.openvswitch.org//support/dist-docs/ovs-vsctl.8.txt
