### PR TITLE
Changes to move svc stats to a low prio thread

### DIFF
--- a/agent-ovs/lib/FSEndpointSource.cpp
+++ b/agent-ovs/lib/FSEndpointSource.cpp
@@ -213,20 +213,18 @@ void FSEndpointSource::updated(const fs::path& filePath) {
         optional<ptree&> qosPol =
             properties.get_child_optional(QOS_POLICY);
         if (qosPol){
-            for (const ptree::value_type &v : qosPol.get()) {
-                optional<string> qosPolicySpace =
-                    v.second.get_optional<string>(SEC_GROUP_POLICY_SPACE);
-                optional<string> qosPolicyName =
-                    v.second.get_optional<string>(SEC_GROUP_NAME);
-                if (qosPolicyName && qosPolicySpace) {
-                    newep.setQosPolicy(opflex::modb::URIBuilder()
-                            .addElement("PolicyUniverse")
-                            .addElement("PolicySpace")
-                            .addElement(qosPolicySpace.get())
-                            .addElement("QosRequirement")
-                            .addElement(qosPolicyName.get())
-                            .build());
-                }
+            optional<string> qosPolicySpace =
+                qosPol.get().get_optional<string>(SEC_GROUP_POLICY_SPACE);
+            optional<string> qosPolicyName =
+                qosPol.get().get_optional<string>(SEC_GROUP_NAME);
+            if (qosPolicyName && qosPolicySpace) {
+                newep.setQosPolicy(opflex::modb::URIBuilder()
+                        .addElement("PolicyUniverse")
+                        .addElement("PolicySpace")
+                        .addElement(qosPolicySpace.get())
+                        .addElement("QosRequirement")
+                        .addElement(qosPolicyName.get())
+                        .build());
             }
         }
 

--- a/agent-ovs/lib/FSEndpointSource.cpp
+++ b/agent-ovs/lib/FSEndpointSource.cpp
@@ -116,6 +116,7 @@ void FSEndpointSource::updated(const fs::path& filePath) {
     static const std::string SNAT_UUIDS("snat-uuids");
     static const std::string ACTIVE_ACTIVE_AAP("active-active-aap");
     static const std::string EP_DISABLE_ADV("disable-adv");
+    static const std::string EP_ACCESS_ALLOW_UNTAGGED("access-allow-untagged");
 
     static const std::string NEUTRON_NW("neutron-network");
 
@@ -473,6 +474,11 @@ void FSEndpointSource::updated(const fs::path& filePath) {
             properties.get_optional<bool>(EP_DISABLE_ADV);
         if (disableAdv)
             newep.setDisableAdv(disableAdv.get());
+
+        optional<bool> accessAllowUntagged =
+            properties.get_optional<bool>(EP_ACCESS_ALLOW_UNTAGGED);
+        if (accessAllowUntagged)
+            newep.setAccessAllowUntagged(accessAllowUntagged.get());
 
         optional<bool> provider_vlan =
                 properties.get_optional<bool>(EP_PROVIDER_VLAN_FLAG);

--- a/agent-ovs/lib/FSEndpointSource.cpp
+++ b/agent-ovs/lib/FSEndpointSource.cpp
@@ -63,6 +63,7 @@ void FSEndpointSource::updated(const fs::path& filePath) {
     static const std::string EP_MAC("mac");
     static const std::string EP_IP("ip");
     static const std::string EP_ANYCAST_RETURN_IP("anycast-return-ip");
+    static const std::string EP_SERVICE_IP("service-ip");
     static const std::string EP_VIRTUAL_IP("virtual-ip");
     static const std::string EP_GROUP("endpoint-group");
     static const std::string POLICY_SPACE_NAME("policy-space-name");
@@ -143,6 +144,12 @@ void FSEndpointSource::updated(const fs::path& filePath) {
         if (anycastReturnIps) {
             for (const ptree::value_type &v : anycastReturnIps.get())
                 newep.addAnycastReturnIP(v.second.data());
+        }
+        optional<ptree&> serviceIps =
+            properties.get_child_optional(EP_SERVICE_IP);
+        if (serviceIps) {
+            for (const ptree::value_type &v : serviceIps.get())
+                newep.addServiceIP(v.second.data());
         }
         optional<ptree&> virtualIps =
             properties.get_child_optional(EP_VIRTUAL_IP);

--- a/agent-ovs/lib/FSExternalEndpointSource.cpp
+++ b/agent-ovs/lib/FSExternalEndpointSource.cpp
@@ -90,6 +90,7 @@ void FSExternalEndpointSource::updated(const fs::path& filePath) {
     static const std::string DHCP_T2("t2");
     static const std::string DHCP_PREFERRED_LIFETIME("preferred-lifetime");
     static const std::string DHCP_VALID_LIFETIME("valid-lifetime");
+    static const std::string EP_ACCESS_ALLOW_UNTAGGED("access-allow-untagged");
 
     try {
         using boost::property_tree::ptree;
@@ -301,6 +302,11 @@ void FSExternalEndpointSource::updated(const fs::path& filePath) {
 
             newep.setDHCPv6Config(c);
         }
+
+        optional<bool> accessAllowUntagged =
+            properties.get_optional<bool>(EP_ACCESS_ALLOW_UNTAGGED);
+        if (accessAllowUntagged)
+            newep.setAccessAllowUntagged(accessAllowUntagged.get());
 
         ep_map_t::const_iterator it = knownEps.find(pathstr);
         if (it != knownEps.end()) {

--- a/agent-ovs/lib/include/opflexagent/Endpoint.h
+++ b/agent-ovs/lib/include/opflexagent/Endpoint.h
@@ -38,7 +38,8 @@ public:
      * Default constructor for containers
      */
     Endpoint() : promiscuousMode(false), discoveryProxyMode(false), natMode(false),
-                 external(false), aapModeAA(false), disableAdv(false), extEncap(0) {
+                 external(false), aapModeAA(false), disableAdv(false),
+                 accessAllowUntagged(false), extEncap(0) {
 #ifdef HAVE_PROMETHEUS_SUPPORT
         annotateEpName = false;
         attr_hash = 0;
@@ -54,7 +55,8 @@ public:
      */
     explicit Endpoint(const std::string& uuid_)
         : uuid(uuid_), promiscuousMode(false), discoveryProxyMode(false), natMode(false),
-          external(false), aapModeAA(false), disableAdv(false), extEncap(0) {
+          external(false), aapModeAA(false), disableAdv(false),
+          accessAllowUntagged(false), extEncap(0) {
 #ifdef HAVE_PROMETHEUS_SUPPORT
         annotateEpName = false;
         attr_hash = 0;
@@ -483,6 +485,28 @@ public:
     */
     bool isDisableAdv() const {
         return disableAdv;
+    }
+
+    /**
+      * Set if access vlan should also allow untagged
+      * traffic like Openshift bootstrap use case
+      *
+      * @param accessAllowUntagged the new value of
+      * accessAllowUntagged flag
+      */
+    void setAccessAllowUntagged(bool accessAllowUntagged) {
+        this->accessAllowUntagged = accessAllowUntagged;
+    }
+
+    /**
+      * Get the current value of accessAllowUntagged flag
+      * for this endpoint
+      *
+      * @return true if untagged traffic should also be allowed
+      * else return false
+      */
+    bool isAccessAllowUntagged() const {
+        return accessAllowUntagged;
     }
 
     /**
@@ -1306,6 +1330,7 @@ private:
     bool external;
     bool aapModeAA;
     bool disableAdv;
+    bool accessAllowUntagged;
     attr_map_t attributes;
 #ifdef HAVE_PROMETHEUS_SUPPORT
     bool annotateEpName;

--- a/agent-ovs/lib/include/opflexagent/Endpoint.h
+++ b/agent-ovs/lib/include/opflexagent/Endpoint.h
@@ -196,6 +196,24 @@ public:
     }
 
     /**
+     * Get the list of Service IPs this endpoint is backend for
+     *
+     * @return the list of IP addresses
+     */
+    const std::unordered_set<std::string>& getServiceIPs() const {
+        return serviceIps;
+    }
+
+    /**
+     * Associate this endpoint with a Service IP
+     *
+     * @param ip the IP address to add
+     */
+    void addServiceIP(const std::string& ip) {
+        this->serviceIps.insert(ip);
+    }
+
+    /**
      * A MAC/IP address pair representing a virtual IP that can be
      * claimed by the endpoint by sending a gratuitous ARP.
      */
@@ -1310,6 +1328,7 @@ private:
     boost::optional<opflex::modb::MAC> mac;
     std::unordered_set<std::string> ips;
     std::unordered_set<std::string> anycastReturnIps;
+    std::unordered_set<std::string> serviceIps;
     virt_ip_set virtualIps;
     boost::optional<std::string> egMappingAlias;
     boost::optional<opflex::modb::URI> egURI;

--- a/agent-ovs/lib/test/EndpointManager_test.cpp
+++ b/agent-ovs/lib/test/EndpointManager_test.cpp
@@ -596,9 +596,8 @@ BOOST_FIXTURE_TEST_CASE( fssource, FSEndpointFixture ) {
        << "\"attributes\":{"
        << "\"attr1\":\"value1\",\"attr2\":\"value2\""
        << "},"
-       <<"\"qos-policy\":["
+       <<"\"qos-policy\":"
        <<"{\"policy-space\":\"sg1-space1\",\"name\":\"bw-limiter\"}"
-       <<"]"
        << "}" << std::endl;
     os.close();
 
@@ -752,9 +751,8 @@ BOOST_FIXTURE_TEST_CASE( fssource, FSEndpointFixture ) {
        << "\"security-group\":["
        << "{\"policy-space\":\"sg1-space1\",\"name\":\"sg1\"}"
        << "],"
-       << "\"qos-policy\":["
-       << "{\"policy-space\":\"sg1-space1\",\"name\":\"bw-limiter\"}"
-       << "],"
+       << "\"qos-policy\":"
+       << "{\"policy-space\":\"sg1-space1\",\"name\":\"bw-limiter\"},"
        << "\"attributes\":{"
        << "\"vm-name\":\"acc-veth0\""
        << "}"

--- a/agent-ovs/lib/test/QosManager_test.cpp
+++ b/agent-ovs/lib/test/QosManager_test.cpp
@@ -221,9 +221,8 @@ BOOST_FIXTURE_TEST_CASE( verify_artifacts, QosFixture ) {
         << "\"attributes\":{"
         << "\"attr1\":\"value1\",\"attr2\":\"value2\""
         << "},"
-        <<"\"qos-policy\":["
+        <<"\"qos-policy\":"
         <<"{\"policy-space\":\"test\",\"name\":\"req1\"}"
-        <<"]"
         << "}" << std::endl;
     os.close();
 

--- a/agent-ovs/ovs/AccessFlowManager.cpp
+++ b/agent-ovs/ovs/AccessFlowManager.cpp
@@ -180,11 +180,18 @@ static FlowEntryPtr flowEmptySecGroup(uint32_t emptySecGrpSetId) {
     return noSecGrp.build();
 }
 
-static void flowBypassDhcpRequest(FlowEntryList& el, bool v4, uint32_t inport,
+static uint64_t getPushVlanMeta(std::shared_ptr<const Endpoint>& ep) {
+    return ep->isAccessAllowUntagged() ?
+        flow::meta::access_out::UNTAGGED_AND_PUSH_VLAN :
+        flow::meta::access_out::PUSH_VLAN;
+}
+
+static void flowBypassDhcpRequest(FlowEntryList& el, bool v4,
+                                  bool skip_pop_vlan, uint32_t inport,
                                   uint32_t outport,
                                   std::shared_ptr<const Endpoint>& ep ) {
     FlowBuilder fb;
-    if (ep->getAccessIfaceVlan()) {
+    if (ep->getAccessIfaceVlan() && !skip_pop_vlan) {
         fb.priority(201).inPort(inport);
     } else {
         fb.priority(200).inPort(inport);
@@ -193,11 +200,14 @@ static void flowBypassDhcpRequest(FlowEntryList& el, bool v4, uint32_t inport,
     flowutils::match_dhcp_req(fb, v4);
     fb.action().reg(MFF_REG7, outport);
 
-    if (ep->getAccessIfaceVlan()) {
+    if (ep->getAccessIfaceVlan() && !skip_pop_vlan) {
         fb.vlan(ep->getAccessIfaceVlan().get());
         fb.action().metadata(flow::meta::access_out::POP_VLAN,
                              flow::meta::out::MASK);
     }
+
+    if (skip_pop_vlan)
+        fb.tci(0, 0x1fff);
 
     fb.action().go(AccessFlowManager::OUT_TABLE_ID);
     fb.build(el);
@@ -205,10 +215,11 @@ static void flowBypassDhcpRequest(FlowEntryList& el, bool v4, uint32_t inport,
 
 static void flowBypassFloatingIP(FlowEntryList& el, uint32_t inport,
                                  uint32_t outport, bool in,
+                                 bool skip_pop_vlan,
                                  address& floatingIp,
                                  std::shared_ptr<const Endpoint>& ep ) {
     FlowBuilder fb;
-    if (ep->getAccessIfaceVlan()) {
+    if (ep->getAccessIfaceVlan() && !skip_pop_vlan) {
         fb.priority(201).inPort(inport);
     } else {
         fb.priority(200).inPort(inport);
@@ -227,12 +238,11 @@ static void flowBypassFloatingIP(FlowEntryList& el, uint32_t inport,
     }
 
     fb.action().reg(MFF_REG7, outport);
-    if (ep->getAccessIfaceVlan()) {
+    if (ep->getAccessIfaceVlan() && !skip_pop_vlan) {
         if (in) {
             fb.action()
                 .reg(MFF_REG5, ep->getAccessIfaceVlan().get())
-                .metadata(flow::meta::access_out::PUSH_VLAN,
-                          flow::meta::out::MASK);
+                .metadata(getPushVlanMeta(ep), flow::meta::out::MASK);
         } else {
             fb.vlan(ep->getAccessIfaceVlan().get());
             fb.action()
@@ -240,6 +250,9 @@ static void flowBypassFloatingIP(FlowEntryList& el, uint32_t inport,
                           flow::meta::out::MASK);
         }
     }
+
+    if (skip_pop_vlan && !in)
+        fb.tci(0, 0x1fff);
 
     fb.action().go(AccessFlowManager::OUT_TABLE_ID);
     fb.build(el);
@@ -262,6 +275,22 @@ void AccessFlowManager::createStaticFlows() {
             .metadata(flow::meta::access_out::PUSH_VLAN,
                       flow::meta::out::MASK)
             .action()
+            .pushVlan().regMove(MFF_REG5, MFF_VLAN_VID).outputReg(MFF_REG7)
+            .parent().build(outFlows);
+        /*
+         * The packet is replicated for a specical case of
+         * Openshift bootstrap that does not use vlan 4094
+         * This is ugly but they do not have iproute2/tc
+         * installed to do this in a cleaner way
+         * This duplication only happens when endpoint
+         * file has "access-interface-vlan" attr
+         */
+        FlowBuilder()
+            .priority(1)
+            .metadata(flow::meta::access_out::UNTAGGED_AND_PUSH_VLAN,
+                      flow::meta::out::MASK)
+            .action()
+            .outputReg(MFF_REG7)
             .pushVlan().regMove(MFF_REG5, MFF_VLAN_VID).outputReg(MFF_REG7)
             .parent().build(outFlows);
         outFlows.push_back(flowutils::default_out_flow());
@@ -385,16 +414,47 @@ void AccessFlowManager::handleEndpointUpdate(const string& uuid) {
         }
 
         /*
+         * We allow without tags to handle Openshift bootstrap
+         */
+        if (ep->isAccessAllowUntagged() && ep->getAccessIfaceVlan()) {
+            FlowBuilder inSkipVlan;
+
+            inSkipVlan.priority(99).inPort(accessPort)
+                      .tci(0, 0x1fff);
+            if (zoneId != static_cast<uint16_t>(-1))
+                inSkipVlan.action()
+                    .reg(MFF_REG6, zoneId);
+
+            inSkipVlan.action()
+                .reg(MFF_REG0, secGrpSetId)
+                .reg(MFF_REG7, uplinkPort)
+                .go(SEC_GROUP_OUT_TABLE_ID);
+            inSkipVlan.build(el);
+        }
+
+        /*
          * Allow DHCP request to bypass the access bridge policy when
          * virtual DHCP is enabled.
+         * We allow both with / without tags to handle Openshift
+         * bootstrap
          */
         optional<Endpoint::DHCPv4Config> v4c = ep->getDHCPv4Config();
-        if (v4c)
-            flowBypassDhcpRequest(el, true, accessPort, uplinkPort, ep);
+        if (v4c) {
+            flowBypassDhcpRequest(el, true, false, accessPort,
+                                  uplinkPort, ep);
+            if (ep->isAccessAllowUntagged() && ep->getAccessIfaceVlan())
+                flowBypassDhcpRequest(el, true, true, accessPort,
+                                      uplinkPort, ep);
+        }
 
         optional<Endpoint::DHCPv6Config> v6c = ep->getDHCPv6Config();
-        if(v6c)
-            flowBypassDhcpRequest(el, false, accessPort, uplinkPort, ep);
+        if(v6c) {
+            flowBypassDhcpRequest(el, false, false, accessPort,
+                                  uplinkPort, ep);
+            if (ep->isAccessAllowUntagged() && ep->getAccessIfaceVlan())
+                flowBypassDhcpRequest(el, false, true, accessPort,
+                                      uplinkPort, ep);
+        }
 
         {
             FlowBuilder out;
@@ -409,8 +469,7 @@ void AccessFlowManager::handleEndpointUpdate(const string& uuid) {
             if (ep->getAccessIfaceVlan()) {
                 out.action()
                     .reg(MFF_REG5, ep->getAccessIfaceVlan().get())
-                    .metadata(flow::meta::access_out::PUSH_VLAN,
-                              flow::meta::out::MASK);
+                    .metadata(getPushVlanMeta(ep), flow::meta::out::MASK);
             }
             out.action().go(SEC_GROUP_IN_TABLE_ID);
             out.build(el);
@@ -452,9 +511,19 @@ void AccessFlowManager::handleEndpointUpdate(const string& uuid) {
                 if (floatingIp.is_unspecified()) continue;
             }
             flowBypassFloatingIP(el, accessPort, uplinkPort, false,
-                                 floatingIp, ep);
+                                 false, floatingIp, ep);
             flowBypassFloatingIP(el, uplinkPort, accessPort, true,
-                                 floatingIp, ep);
+                                 false, floatingIp, ep);
+            /*
+             * We allow both with / without tags to handle Openshift
+             * bootstrap
+             */
+            if (ep->isAccessAllowUntagged() && ep->getAccessIfaceVlan()) {
+                flowBypassFloatingIP(el, accessPort, uplinkPort, false,
+                                     true, floatingIp, ep);
+                flowBypassFloatingIP(el, uplinkPort, accessPort, true,
+                                     true, floatingIp, ep);
+            }
         }
     }
     switchManager.writeFlow(uuid, GROUP_MAP_TABLE_ID, el);

--- a/agent-ovs/ovs/AccessFlowManager.cpp
+++ b/agent-ovs/ovs/AccessFlowManager.cpp
@@ -16,6 +16,7 @@
 #include "eth.h"
 #include <opflexagent/logging.h>
 
+#include <boost/system/error_code.hpp>
 #include <boost/algorithm/string/find_iterator.hpp>
 #include <boost/algorithm/string/finder.hpp>
 #include <boost/algorithm/string/classification.hpp>
@@ -55,6 +56,8 @@ void AccessFlowManager::populateTableDescriptionMap(
         fwdTblDescr.insert( \
                     std::make_pair(table_id, \
                             std::make_pair(table_name, drop_reason)));
+    TABLE_DESC(SERVICE_BYPASS_TABLE_ID, "SERVICE_BYPASS_TABLE",
+               "Skip security-group checks for Service loopback traffic")
     TABLE_DESC(GROUP_MAP_TABLE_ID, "GROUP_MAP_TABLE", "Access port incorrect")
     TABLE_DESC(SEC_GROUP_IN_TABLE_ID, "SEC_GROUP_IN_TABLE",
             "Egress Security group derivation missing/incorrect")
@@ -258,6 +261,58 @@ static void flowBypassFloatingIP(FlowEntryList& el, uint32_t inport,
     fb.build(el);
 }
 
+static void flowBypassServiceIP(FlowEntryList& el,
+                                uint32_t accessPort, uint32_t uplinkPort,
+                                std::shared_ptr<const Endpoint>& ep ) {
+
+    for (const string& epipStr : ep->getIPs()) {
+        network::cidr_t cidr;
+        if (!network::cidr_from_string(epipStr, cidr, false))
+            continue;
+        for (const string& svcipStr : ep->getServiceIPs()) {
+            boost::system::error_code ec;
+            address serviceAddr =
+                address::from_string(svcipStr, ec);
+            if (ec) continue;
+
+            FlowBuilder ingress, egress;
+            ingress.priority(10)
+                   .ethType(eth::type::IP)
+                   .inPort(uplinkPort)
+                   .ipSrc(serviceAddr)
+                   .ipDst(cidr.first, cidr.second)
+                   .action()
+                   .reg(MFF_REG7, accessPort);
+            if (ep->getAccessIfaceVlan()) {
+                ingress.action()
+                       .reg(MFF_REG5, ep->getAccessIfaceVlan().get())
+                       .metadata(flow::meta::access_out::PUSH_VLAN,
+                                 flow::meta::out::MASK);
+            }
+            ingress.action().go(AccessFlowManager::OUT_TABLE_ID);
+            ingress.build(el);
+
+            egress.priority(10)
+                  .ethType(eth::type::IP)
+                  .inPort(accessPort)
+                  .ipSrc(cidr.first, cidr.second)
+                  .ipDst(serviceAddr)
+                  .action()
+                  .reg(MFF_REG7, uplinkPort);
+            if (ep->getAccessIfaceVlan()) {
+                egress.vlan(ep->getAccessIfaceVlan().get());
+                egress.action()
+                      .metadata(flow::meta::access_out::POP_VLAN,
+                                flow::meta::out::MASK);
+            } else {
+                egress.tci(0, 0x1fff);
+            }
+            egress.action().go(AccessFlowManager::OUT_TABLE_ID);
+            egress.build(el);
+        }
+    }
+}
+
 void AccessFlowManager::createStaticFlows() {
     LOG(DEBUG) << "Writing static flows";
     {
@@ -310,13 +365,13 @@ void AccessFlowManager::createStaticFlows() {
     {
         FlowEntryList dropLogFlows;
         FlowBuilder().priority(0)
-                .action().go(GROUP_MAP_TABLE_ID)
+                .action().go(SERVICE_BYPASS_TABLE_ID)
                 .parent().build(dropLogFlows);
         switchManager.writeFlow("static", DROP_LOG_TABLE_ID, dropLogFlows);
         /* Insert a flow at the end of every table to match dropped packets
          * and go to the drop table where it will be punted to a port when configured
          */
-        for(unsigned table_id = GROUP_MAP_TABLE_ID; table_id < EXP_DROP_TABLE_ID; table_id++) {
+        for(unsigned table_id = SERVICE_BYPASS_TABLE_ID; table_id < EXP_DROP_TABLE_ID; table_id++) {
             FlowEntryList dropLogFlow;
             FlowBuilder().priority(0).cookie(flow::cookie::TABLE_DROP_FLOW)
                     .flags(OFPUTIL_FF_SEND_FLOW_REM)
@@ -326,6 +381,13 @@ void AccessFlowManager::createStaticFlows() {
             switchManager.writeFlow("DropLogFlow", table_id, dropLogFlow);
         }
         handleDropLogPortUpdate();
+    }
+    {
+        FlowEntryList skipServiceFlows;
+        FlowBuilder().priority(1)
+            .action().go(GROUP_MAP_TABLE_ID)
+            .parent().build(skipServiceFlows);
+        switchManager.writeFlow("static", SERVICE_BYPASS_TABLE_ID, skipServiceFlows);
     }
 
     // everything is allowed for endpoints with no security group set
@@ -342,6 +404,7 @@ void AccessFlowManager::handleEndpointUpdate(const string& uuid) {
         agent.getEndpointManager().getEndpoint(uuid);
     if (!ep) {
         switchManager.clearFlows(uuid, GROUP_MAP_TABLE_ID);
+        switchManager.clearFlows(uuid, SERVICE_BYPASS_TABLE_ID);
         if (conntrackEnabled)
             ctZoneManager.erase(uuid);
         return;
@@ -387,6 +450,7 @@ void AccessFlowManager::handleEndpointUpdate(const string& uuid) {
     }
 
     FlowEntryList el;
+    FlowEntryList skipServiceFlows;
     if (accessPort != OFPP_NONE && uplinkPort != OFPP_NONE) {
         {
             FlowBuilder in;
@@ -412,6 +476,14 @@ void AccessFlowManager::handleEndpointUpdate(const string& uuid) {
             in.build(el);
 
         }
+
+        /*
+         * When an endpoint that is backend for a service is
+         * reaching its own service IP we skip security group
+         * checks
+         */
+        flowBypassServiceIP(skipServiceFlows, accessPort,
+                            uplinkPort, ep);
 
         /*
          * We allow without tags to handle Openshift bootstrap
@@ -527,6 +599,7 @@ void AccessFlowManager::handleEndpointUpdate(const string& uuid) {
         }
     }
     switchManager.writeFlow(uuid, GROUP_MAP_TABLE_ID, el);
+    switchManager.writeFlow(uuid, SERVICE_BYPASS_TABLE_ID, skipServiceFlows);
 }
 
 void AccessFlowManager::handleDscpQosUpdate(const string& interface) {
@@ -901,7 +974,7 @@ void AccessFlowManager::packetDropLogConfigUpdated(const opflex::modb::URI& drop
             DropLogConfig::resolve(agent.getFramework(), dropLogCfgURI);
     if(!dropLogCfg) {
         FlowBuilder().priority(2)
-                .action().go(GROUP_MAP_TABLE_ID)
+                .action().go(SERVICE_BYPASS_TABLE_ID)
                 .parent().build(dropLogFlows);
         switchManager.writeFlow("DropLogConfig", DROP_LOG_TABLE_ID, dropLogFlows);
         LOG(INFO) << "Defaulting to droplog disabled";
@@ -915,7 +988,7 @@ void AccessFlowManager::packetDropLogConfigUpdated(const opflex::modb::URI& drop
                     .action()
                     .metadata(flow::meta::DROP_LOG,
                               flow::meta::DROP_LOG)
-                    .go(GROUP_MAP_TABLE_ID)
+                    .go(SERVICE_BYPASS_TABLE_ID)
                     .parent().build(dropLogFlows);
             LOG(INFO) << "Droplog mode set to unfiltered";
         } else {
@@ -926,7 +999,7 @@ void AccessFlowManager::packetDropLogConfigUpdated(const opflex::modb::URI& drop
     } else {
         FlowBuilder().priority(2)
                 .action()
-                .go(GROUP_MAP_TABLE_ID)
+                .go(SERVICE_BYPASS_TABLE_ID)
                 .parent().build(dropLogFlows);
         LOG(INFO) << "Droplog disabled";
     }
@@ -980,7 +1053,7 @@ void AccessFlowManager::packetDropFlowConfigUpdated(const opflex::modb::URI& dro
         fb.tpDst(dropFlowCfg.get()->getDstPort(0));
     }
     fb.action().metadata(flow::meta::DROP_LOG, flow::meta::DROP_LOG)
-            .go(GROUP_MAP_TABLE_ID).parent().build(dropLogFlows);
+            .go(SERVICE_BYPASS_TABLE_ID).parent().build(dropLogFlows);
     switchManager.writeFlow(dropFlowCfgURI.toString(), DROP_LOG_TABLE_ID,
             dropLogFlows);
 }

--- a/agent-ovs/ovs/AdvertManager.cpp
+++ b/agent-ovs/ovs/AdvertManager.cpp
@@ -646,9 +646,9 @@ void AdvertManager::sendTunnelEpRarp(const string& uuid) {
     string uplinkIface;
     intFlowManager.getTunnelEpManager().getUplinkIface(uplinkIface);
     sa_ll.sll_ifindex = if_nametoindex(uplinkIface.c_str());
-    if(sa_ll.sll_ifindex < 0) {
+    if(sa_ll.sll_ifindex == 0) {
         LOG(ERROR) << "Failed to get ifindex by name " << uplinkIface <<
-                ": " << sa_ll.sll_ifindex;
+                ": " << strerror(errno);
         return;
     }
     memset(sa_ll.sll_addr, 0xff, ETH_ALEN);
@@ -703,9 +703,9 @@ void AdvertManager::sendTunnelEpGarp(const string& uuid) {
     string uplinkIface;
     intFlowManager.getTunnelEpManager().getUplinkIface(uplinkIface);
     sa_ll.sll_ifindex = if_nametoindex(uplinkIface.c_str());
-    if(sa_ll.sll_ifindex < 0) {
+    if(sa_ll.sll_ifindex == 0) {
         LOG(ERROR) << "Failed to get ifindex by name " << uplinkIface <<
-                ": " << sa_ll.sll_ifindex;
+                ": " << strerror(errno);
         return;
     }
     memset(sa_ll.sll_addr, 0xff, ETH_ALEN);

--- a/agent-ovs/ovs/IntFlowManager.cpp
+++ b/agent-ovs/ovs/IntFlowManager.cpp
@@ -344,7 +344,14 @@ void IntFlowManager::endpointUpdated(const std::string& uuid) {
     if (stopping) return;
 
     if(tunnelEpManager.isTunnelEp(uuid)){
-        advertManager.scheduleTunnelEpAdv(uuid);
+        string uplinkIface;
+        tunnelEpManager.getUplinkIface(uplinkIface);
+        if(!uplinkIface.empty()) {
+            advertManager.scheduleTunnelEpAdv(uuid);
+        } else {
+            // This is true in the cloud case
+            LOG(INFO) << "Configured uplink is empty.Not starting Tunnel advertisements";
+        }
         return;
     }
     advertManager.scheduleEndpointAdv(uuid);

--- a/agent-ovs/ovs/IntFlowManager.cpp
+++ b/agent-ovs/ovs/IntFlowManager.cpp
@@ -10,6 +10,9 @@
 #include <cstdlib>
 #include <cstring>
 #include <sstream>
+#include <sys/resource.h>
+#include <unistd.h>
+#include <sys/syscall.h>
 #include <boost/system/error_code.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
@@ -149,8 +152,9 @@ IntFlowManager::IntFlowManager(Agent& agent_,
     floodScope(FLOOD_DOMAIN), tunnelPortStr("4789"),
     virtualRouterEnabled(false), routerAdv(false),
     virtualDHCPEnabled(false), conntrackEnabled(false), dropLogRemotePort(0),
-    serviceStatsFlowDisabled(true),
-    advertManager(agent, *this), isSyncing(false), stopping(false) {
+    serviceStatsFlowDisabled(false),
+    advertManager(agent, *this), isSyncing(false), stopping(false),
+    svcStatsTaskQueue(svcStatsIOService) {
     // set up flow tables
     switchManager.setMaxFlowTables(NUM_FLOW_TABLES);
     SwitchManager::TableDescriptionMap fwdTblDescr;
@@ -183,6 +187,30 @@ void IntFlowManager::start(bool serviceStatsFlowDisabled_) {
 
     initPlatformConfig();
     createStaticFlows();
+
+    svcStatsIOWork.reset(new boost::asio::io_service::work(svcStatsIOService));
+    svcStatsThread.reset(new std::thread([this]() {
+            LOG(DEBUG) << "svcStatsThread start IO run";
+            const pid_t tid = syscall(SYS_gettid);
+            // By default sched policy is SCHED_OTHER for all threads in linux.
+            // Default priority is 0. SCHED_FIFO/RR will make threads with
+            // min prio of 1 and max prio of 99, and these policy threads will
+            // always preempt threads with SCHED_OTHER. Instead of changing all
+            // the existing threads to SCHED_FIFO/RR and innfluence priorities,
+            // there is a way to influence NICE values of SCHED_OTHER threads.
+            // Nice values vary from -20(high) to +19(low)
+            // Refer:
+            // 1. https://man7.org/linux/man-pages/man7/sched.7.html
+            // 2. https://linux.die.net/man/2/setpriority <-- this sets the nice
+            //                                      value of SCHED_OTHER threads
+            if (setpriority(PRIO_PROCESS, tid, 19)) {
+                LOG(ERROR) << "Unable to set low priority for svcStatsThread";
+                return;
+            }
+            svcStatsIOService.run();
+            LOG(DEBUG) << "svcStatsThread no more IO";
+        }));
+    LOG(DEBUG) << "Starting svcStatsIOWork and svcStatsThread";
 }
 
 void IntFlowManager::registerModbListeners() {
@@ -199,6 +227,16 @@ void IntFlowManager::registerModbListeners() {
 void IntFlowManager::stop() {
     LOG(DEBUG) << "Stopping IntFlowManager";
     stopping = true;
+
+    if (svcStatsIOWork) {
+        LOG(DEBUG) << "Stopping svcStatsIOWork";
+        svcStatsIOWork.reset();
+    }
+    if (svcStatsThread) {
+        LOG(DEBUG) << "Stopping svcStatsThread";
+        svcStatsThread->join();
+        svcStatsThread.reset();
+    }
 
     agent.getEndpointManager().unregisterListener(this);
     agent.getServiceManager().unregisterListener(this);
@@ -2972,6 +3010,50 @@ void IntFlowManager::clearSvcStatsCounters (const std::string& uuid,
     mutator.commit();
 }
 
+void IntFlowManager::handleUpdateSvcStatsFlows (const string& task_id)
+{
+    const std::lock_guard<mutex> lock(svcStatMutex);
+
+    bool is_svc = strcmp(task_id.substr(0,1).c_str(),"1") == 0;
+    bool is_add = strcmp(task_id.substr(1,1).c_str(),"1") == 0;
+    const string& uuid = task_id.substr(2);
+
+    LOG(DEBUG) << "#####  Updating service stats flows:"
+               << " uuid: " << uuid
+               << " is_svc: " << is_svc
+               << " is_add: " << is_add << "#######";
+
+    updatePodSvcStatsFlows(uuid, is_svc, is_add);
+    updateSvcTgtStatsFlows(uuid, is_svc, is_add);
+    updateSvcNodeStatsFlows(uuid, is_svc, is_add);
+    updateSvcExtStatsFlows(uuid, is_svc, is_add);
+
+    if (is_svc && is_add) {
+        // Svc Stats flow programming happens in this low prio thread.
+        // SNAT/DNAT flows will be programmed initially from a different thread.
+        // It will get updated here if needed for stats to work.
+        ServiceManager& srvMgr = agent.getServiceManager();
+        shared_ptr<const Service> asWrapper = srvMgr.getService(uuid);
+        if (!asWrapper || !asWrapper->getDomainURI()) {
+            LOG(DEBUG) << "unable to get service from uuid";
+            return;
+        }
+        programServiceSnatDnatFlows(uuid);
+    } else {
+        unordered_set<string> svcUuids;
+        ServiceManager& svcMgr = agent.getServiceManager();
+        svcMgr.getServiceUUIDs(svcUuids);
+        for (const string& svcUuid : svcUuids) {
+            // If EP IP is added, and happens to be NH of this service, then cookie needs to be updated
+            // If EP IP is deleted, and happens to be NH of this service, then cookie needs to be removed
+            // If EP IP is modified:
+            //  - if it became NH of this service, then cookie needs to be updated
+            //  - if it moved away from being NH of this service, then cookie needs to be removed
+            programServiceSnatDnatFlows(svcUuid);
+        }
+    }
+}
+
 /**
  * Add/del stats flows:
  * Cluster/E-W:
@@ -2982,20 +3064,20 @@ void IntFlowManager::updateSvcStatsFlows (const string& uuid,
                                           const bool& is_svc,
                                           const bool& is_add)
 {
-    const std::lock_guard<mutex> lock(svcStatMutex);
-
     if (serviceStatsFlowDisabled)
         return;
 
-    LOG(DEBUG) << "##### Updating service stats flows:"
-               << " uuid: " << uuid
-               << " is_svc: " << is_svc
-               << " is_add: " << is_add << "#######";
-
-    updatePodSvcStatsFlows(uuid, is_svc, is_add);
-    updateSvcTgtStatsFlows(uuid, is_svc, is_add);
-    updateSvcNodeStatsFlows(uuid, is_svc, is_add);
-    updateSvcExtStatsFlows(uuid, is_svc, is_add);
+    std::string task_id;
+    if (is_svc)
+        task_id += "1";
+    else
+        task_id += "0";
+    if (is_add)
+        task_id += "1";
+    else
+        task_id += "0";
+    task_id += uuid;
+    svcStatsTaskQueue.dispatch(task_id, [=]() { handleUpdateSvcStatsFlows(task_id); });
 }
 
 void IntFlowManager::updateSvcExtStatsFlows (const string &uuid,
@@ -3202,12 +3284,6 @@ void IntFlowManager::updateSvcExtStatsFlows (const string &uuid,
         // If an IP is deleted, then cookie will be deleted
         for (const string& svcUuid : svcUuids) {
             updateSvcExtStatsFlows(svcUuid, true, true);
-            // If EP IP is modified:
-            //  - if it became NH of this service, then SNAT/DNAT flows should be
-            //    updated with stats cookie
-            //  - if it moved away from being NH of this service, then SNAT/DNAT
-            //    flows shouldnt match on stats cookie
-            programServiceSnatDnatFlows(svcUuid);
         }
     }
 }
@@ -3743,12 +3819,6 @@ void IntFlowManager::updateSvcTgtStatsFlows (const string &uuid,
         // If an IP is deleted, then stats flows will be deleted
         for (const string& svcUuid : svcUuids) {
             updateSvcTgtStatsFlows(svcUuid, true, true);
-            // If EP IP is added, and happens to be NH of this service, then cookie needs to be updated
-            // If EP IP is deleted, and happens to be NH of this service, then cookie needs to be removed
-            // If EP IP is modified:
-            //  - if it became NH of this service, then cookie needs to be updated
-            //  - if it moved away from being NH of this service, then cookie needs to be removed
-            programServiceSnatDnatFlows(svcUuid);
         }
     }
 

--- a/agent-ovs/ovs/OVSRenderer.cpp
+++ b/agent-ovs/ovs/OVSRenderer.cpp
@@ -483,7 +483,7 @@ void OVSRenderer::setProperties(const ptree& properties) {
 
     ifaceStatsEnabled = properties.get<bool>(STATS_INTERFACE_ENABLED, true);
     contractStatsEnabled = properties.get<bool>(STATS_CONTRACT_ENABLED, true);
-    serviceStatsFlowDisabled = properties.get<bool>(STATS_SERVICE_FLOWDISABLED, true);
+    serviceStatsFlowDisabled = properties.get<bool>(STATS_SERVICE_FLOWDISABLED, false);
     serviceStatsEnabled = properties.get<bool>(STATS_SERVICE_ENABLED, true);
     secGroupStatsEnabled = properties.get<bool>(STATS_SECGROUP_ENABLED, true);
     ifaceStatsInterval = properties.get<long>(STATS_INTERFACE_INTERVAL, 30000);

--- a/agent-ovs/ovs/ServiceStatsManager.cpp
+++ b/agent-ovs/ovs/ServiceStatsManager.cpp
@@ -46,7 +46,7 @@ ServiceStatsManager::~ServiceStatsManager() {
 void ServiceStatsManager::start() {
     LOG(DEBUG) << "Starting service stats manager ("
                << timer_interval << " ms)";
-    PolicyStatsManager::start();
+    PolicyStatsManager::start(true, intFlowManager.getSvcStatsIOService());
     {
         std::lock_guard<std::mutex> lock(timer_mutex);
         timer->async_wait(bind(&ServiceStatsManager::on_timer, this, error));

--- a/agent-ovs/ovs/include/AccessFlowManager.h
+++ b/agent-ovs/ovs/include/AccessFlowManager.h
@@ -128,6 +128,11 @@ public:
          */
         DROP_LOG_TABLE_ID,
         /**
+         * bypass loopback flows from service backends to service
+         * from security group checks
+         */
+        SERVICE_BYPASS_TABLE_ID,
+        /**
          * Map packets to a security group and set their destination
          * port after applying policy
          */

--- a/agent-ovs/ovs/include/FlowConstants.h
+++ b/agent-ovs/ovs/include/FlowConstants.h
@@ -183,6 +183,11 @@ const uint64_t POP_VLAN = 0x1;
  */
 const uint64_t PUSH_VLAN = 0x2;
 
+/**
+ * Replicate the packet both untagged followed by tagged
+ */
+const uint64_t UNTAGGED_AND_PUSH_VLAN = 0x3;
+
 } // namespace access
 
 } // namespace meta

--- a/agent-ovs/ovs/include/PolicyStatsManager.h
+++ b/agent-ovs/ovs/include/PolicyStatsManager.h
@@ -85,7 +85,8 @@ public:
     /**
      * Start the policy stats manager
      */
-    void start(bool register_listener=true);
+    void start(bool register_listener=true,
+               boost::optional<boost::asio::io_service&> io_service=boost::none);
 
     /**
      * Get the classifier counter generation ID

--- a/agent-ovs/ovs/include/SwitchManager.h
+++ b/agent-ovs/ovs/include/SwitchManager.h
@@ -281,6 +281,7 @@ private:
     // table state
     std::vector<TableState> flowTables;
     TableState tlvTable;
+    std::recursive_mutex sm_mutex;
 
     // connection state
     void handleConnection(SwitchConnection *sw);
@@ -290,19 +291,19 @@ private:
     long connectDelayMs;
 
     // sync state
-    bool stopping;
-    bool syncEnabled;
-    bool syncing;
-    bool syncInProgress;
-    bool syncPending;
+    std::atomic<bool> stopping;
+    std::atomic<bool> syncEnabled;
+    std::atomic<bool> syncing;
+    std::atomic<bool> syncInProgress;
+    std::atomic<bool> syncPending;
 
     std::vector<FlowEntryList> recvFlows;
     std::vector<bool> tableDone;
     TlvEntryList recvTlvs;
-    bool tlvTableDone;
+    std::atomic<bool> tlvTableDone;
 
     SwitchStateHandler::GroupMap recvGroups;
-    bool groupsDone;
+    std::atomic<bool> groupsDone;
 
     /*Drop counter table list*/
     TableDescriptionMap tableDescriptionMap;

--- a/agent-ovs/ovs/test/AccessFlowManager_test.cpp
+++ b/agent-ovs/ovs/test/AccessFlowManager_test.cpp
@@ -230,7 +230,7 @@ BOOST_FIXTURE_TEST_CASE(learningBridge, AccessFlowManagerFixture) {
 
 #define ADDF(flow) addExpFlowEntry(expTables, flow)
 enum TABLE {
-    DROP_LOG=0, GRP = 1, IN_POL = 2, OUT_POL = 3, OUT = 4, EXP_DROP=5
+    DROP_LOG=0, SVC_BYPASS = 1, GRP = 2, IN_POL = 3, OUT_POL = 4, OUT = 5, EXP_DROP=6
 };
 
 enum CaptureReason {
@@ -492,8 +492,10 @@ void AccessFlowManagerFixture::initExpStatic() {
     ADDF(Bldr().table(IN_POL).priority(PolicyManager::MAX_POLICY_RULE_PRIORITY)
          .reg(SEPG, 1).actions().go(OUT).done());
     ADDF(Bldr().table(DROP_LOG).priority(0)
+            .actions().go(SVC_BYPASS).done());
+    ADDF(Bldr().table(SVC_BYPASS).priority(1)
             .actions().go(GRP).done());
-    for(int i=GRP; i<=OUT; i++) {
+    for(int i=SVC_BYPASS; i<=OUT; i++) {
         ADDF(Bldr().table(i).priority(0)
         .cookie(ovs_ntohll(opflexagent::flow::cookie::TABLE_DROP_FLOW))
         .flags(OFPUTIL_FF_SEND_FLOW_REM).priority(0)
@@ -708,11 +710,11 @@ uint16_t AccessFlowManagerFixture::initExpSecGrp2(uint32_t setId) {
          .actions().go(OUT).done());
     ADDF(Bldr(SEND_FLOW_REM).table(IN_POL).priority(prio - 128)
          .isCtState("-trk").tcp().reg(SEPG, setId)
-         .actions().ct("table=1,zone=NXM_NX_REG6[0..15]").done());
+         .actions().ct("table=2,zone=NXM_NX_REG6[0..15]").done());
     ADDF(Bldr(SEND_FLOW_REM).table(OUT_POL).priority(prio - 128).cookie(ruleId)
          .isCtState("-trk")
          .tcp().reg(SEPG, setId).isTpDst(22)
-         .actions().ct("table=1,zone=NXM_NX_REG6[0..15]").done());
+         .actions().ct("table=2,zone=NXM_NX_REG6[0..15]").done());
     ADDF(Bldr(SEND_FLOW_REM).table(OUT_POL).priority(prio - 128).cookie(ruleId)
          .isCtState("+est+trk")
          .tcp().reg(SEPG, setId).isTpDst(22)

--- a/agent-ovs/ovs/test/AccessFlowManager_test.cpp
+++ b/agent-ovs/ovs/test/AccessFlowManager_test.cpp
@@ -477,7 +477,11 @@ void AccessFlowManagerFixture::initExpStatic() {
          .actions().out(OUTPORT).done());
     ADDF(Bldr().table(OUT).priority(1)
          .isMdAct(opflexagent::flow::meta::access_out::PUSH_VLAN)
-          .actions().pushVlan().move(FD12, VLAN).out(OUTPORT).done());
+         .actions().pushVlan().move(FD12, VLAN).out(OUTPORT).done());
+    ADDF(Bldr().table(OUT).priority(1)
+         .isMdAct(opflexagent::flow::meta::access_out::UNTAGGED_AND_PUSH_VLAN)
+         .actions().out(OUTPORT).pushVlan()
+         .move(FD12, VLAN).out(OUTPORT).done());
     ADDF(Bldr().table(OUT).priority(1)
          .isMdAct(opflexagent::flow::meta::access_out::POP_VLAN)
          .isVlanTci("0x1000/0x1000")
@@ -513,6 +517,15 @@ void AccessFlowManagerFixture::initExpDhcpEp(shared_ptr<Endpoint>& ep) {
              .load(OUTPORT, uplink)
              .mdAct(opflexagent::flow::meta::access_out::POP_VLAN)
              .go(OUT).done());
+        if (ep->isAccessAllowUntagged() && ep->getAccessIfaceVlan()) {
+            ADDF(Bldr()
+                 .table(GRP).priority(200).udp().in(access)
+                 .isVlanTci("0x0000/0x1fff")
+                 .isTpSrc(68).isTpDst(67)
+                 .actions()
+                 .load(OUTPORT, uplink)
+                 .go(OUT).done());
+        }
     }
     if (ep->getDHCPv6Config()) {
         ADDF(Bldr()
@@ -523,6 +536,15 @@ void AccessFlowManagerFixture::initExpDhcpEp(shared_ptr<Endpoint>& ep) {
              .load(OUTPORT, uplink)
              .mdAct(opflexagent::flow::meta::access_out::POP_VLAN)
              .go(OUT).done());
+        if (ep->isAccessAllowUntagged() && ep->getAccessIfaceVlan()) {
+            ADDF(Bldr()
+                 .table(GRP).priority(200).udp6().in(access)
+                 .isVlanTci("0x0000/0x1fff")
+                 .isTpSrc(546).isTpDst(547)
+                 .actions()
+                 .load(OUTPORT, uplink)
+                 .go(OUT).done());
+        }
     }
 }
 
@@ -541,6 +563,14 @@ void AccessFlowManagerFixture::initExpEp(shared_ptr<Endpoint>& ep) {
              .load(OUTPORT, uplink)
              .mdAct(opflexagent::flow::meta::access_out::POP_VLAN)
              .go(OUT_POL).done());
+        if (ep->isAccessAllowUntagged()) {
+            ADDF(Bldr().table(GRP).priority(99).in(access)
+                 .isVlanTci("0x0000/0x1fff")
+                 .actions()
+                 .load(RD, zoneId).load(SEPG, 1)
+                 .load(OUTPORT, uplink)
+                 .go(OUT_POL).done());
+        }
         ADDF(Bldr().table(GRP).priority(100).in(uplink)
              .actions().load(RD, zoneId).load(SEPG, 1).load(OUTPORT, access)
              .load(FD, ep->getAccessIfaceVlan().get())

--- a/libopflex/engine/MOSerializer.cpp
+++ b/libopflex/engine/MOSerializer.cpp
@@ -24,7 +24,6 @@
 #include <rapidjson/prettywriter.h>
 
 #include "opflex/engine/internal/MOSerializer.h"
-#include "opflex/modb/internal/ObjectStore.h"
 #include "opflex/modb/internal/Region.h"
 
 namespace opflex {
@@ -273,9 +272,6 @@ void MOSerializer::deserialize(const rapidjson::Value& mo,
                                                          parent_uri,
                                                          *notifs);
                         }
-                    } else {
-                        LOG(DEBUG) << "No parent present for "
-                                    << uri.toString();
                     }
                 } catch (const std::out_of_range& e) {
                     // no parent class or property found

--- a/libopflex/engine/Processor.cpp
+++ b/libopflex/engine/Processor.cpp
@@ -649,8 +649,11 @@ void Processor::objectUpdated(modb::class_id_t class_id,
 
     if (uit == uri_index.end()) {
         if (present) {
-            LOG(DEBUG) << "Tracking new " << (local ? "local" : "nonlocal")
-                       << " item " << uri << " from update";
+            const ClassInfo& ci = store->getClassInfo(class_id);
+            if (ci.getType() != ClassInfo::OBSERVABLE) {
+                LOG(DEBUG) << "Tracking new " << (local ? "local" : "nonlocal")
+                           << " item " << uri << " from update";
+            }
             uint64_t nexp = 0;
             if (local) nexp = curtime+processingDelay;
             double prrRange1 = prrTimerDuration/3;


### PR DESCRIPTION
- Created a new thread to handle svc stat flows CRUD. The thread works on a new asio io_service object to handle new events from taskqueue.
- Stats collection done via ServiceStatsManager also uses the new asio io_service.
- All linux threads by default have SCHED_OTHER scheduling policy. This has a static priority of 0. Other sched policies like SCHED_FIFO and SCHED_RR allow users to control thread priority varying from values 1 to 99. Due to this FIFO/RR will preempt SCHED_OTHER threads. Either we move all threads to FIFO/RR and set priorities or somehow influence priority within SCHED_OTHER policy. Luckily there is a "nice" value than is configurable at a thread level per process which can control the total time allocated per thread. The new thread has highest "nice" value, which makes it consume least CPU time.
- Call programServiceSnatDnatFlows() appropriately per service, once all the stats flows are programmed. This is to update cookie values in SNAT/DNAT flows for stats collection. Note: This used to be called twice for every service during EP update. Reduced this to just one call. Also, since service flows get programmed via agent thread and since stats flows are created via different thread, this call needs to be called separately for service updates as well.
- Flows get programmed by both agent thread and new thread. Addressed tsan issues with a mutex in switch manager.
- Changed a few booleans to atomic bools.
- enabled svc stats by default
- make check and mock agent work fine.
- reproduced the issue faced by telenor on fab1 with old opflex-agent image. 177 services + 110 pods per node took 2 hours to get applied. 40% CPU consumed by opflex-agent consistently. A new service-pod when spawned, took around 2 mins 20 seconds to be responsive. With the fix, CPU consumption during flow creation is around 25%. New service-pod is accessible instantaneously. Bootup with new image was also v quick.