### PR TITLE
Protect ep_map while updating ep counters

### DIFF
--- a/agent-ovs/lib/EndpointManager.cpp
+++ b/agent-ovs/lib/EndpointManager.cpp
@@ -1448,6 +1448,7 @@ void EndpointManager::updateEndpointCounters(const std::string& uuid,
 
     mutator.commit();
 #ifdef HAVE_PROMETHEUS_SUPPORT
+    lock_guard<mutex> guard(ep_mutex);
     ep_map_t::iterator it = ep_map.find(uuid);
     if (it != ep_map.end()) {
         EndpointState& es = it->second;


### PR DESCRIPTION
WARNING: ThreadSanitizer: data race (pid=29448)
  Write of size 8 at 0x7b4400040100 by thread T16 (mutexes: write M1154):
    #0 operator delete(void*) <null> (libtsan.so.0+0x75b31)
    #1 std::_Hashtable<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, opflexagent::EndpointManager::EndpointState>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, opflexagent::EndpointManager::EndpointState> >, std::__detail::_Select1st, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true> >::_M_rehash(unsigned long, unsigned long const&) <null> (libopflex_agent.so.0+0x1b7d2f)
    #2 std::_Hashtable<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, opflexagent::EndpointManager::EndpointState>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, opflexagent::EndpointManager::EndpointState> >, std::__detail::_Select1st, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true> >::_M_insert_unique_node(unsigned long, unsigned long, std::__detail::_Hash_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, opflexagent::EndpointManager::EndpointState>, true>*, unsigned long) <null> (libopflex_agent.so.0+0x1bd4d6)
    #3 std::__detail::_Map_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, opflexagent::EndpointManager::EndpointState>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, opflexagent::EndpointManager::EndpointState> >, std::__detail::_Select1st, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true>, true>::operator[](std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) <null> (libopflex_agent.so.0+0x1bd77f)
    #4 opflexagent::EndpointManager::updateEndpoint(opflexagent::Endpoint const&) <null> (libopflex_agent.so.0+0x1a6a48)
    #5 opflexagent::EndpointSource::updateEndpoint(opflexagent::Endpoint const&) <null> (libopflex_agent.so.0+0x1d9f2a)
    #6 opflexagent::FSEndpointSource::updated(boost::filesystem::path const&) <null> (libopflex_agent.so.0+0x1e2467)

  Previous read of size 8 at 0x7b4400040100 by thread T12 (mutexes: write M402926635977816456):
    #2 opflexagent::EndpointManager::updateEndpointCounters(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, opflexagent::EpCounters&) <null> (libopflex_agent.so.0+0x19b594)
    #3 opflexagent::InterfaceStatsManager::updateEndpointCounters(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, opflexagent::SwitchConnection*, opflexagent::EpCounters&) <null> (libopflex_agent_renderer_openvswitch.so+0x1c99eb)
    #4 opflexagent::InterfaceStatsManager::Handle(opflexagent::SwitchConnection*, int, ofpbuf*, ofputil_flow_removed*) <null> (libopflex_agent_renderer_openvswitch.so+0x1c9fd5)
    #5 opflexagent::SwitchConnection::receiveOFMessage() <null> (libopflex_agent_renderer_openvswitch.so+0x1a121b)
    #6 opflexagent::SwitchConnection::Monitor() <null> (libopflex_agent_renderer_openvswitch.so+0x1a40d8)
    #7 opflexagent::SwitchConnection::operator()() <null> (libopflex_agent_renderer_openvswitch.so+0x1a5bf5)

Signed-off-by: Gautam Venkataramanan <gautam.chennai@gmail.com>