### PR TITLE
Address TSAN issue in OVSDB shutdown + other cleanups

### DIFF
--- a/agent-ovs/opflex-agent-ovs.conf.in
+++ b/agent-ovs/opflex-agent-ovs.conf.in
@@ -72,7 +72,7 @@
             // Default: true
             "enabled": true,
 
-            // Listen on the specified socket for the inspector
+            // Socket to use to send notifications to listeners
             // Default: "DEFAULT_NOTIF_SOCKET"
             "socket-name": "DEFAULT_NOTIF_SOCKET",
 

--- a/agent-ovs/ovs/OvsdbConnection.cpp
+++ b/agent-ovs/ovs/OvsdbConnection.cpp
@@ -65,9 +65,6 @@ void OvsdbConnection::connect_cb(uv_async_t* handle) {
 void OvsdbConnection::stop() {
     uv_close((uv_handle_t*)&connect_async, nullptr);
     uv_close((uv_handle_t*)&writeq_async, nullptr);
-    if (peer) {
-        peer->destroy();
-    }
     yajr::finiLoop(client_loop);
     threadManager.stopTask("OvsdbConnection");
     cleanup();


### PR DESCRIPTION
Peer cleanup happens automatically when the uv loop
is shutdown.

Cleanup codacy, clang-tidy issues in opflex_agent.cpp

Fix copy pasted comments in agent config

Signed-off-by: Tom Flynn <tom.flynn@gmail.com>