### PR TITLE
Revert "Changes to move svc stats to a low prio thread"

### DIFF
--- a/agent-ovs/ovs/OVSRenderer.cpp
+++ b/agent-ovs/ovs/OVSRenderer.cpp
@@ -483,7 +483,7 @@ void OVSRenderer::setProperties(const ptree& properties) {
 
     ifaceStatsEnabled = properties.get<bool>(STATS_INTERFACE_ENABLED, true);
     contractStatsEnabled = properties.get<bool>(STATS_CONTRACT_ENABLED, true);
-    serviceStatsFlowDisabled = properties.get<bool>(STATS_SERVICE_FLOWDISABLED, false);
+    serviceStatsFlowDisabled = properties.get<bool>(STATS_SERVICE_FLOWDISABLED, true);
     serviceStatsEnabled = properties.get<bool>(STATS_SERVICE_ENABLED, true);
     secGroupStatsEnabled = properties.get<bool>(STATS_SECGROUP_ENABLED, true);
     ifaceStatsInterval = properties.get<long>(STATS_INTERFACE_INTERVAL, 30000);

--- a/agent-ovs/ovs/PolicyStatsManager.cpp
+++ b/agent-ovs/ovs/PolicyStatsManager.cpp
@@ -64,8 +64,7 @@ void PolicyStatsManager::registerConnection(SwitchConnection* connection) {
     this->connection = connection;
 }
 
-void PolicyStatsManager::start(bool register_listener,
-                               boost::optional<boost::asio::io_service&> io_service) {
+void PolicyStatsManager::start(bool register_listener) {
     stopping = false;
 
     LOG(DEBUG) << "Starting policy stats manager " << this;
@@ -74,11 +73,7 @@ void PolicyStatsManager::start(bool register_listener,
         connection->RegisterMessageHandler(OFPTYPE_FLOW_REMOVED, this);
         {
             std::lock_guard<std::mutex> lock(timer_mutex);
-            if (io_service)
-                timer.reset(new deadline_timer(io_service.get(),
-                                               milliseconds(timer_interval)));
-            else
-                timer.reset(new deadline_timer(agent->getAgentIOService(),
+            timer.reset(new deadline_timer(agent->getAgentIOService(),
                                                milliseconds(timer_interval)));
         }
     }

--- a/agent-ovs/ovs/ServiceStatsManager.cpp
+++ b/agent-ovs/ovs/ServiceStatsManager.cpp
@@ -46,7 +46,7 @@ ServiceStatsManager::~ServiceStatsManager() {
 void ServiceStatsManager::start() {
     LOG(DEBUG) << "Starting service stats manager ("
                << timer_interval << " ms)";
-    PolicyStatsManager::start(true, intFlowManager.getSvcStatsIOService());
+    PolicyStatsManager::start();
     {
         std::lock_guard<std::mutex> lock(timer_mutex);
         timer->async_wait(bind(&ServiceStatsManager::on_timer, this, error));

--- a/agent-ovs/ovs/SwitchManager.cpp
+++ b/agent-ovs/ovs/SwitchManager.cpp
@@ -78,7 +78,6 @@ void SwitchManager::stop() {
 }
 
 void SwitchManager::setMaxFlowTables(int max) {
-    const lock_guard<recursive_mutex> lock(sm_mutex);
     flowTables.resize(max);
     recvFlows.resize(max);
     tableDone.resize(max);
@@ -136,7 +135,6 @@ void SwitchManager::Connected(SwitchConnection *swConn) {
 }
 
 void SwitchManager::handleConnection(SwitchConnection *sw) {
-    const lock_guard<recursive_mutex> lock(sm_mutex);
     flowReader.clear();
     syncInProgress = false;
     syncPending = false;
@@ -151,6 +149,7 @@ void SwitchManager::handleConnection(SwitchConnection *sw) {
         return;
     }
 
+    const lock_guard<recursive_mutex> lock(timer_mutex);
     if (connectTimer) {
         LOG(DEBUG) << "[" << connection->getSwitchName() << "] "
                    << "Sync state with switch will begin in "
@@ -174,7 +173,6 @@ void SwitchManager::onConnectTimer(const boost::system::error_code& ec) {
 
 bool SwitchManager::writeFlow(const std::string& objId, int tableId,
                               FlowEntryList& el) {
-    const lock_guard<recursive_mutex> lock(sm_mutex);
     bool success = true;
 
     assert(tableId >= 0 &&
@@ -219,7 +217,6 @@ bool SwitchManager::clearFlows(const std::string& objId, int tableId) {
 }
 
 bool SwitchManager::writeGroupMod(const GroupEdit::Entry& e) {
-    const lock_guard<recursive_mutex> lock(sm_mutex);
     // If a sync is in progress, don't write to the group table while
     // we are reading and reconciling with the current groups.
     if (syncing) {
@@ -237,7 +234,6 @@ bool SwitchManager::writeGroupMod(const GroupEdit::Entry& e) {
 }
 
 bool SwitchManager::writeTlv(const std::string& objId, TlvEntryList& el) {
-    const lock_guard<recursive_mutex> lock(sm_mutex);
     bool success = true;
 
     TlvEdit diffs;
@@ -259,20 +255,17 @@ bool SwitchManager::writeTlv(const std::string& objId, TlvEntryList& el) {
 
 void SwitchManager::diffTableState(int tableId, const FlowEntryList& el,
                                    /* out */ FlowEdit& diffs) {
-    const lock_guard<recursive_mutex> lock(sm_mutex);
     const TableState& tab = flowTables[tableId];
     tab.diffSnapshot(el, diffs);
 }
 
 void SwitchManager::forEachCookieMatch(int tableId,
                                        TableState::cookie_callback_t& cb) {
-    const lock_guard<recursive_mutex> lock(sm_mutex);
     const TableState& tab = flowTables[tableId];
     tab.forEachCookieMatch(cb);
 }
 
 void SwitchManager::initiateSync() {
-    const lock_guard<recursive_mutex> lock(sm_mutex);
     if (syncInProgress) {
         LOG(DEBUG) << "[" << connection->getSwitchName() << "] "
                    << "Sync is already in progress, marking it as pending";
@@ -297,7 +290,6 @@ void SwitchManager::initiateSync() {
 
 void SwitchManager::gotGroups(const GroupEdit::EntryList& groups,
     bool done) {
-    const lock_guard<recursive_mutex> lock(sm_mutex);
     for (const GroupEdit::Entry& e : groups) {
         recvGroups[e->mod->group_id] = e;
     }
@@ -311,7 +303,6 @@ void SwitchManager::gotGroups(const GroupEdit::EntryList& groups,
 
 void SwitchManager::gotFlows(int tableId, const FlowEntryList& flows,
                              bool done) {
-    const lock_guard<recursive_mutex> lock(sm_mutex);
     assert(tableId >= 0 &&
            static_cast<size_t>(tableId) < flowTables.size());
 
@@ -328,7 +319,6 @@ void SwitchManager::gotFlows(int tableId, const FlowEntryList& flows,
 
 void SwitchManager::gotTlvEntries(const TlvEntryList& tlvs,
                              bool done) {
-    const lock_guard<recursive_mutex> lock(sm_mutex);
     TlvEntryList& rl = recvTlvs;
     rl.insert(rl.end(), tlvs.begin(), tlvs.end());
     tlvTableDone = done;
@@ -341,7 +331,6 @@ void SwitchManager::gotTlvEntries(const TlvEntryList& tlvs,
 }
 
 void SwitchManager::checkRecvDone() {
-    const lock_guard<recursive_mutex> lock(sm_mutex);
     bool allDone = groupsDone;
     for (size_t i = 0; allDone && i < flowTables.size(); ++i) {
         allDone = allDone && tableDone[i];
@@ -357,7 +346,6 @@ void SwitchManager::checkRecvDone() {
 }
 
 void SwitchManager::completeSync() {
-    const lock_guard<recursive_mutex> lock(sm_mutex);
     assert(syncInProgress == true);
     if (stateHandler) {
         GroupEdit ge = stateHandler->reconcileGroups(recvGroups);

--- a/agent-ovs/ovs/include/IntFlowManager.h
+++ b/agent-ovs/ovs/include/IntFlowManager.h
@@ -32,9 +32,7 @@
 #include <boost/asio/ip/address.hpp>
 #include <boost/optional.hpp>
 #include <boost/noncopyable.hpp>
-#include <boost/asio/io_service.hpp>
 
-#include <thread>
 #include <utility>
 #include <unordered_map>
 
@@ -532,12 +530,6 @@ public:
      */
     static void populateTableDescriptionMap(
             SwitchManager::TableDescriptionMap &fwdTblDescr);
-    /**
-     * Get ASIO io_service used for svc stats processing
-     */
-    boost::asio::io_service& getSvcStatsIOService() {
-        return svcStatsIOService;
-    }
 private:
     /**
      * Write flows that are fixed and not related to any policy or
@@ -597,13 +589,6 @@ private:
     void updateSvcStatsFlows(const std::string &uuid,
                              const bool &is_svc,
                              const bool &is_add);
-
-    /**
-     * Handle update of service stats flows for metric collection
-     *
-     * @param task_id made up of is_svc,is_add, & UUID of the changed service/ep
-     */
-    void handleUpdateSvcStatsFlows(const std::string& task_id);
 
     /**
      * Update ext<-->svc-tgt flows due to changes in a service/ep
@@ -902,7 +887,7 @@ private:
     std::string dropLogIface;
     boost::asio::ip::address dropLogDst;
     uint16_t dropLogRemotePort;
-    std::atomic<bool> serviceStatsFlowDisabled;
+    bool serviceStatsFlowDisabled;
 
     /* Map containing ingress and egress cookie: Flows generated out
      * of same pod<-->svc uuid will use these cookies */
@@ -988,10 +973,6 @@ private:
      */
     void handleDropLogPortUpdate();
 
-    std::unique_ptr<std::thread> svcStatsThread;
-    boost::asio::io_service svcStatsIOService;
-    std::unique_ptr<boost::asio::io_service::work> svcStatsIOWork;
-    TaskQueue svcStatsTaskQueue;
 };
 
 } // namespace opflexagent

--- a/agent-ovs/ovs/include/PolicyStatsManager.h
+++ b/agent-ovs/ovs/include/PolicyStatsManager.h
@@ -85,8 +85,7 @@ public:
     /**
      * Start the policy stats manager
      */
-    void start(bool register_listener=true,
-               boost::optional<boost::asio::io_service&> io_service=boost::none);
+    void start(bool register_listener=true);
 
     /**
      * Get the classifier counter generation ID

--- a/agent-ovs/ovs/include/SwitchManager.h
+++ b/agent-ovs/ovs/include/SwitchManager.h
@@ -281,7 +281,6 @@ private:
     // table state
     std::vector<TableState> flowTables;
     TableState tlvTable;
-    std::recursive_mutex sm_mutex;
 
     // connection state
     void handleConnection(SwitchConnection *sw);
@@ -291,19 +290,19 @@ private:
     long connectDelayMs;
 
     // sync state
-    std::atomic<bool> stopping;
-    std::atomic<bool> syncEnabled;
-    std::atomic<bool> syncing;
-    std::atomic<bool> syncInProgress;
-    std::atomic<bool> syncPending;
+    bool stopping;
+    bool syncEnabled;
+    bool syncing;
+    bool syncInProgress;
+    bool syncPending;
 
     std::vector<FlowEntryList> recvFlows;
     std::vector<bool> tableDone;
     TlvEntryList recvTlvs;
-    std::atomic<bool> tlvTableDone;
+    bool tlvTableDone;
 
     SwitchStateHandler::GroupMap recvGroups;
-    std::atomic<bool> groupsDone;
+    bool groupsDone;
 
     /*Drop counter table list*/
     TableDescriptionMap tableDescriptionMap;


### PR DESCRIPTION
Some flow programming problems have been reported with this change.
Reverting from the jefferson branch for now. We'll reenable once we
root cause the issue

Reverts noironetworks/opflex#297