### PR TITLE
Changes to move svc stats to a low prio thread

### DIFF
--- a/agent-ovs/ovs/IntFlowManager.cpp
+++ b/agent-ovs/ovs/IntFlowManager.cpp
@@ -10,6 +10,9 @@
 #include <cstdlib>
 #include <cstring>
 #include <sstream>
+#include <sys/resource.h>
+#include <unistd.h>
+#include <sys/syscall.h>
 #include <boost/system/error_code.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
@@ -149,8 +152,9 @@ IntFlowManager::IntFlowManager(Agent& agent_,
     floodScope(FLOOD_DOMAIN), tunnelPortStr("4789"),
     virtualRouterEnabled(false), routerAdv(false),
     virtualDHCPEnabled(false), conntrackEnabled(false), dropLogRemotePort(0),
-    serviceStatsFlowDisabled(true),
-    advertManager(agent, *this), isSyncing(false), stopping(false) {
+    serviceStatsFlowDisabled(false),
+    advertManager(agent, *this), isSyncing(false), stopping(false),
+    svcStatsTaskQueue(svcStatsIOService) {
     // set up flow tables
     switchManager.setMaxFlowTables(NUM_FLOW_TABLES);
     SwitchManager::TableDescriptionMap fwdTblDescr;
@@ -183,6 +187,30 @@ void IntFlowManager::start(bool serviceStatsFlowDisabled_) {
 
     initPlatformConfig();
     createStaticFlows();
+
+    svcStatsIOWork.reset(new boost::asio::io_service::work(svcStatsIOService));
+    svcStatsThread.reset(new std::thread([this]() {
+            LOG(DEBUG) << "svcStatsThread start IO run";
+            const pid_t tid = syscall(SYS_gettid);
+            // By default sched policy is SCHED_OTHER for all threads in linux.
+            // Default priority is 0. SCHED_FIFO/RR will make threads with
+            // min prio of 1 and max prio of 99, and these policy threads will
+            // always preempt threads with SCHED_OTHER. Instead of changing all
+            // the existing threads to SCHED_FIFO/RR and innfluence priorities,
+            // there is a way to influence NICE values of SCHED_OTHER threads.
+            // Nice values vary from -20(high) to +19(low)
+            // Refer:
+            // 1. https://man7.org/linux/man-pages/man7/sched.7.html
+            // 2. https://linux.die.net/man/2/setpriority <-- this sets the nice
+            //                                      value of SCHED_OTHER threads
+            if (setpriority(PRIO_PROCESS, tid, 19)) {
+                LOG(ERROR) << "Unable to set low priority for svcStatsThread";
+                return;
+            }
+            svcStatsIOService.run();
+            LOG(DEBUG) << "svcStatsThread no more IO";
+        }));
+    LOG(DEBUG) << "Starting svcStatsIOWork and svcStatsThread";
 }
 
 void IntFlowManager::registerModbListeners() {
@@ -199,6 +227,16 @@ void IntFlowManager::registerModbListeners() {
 void IntFlowManager::stop() {
     LOG(DEBUG) << "Stopping IntFlowManager";
     stopping = true;
+
+    if (svcStatsIOWork) {
+        LOG(DEBUG) << "Stopping svcStatsIOWork";
+        svcStatsIOWork.reset();
+    }
+    if (svcStatsThread) {
+        LOG(DEBUG) << "Stopping svcStatsThread";
+        svcStatsThread->join();
+        svcStatsThread.reset();
+    }
 
     agent.getEndpointManager().unregisterListener(this);
     agent.getServiceManager().unregisterListener(this);
@@ -2972,6 +3010,50 @@ void IntFlowManager::clearSvcStatsCounters (const std::string& uuid,
     mutator.commit();
 }
 
+void IntFlowManager::handleUpdateSvcStatsFlows (const string& task_id)
+{
+    const std::lock_guard<mutex> lock(svcStatMutex);
+
+    bool is_svc = strcmp(task_id.substr(0,1).c_str(),"1") == 0;
+    bool is_add = strcmp(task_id.substr(1,1).c_str(),"1") == 0;
+    const string& uuid = task_id.substr(2);
+
+    LOG(DEBUG) << "#####  Updating service stats flows:"
+               << " uuid: " << uuid
+               << " is_svc: " << is_svc
+               << " is_add: " << is_add << "#######";
+
+    updatePodSvcStatsFlows(uuid, is_svc, is_add);
+    updateSvcTgtStatsFlows(uuid, is_svc, is_add);
+    updateSvcNodeStatsFlows(uuid, is_svc, is_add);
+    updateSvcExtStatsFlows(uuid, is_svc, is_add);
+
+    if (is_svc && is_add) {
+        // Svc Stats flow programming happens in this low prio thread.
+        // SNAT/DNAT flows will be programmed initially from a different thread.
+        // It will get updated here if needed for stats to work.
+        ServiceManager& srvMgr = agent.getServiceManager();
+        shared_ptr<const Service> asWrapper = srvMgr.getService(uuid);
+        if (!asWrapper || !asWrapper->getDomainURI()) {
+            LOG(DEBUG) << "unable to get service from uuid";
+            return;
+        }
+        programServiceSnatDnatFlows(uuid);
+    } else {
+        unordered_set<string> svcUuids;
+        ServiceManager& svcMgr = agent.getServiceManager();
+        svcMgr.getServiceUUIDs(svcUuids);
+        for (const string& svcUuid : svcUuids) {
+            // If EP IP is added, and happens to be NH of this service, then cookie needs to be updated
+            // If EP IP is deleted, and happens to be NH of this service, then cookie needs to be removed
+            // If EP IP is modified:
+            //  - if it became NH of this service, then cookie needs to be updated
+            //  - if it moved away from being NH of this service, then cookie needs to be removed
+            programServiceSnatDnatFlows(svcUuid);
+        }
+    }
+}
+
 /**
  * Add/del stats flows:
  * Cluster/E-W:
@@ -2982,20 +3064,20 @@ void IntFlowManager::updateSvcStatsFlows (const string& uuid,
                                           const bool& is_svc,
                                           const bool& is_add)
 {
-    const std::lock_guard<mutex> lock(svcStatMutex);
-
     if (serviceStatsFlowDisabled)
         return;
 
-    LOG(DEBUG) << "##### Updating service stats flows:"
-               << " uuid: " << uuid
-               << " is_svc: " << is_svc
-               << " is_add: " << is_add << "#######";
-
-    updatePodSvcStatsFlows(uuid, is_svc, is_add);
-    updateSvcTgtStatsFlows(uuid, is_svc, is_add);
-    updateSvcNodeStatsFlows(uuid, is_svc, is_add);
-    updateSvcExtStatsFlows(uuid, is_svc, is_add);
+    std::string task_id;
+    if (is_svc)
+        task_id += "1";
+    else
+        task_id += "0";
+    if (is_add)
+        task_id += "1";
+    else
+        task_id += "0";
+    task_id += uuid;
+    svcStatsTaskQueue.dispatch(task_id, [=]() { handleUpdateSvcStatsFlows(task_id); });
 }
 
 void IntFlowManager::updateSvcExtStatsFlows (const string &uuid,
@@ -3202,12 +3284,6 @@ void IntFlowManager::updateSvcExtStatsFlows (const string &uuid,
         // If an IP is deleted, then cookie will be deleted
         for (const string& svcUuid : svcUuids) {
             updateSvcExtStatsFlows(svcUuid, true, true);
-            // If EP IP is modified:
-            //  - if it became NH of this service, then SNAT/DNAT flows should be
-            //    updated with stats cookie
-            //  - if it moved away from being NH of this service, then SNAT/DNAT
-            //    flows shouldnt match on stats cookie
-            programServiceSnatDnatFlows(svcUuid);
         }
     }
 }
@@ -3743,12 +3819,6 @@ void IntFlowManager::updateSvcTgtStatsFlows (const string &uuid,
         // If an IP is deleted, then stats flows will be deleted
         for (const string& svcUuid : svcUuids) {
             updateSvcTgtStatsFlows(svcUuid, true, true);
-            // If EP IP is added, and happens to be NH of this service, then cookie needs to be updated
-            // If EP IP is deleted, and happens to be NH of this service, then cookie needs to be removed
-            // If EP IP is modified:
-            //  - if it became NH of this service, then cookie needs to be updated
-            //  - if it moved away from being NH of this service, then cookie needs to be removed
-            programServiceSnatDnatFlows(svcUuid);
         }
     }
 

--- a/agent-ovs/ovs/OVSRenderer.cpp
+++ b/agent-ovs/ovs/OVSRenderer.cpp
@@ -483,7 +483,7 @@ void OVSRenderer::setProperties(const ptree& properties) {
 
     ifaceStatsEnabled = properties.get<bool>(STATS_INTERFACE_ENABLED, true);
     contractStatsEnabled = properties.get<bool>(STATS_CONTRACT_ENABLED, true);
-    serviceStatsFlowDisabled = properties.get<bool>(STATS_SERVICE_FLOWDISABLED, true);
+    serviceStatsFlowDisabled = properties.get<bool>(STATS_SERVICE_FLOWDISABLED, false);
     serviceStatsEnabled = properties.get<bool>(STATS_SERVICE_ENABLED, true);
     secGroupStatsEnabled = properties.get<bool>(STATS_SECGROUP_ENABLED, true);
     ifaceStatsInterval = properties.get<long>(STATS_INTERFACE_INTERVAL, 30000);

--- a/agent-ovs/ovs/ServiceStatsManager.cpp
+++ b/agent-ovs/ovs/ServiceStatsManager.cpp
@@ -46,7 +46,7 @@ ServiceStatsManager::~ServiceStatsManager() {
 void ServiceStatsManager::start() {
     LOG(DEBUG) << "Starting service stats manager ("
                << timer_interval << " ms)";
-    PolicyStatsManager::start();
+    PolicyStatsManager::start(true, intFlowManager.getSvcStatsIOService());
     {
         std::lock_guard<std::mutex> lock(timer_mutex);
         timer->async_wait(bind(&ServiceStatsManager::on_timer, this, error));

--- a/agent-ovs/ovs/include/PolicyStatsManager.h
+++ b/agent-ovs/ovs/include/PolicyStatsManager.h
@@ -85,7 +85,8 @@ public:
     /**
      * Start the policy stats manager
      */
-    void start(bool register_listener=true);
+    void start(bool register_listener=true,
+               boost::optional<boost::asio::io_service&> io_service=boost::none);
 
     /**
      * Get the classifier counter generation ID

--- a/agent-ovs/ovs/include/SwitchManager.h
+++ b/agent-ovs/ovs/include/SwitchManager.h
@@ -281,6 +281,7 @@ private:
     // table state
     std::vector<TableState> flowTables;
     TableState tlvTable;
+    std::recursive_mutex sm_mutex;
 
     // connection state
     void handleConnection(SwitchConnection *sw);
@@ -290,19 +291,19 @@ private:
     long connectDelayMs;
 
     // sync state
-    bool stopping;
-    bool syncEnabled;
-    bool syncing;
-    bool syncInProgress;
-    bool syncPending;
+    std::atomic<bool> stopping;
+    std::atomic<bool> syncEnabled;
+    std::atomic<bool> syncing;
+    std::atomic<bool> syncInProgress;
+    std::atomic<bool> syncPending;
 
     std::vector<FlowEntryList> recvFlows;
     std::vector<bool> tableDone;
     TlvEntryList recvTlvs;
-    bool tlvTableDone;
+    std::atomic<bool> tlvTableDone;
 
     SwitchStateHandler::GroupMap recvGroups;
-    bool groupsDone;
+    std::atomic<bool> groupsDone;
 
     /*Drop counter table list*/
     TableDescriptionMap tableDescriptionMap;


### PR DESCRIPTION
- Created a new thread to handle svc stat flows CRUD. The thread works on a new asio io_service object to handle new events from taskqueue.
- Stats collection done via ServiceStatsManager also uses the new asio io_service.
- All linux threads by default have SCHED_OTHER scheduling policy. This has a static priority of 0. Other sched policies like SCHED_FIFO and SCHED_RR allow users to control thread priority varying from values 1 to 99. Due to this FIFO/RR will preempt SCHED_OTHER threads. Either we move all threads to FIFO/RR and set priorities or somehow influence priority within SCHED_OTHER policy. Luckily there is a "nice" value than is configurable at a thread level per process which can control the total time allocated per thread. The new thread has highest "nice" value, which makes it consume least CPU time.
- Call programServiceSnatDnatFlows() appropriately per service, once all the stats flows are programmed. This is to update cookie values in SNAT/DNAT flows for stats collection. Note: This used to be called twice for every service during EP update. Reduced this to just one call. Also, since service flows get programmed via agent thread and since stats flows are created via different thread, this call needs to be called separately for service updates as well.
- Flows get programmed by both agent thread and new thread. Addressed tsan issues with a mutex in switch manager.
- Changed a few booleans to atomic bools.
- enabled svc stats by default
- make check and mock agent work fine.
- reproduced the issue faced by telenor on fab1 with old opflex-agent image. 177 services + 110 pods per node took 2 hours to get applied. 40% CPU consumed by opflex-agent consistently. A new service-pod when spawned, took around 2 mins 20 seconds to be responsive. With the fix, CPU consumption during flow creation is around 25%. New service-pod is accessible instantaneously. Bootup with new image was also v quick.

Signed-off-by: Gautam Venkataramanan <gautam.chennai@gmail.com>