### PR TITLE
Fix more data race issues

### DIFF
--- a/agent-ovs/lib/IdGenerator.cpp
+++ b/agent-ovs/lib/IdGenerator.cpp
@@ -379,6 +379,7 @@ void IdGenerator::initNamespace(const std::string& nmspc,
 
 void IdGenerator::collectGarbage(const std::string& ns,
                                  garbage_cb_t cb) {
+    lock_guard<mutex> guard(id_mutex);
     NamespaceMap::iterator nitr = namespaces.find(ns);
     if (nitr == namespaces.end()) {
         return;

--- a/agent-ovs/ovs/ContractStatsManager.cpp
+++ b/agent-ovs/ovs/ContractStatsManager.cpp
@@ -92,14 +92,15 @@ void ContractStatsManager::on_timer(const error_code& ec) {
     TableState::cookie_callback_t cb_func;
     cb_func = [this](uint64_t cookie, uint16_t priority,
                      const struct match& match) {
+        const std::lock_guard<std::mutex> lock(pstatMtx);
         updateFlowEntryMap(contractState, cookie, priority, match);
     };
 
     // Request Switch Manager to provide flow entries
     {
-        std::lock_guard<std::mutex> lock(pstatMtx);
         switchManager.forEachCookieMatch(IntFlowManager::POL_TABLE_ID,
                                          cb_func);
+        const std::lock_guard<std::mutex> lock(pstatMtx);
         PolicyCounterMap_t newClassCountersMap;
         on_timer_base(ec, contractState, newClassCountersMap);
         generatePolicyStatsObjects(&newClassCountersMap);

--- a/agent-ovs/ovs/IntFlowManager.cpp
+++ b/agent-ovs/ovs/IntFlowManager.cpp
@@ -2440,8 +2440,6 @@ updateSvcStatsCounters (const uint64_t &cookie,
                         const uint64_t &newPktCount,
                         const uint64_t &newByteCount)
 {
-    const std::lock_guard<mutex> lock(svcStatMutex);
-
     // Additional safety for stats flows:
     // Nothing must be reported from ServiceStatsManager
     // if serviceStatsFlowDisabled=true, since the stats flows wont be created
@@ -3012,8 +3010,6 @@ void IntFlowManager::clearSvcStatsCounters (const std::string& uuid,
 
 void IntFlowManager::handleUpdateSvcStatsFlows (const string& task_id)
 {
-    const std::lock_guard<mutex> lock(svcStatMutex);
-
     bool is_svc = strcmp(task_id.substr(0,1).c_str(),"1") == 0;
     bool is_add = strcmp(task_id.substr(1,1).c_str(),"1") == 0;
     const string& uuid = task_id.substr(2);
@@ -3849,6 +3845,7 @@ void IntFlowManager::updatePodSvcStatsFlows (const string &uuid,
         clearPodSvcStatsCounters("svctoep:"+uuid);
         idGen.erase(ID_NMSPC_SVCSTATS, "eptosvc:"+uuid);
         idGen.erase(ID_NMSPC_SVCSTATS, "svctoep:"+uuid);
+        const std::lock_guard<mutex> lock(svcStatMutex);
         podSvcUuidCkMap.erase(uuid);
     };
 
@@ -3900,6 +3897,7 @@ void IntFlowManager::updatePodSvcStatsFlows (const string &uuid,
             }
         }
 
+        const std::lock_guard<mutex> lock(svcStatMutex);
         const string& ingStr = "eptosvc:"+uuid;
         const string& egrStr = "svctoep:"+uuid;
         auto itr = podSvcUuidCkMap.find(uuid);

--- a/agent-ovs/ovs/SecGrpStatsManager.cpp
+++ b/agent-ovs/ovs/SecGrpStatsManager.cpp
@@ -81,24 +81,26 @@ void SecGrpStatsManager::on_timer(const error_code& ec) {
     TableState::cookie_callback_t cb_func;
     cb_func = [this](uint64_t cookie, uint16_t priority,
                      const struct match& match) {
+        const std::lock_guard<std::mutex> lock(pstatMtx);
         updateFlowEntryMap(secGrpInState, cookie, priority, match);
     };
 
     // Request Switch Manager to provide flow entries
     {
-        std::lock_guard<std::mutex> lock(pstatMtx);
         switchManager.
             forEachCookieMatch(AccessFlowManager::SEC_GROUP_IN_TABLE_ID,
                                cb_func);
 
         cb_func = [this](uint64_t cookie, uint16_t priority,
                          const struct match& match) {
+            const std::lock_guard<std::mutex> lock(pstatMtx);
             updateFlowEntryMap(secGrpOutState, cookie, priority, match);
         };
         switchManager.
             forEachCookieMatch(AccessFlowManager::SEC_GROUP_OUT_TABLE_ID,
                                cb_func);
 
+        const std::lock_guard<std::mutex> lock(pstatMtx);
         PolicyCounterMap_t newClassCountersMap1;
         PolicyCounterMap_t newClassCountersMap2;
         on_timer_base(ec, secGrpInState, newClassCountersMap1);

--- a/agent-ovs/ovs/ServiceStatsManager.cpp
+++ b/agent-ovs/ovs/ServiceStatsManager.cpp
@@ -66,17 +66,18 @@ void ServiceStatsManager::update_state (const error_code& ec)
         TableState::cookie_callback_t cb_func;
         cb_func = [this](uint64_t cookie, uint16_t priority,
                          const struct match& match) {
+            const std::lock_guard<std::mutex> lock(pstatMtx);
             updateFlowEntryMap(statsState, cookie, priority, match);
         };
 
         // Pod <--> Svc and * <--> svc-tgt stats handling based
         // on flows in STATS table
-        std::lock_guard<std::mutex> lock(pstatMtx);
 
         // create flowcountermap entries for new flows
         switchManager.forEachCookieMatch(IntFlowManager::STATS_TABLE_ID,
                                          cb_func);
 
+        const std::lock_guard<std::mutex> lock(pstatMtx);
         // aggregate statsCounterMap based on FlowCounterState
         ServiceCounterMap_t statsCountersMap;
         on_timer_base(ec, statsState, statsCountersMap);
@@ -91,16 +92,17 @@ void ServiceStatsManager::update_state (const error_code& ec)
         TableState::cookie_callback_t cb_func;
         cb_func = [this](uint64_t cookie, uint16_t priority,
                          const struct match& match) {
+            const std::lock_guard<std::mutex> lock(pstatMtx);
             updateFlowEntryMap(svhState, cookie, priority, match);
         };
 
         // svc-tgt rx stats handling based on flows in SERVICE_NEXTHOP table
-        std::lock_guard<std::mutex> lock(pstatMtx);
 
         // create flowcountermap entries for new flows
         switchManager.forEachCookieMatch(IntFlowManager::SERVICE_NEXTHOP_TABLE_ID,
                                          cb_func);
 
+        const std::lock_guard<std::mutex> lock(pstatMtx);
         // aggregate statsCounterMap based on FlowCounterState
         ServiceCounterMap_t svhCountersMap;
         on_timer_base(ec, svhState, svhCountersMap);
@@ -114,16 +116,17 @@ void ServiceStatsManager::update_state (const error_code& ec)
         TableState::cookie_callback_t cb_func;
         cb_func = [this](uint64_t cookie, uint16_t priority,
                          const struct match& match) {
+            const std::lock_guard<std::mutex> lock(pstatMtx);
             updateFlowEntryMap(svrState, cookie, priority, match);
         };
 
         // svc-tgt tx stats handling based on flows in SERVICE_REV table
-        std::lock_guard<std::mutex> lock(pstatMtx);
 
         // create flowcountermap entries for new flows
         switchManager.forEachCookieMatch(IntFlowManager::SERVICE_REV_TABLE_ID,
                                          cb_func);
 
+        const std::lock_guard<std::mutex> lock(pstatMtx);
         // aggregate svrCounterMap based on FlowCounterState
         ServiceCounterMap_t svrCountersMap;
         on_timer_base(ec, svrState, svrCountersMap);

--- a/agent-ovs/ovs/TableDropStatsManager.cpp
+++ b/agent-ovs/ovs/TableDropStatsManager.cpp
@@ -279,6 +279,7 @@ void BaseTableDropStatsManager::on_timer(const boost::system::error_code& ec) {
         TableState::cookie_callback_t cb_func;
         cb_func = [this, tbl_it](uint64_t cookie, uint16_t priority,
                          const struct match& match) {
+            const std::lock_guard<std::mutex> lock(pstatMtx);
             updateDropFlowStatsCounters(
                     CurrentDropCounterState[tbl_it.first], cookie, priority,
                    match);
@@ -286,9 +287,9 @@ void BaseTableDropStatsManager::on_timer(const boost::system::error_code& ec) {
 
         // Request Switch Manager to provide flow entries
         {
-            std::lock_guard<std::mutex> lock(pstatMtx);
             switchManager.forEachCookieMatch(tbl_it.first,
                                              cb_func);
+            const std::lock_guard<std::mutex> lock(pstatMtx);
             on_timer_base(ec, CurrentDropCounterState[tbl_it.first],
                             TableDropCounterState[tbl_it.first]);
 


### PR DESCRIPTION
1) Triangular deadlock
Scenario:
Svc Stats thread:
Holds switch manager mutex (sm_mutex) and sends barrier message to OVS and is stuck to get a response.
CondVar needs to be notified by sw connection thread.
Due to this all flow CRUD stalls.

Agent thread:
During contract/table-drop timer kickoff, it holds pstatMtx (to protect while going through all tables and collects stats from flows).
It is blocked while trying to acquire switch manager mutex.... (which is needed to protect flow writes)

Switch Connection thread:
Tries to acquire pstatMtx during stats response, and is stuck
It wont be able to send condVar notify to unblock svc stats thread since it doesnt get a chance to service barrier response.....

Fix:
Unfortunately not detected by tsan. The fix is to break the cycle by making the lock order static.
i.e. "sm_mutex --> pstatMtx"

2) Optimization: Reduce critical section of svcStatsMutex. Both stats CRUD and collection handling are done by Svc Stats thread. Reducing the critical section just to protect cookie podsvc map.

3) Protecting idgen maps during cleanup timer that does garbage collection (every 360 seconds)

Tested the changes on fab3 - both ns and ew data path tests pass consistently. A few times I did notice missing service files in worker nodes. This needs to be tracked and debugged separately.

Tested 160 services and pods in fab1. It took a min and 40 sec for this config to be fully up. Extra pod+service was instantaneously up. Reboot + new pod+service was up instantaneously.

Signed-off-by: Gautam Venkataramanan <gautam.chennai@gmail.com>