### PR TITLE
Support for modb counts in opflex-agent

### DIFF
--- a/agent-ovs/lib/AgentPrometheusManager.cpp
+++ b/agent-ovs/lib/AgentPrometheusManager.cpp
@@ -26,6 +26,7 @@ using std::size_t;
 using std::to_string;
 using namespace prometheus::detail;
 using boost::split;
+using namespace modelgbp::observer;
 
 static string ep_family_names[] =
 {
@@ -155,14 +156,30 @@ static string ofpeer_family_help[] =
   "number of policies requested by the agent which aren't yet resolved by opflex peer"
 };
 
-static string remote_ep_family_names[] =
+static string modb_count_family_names[] =
 {
-  "opflex_remote_endpoint_count"
+  "opflex_total_ep_local",
+  "opflex_total_ep_remote",
+  "opflex_total_ep_ext",
+  "opflex_total_epg",
+  "opflex_total_ext_intf",
+  "opflex_total_rd",
+  "opflex_total_service",
+  "opflex_total_contract",
+  "opflex_total_sg"
 };
 
-static string remote_ep_family_help[] =
+static string modb_count_family_help[] =
 {
-  "number of remote endpoints under the same uplink port"
+  "number of local endpoints",
+  "number of remote endpoints under the same uplink port",
+  "number of external endpoints",
+  "number of endpoint groups",
+  "number of external interfaces",
+  "number of routing domains",
+  "number of services",
+  "number of contracts",
+  "number of security groups"
 };
 
 static string rddrop_family_names[] =
@@ -225,8 +242,6 @@ AgentPrometheusManager::AgentPrometheusManager(Agent &agent_,
                                              PrometheusManager(),
                                              agent(agent_),
                                              framework(fwk_),
-                                             gauge_ep_total{0},
-                                             gauge_svc_total{0},
                                              exposeEpSvcNan{false}
 {
     //Init state to avoid coverty warnings
@@ -374,10 +389,10 @@ void AgentPrometheusManager::removeDynamicGauges ()
         removeDynamicGaugeOFPeer();
     }
 
-    // Remove RemoteEp related gauges
+    // Remove MoDBCounts related gauges
     {
-        const lock_guard<mutex> lock(remote_ep_mutex);
-        removeDynamicGaugeRemoteEp();
+        const lock_guard<mutex> lock(modb_count_mutex);
+        removeDynamicGaugeMoDBCount();
     }
 
     // Remove RDDropCounter related gauges
@@ -496,26 +511,26 @@ void AgentPrometheusManager::createStaticGaugeFamiliesSGClassifier (void)
     }
 }
 
-// create all RemoteEp specific gauge families during start
-void AgentPrometheusManager::createStaticGaugeFamiliesRemoteEp (void)
+// create all MoDBCount specific gauge families during start
+void AgentPrometheusManager::createStaticGaugeFamiliesMoDBCount (void)
 {
     // add a new gauge family to the registry (families combine values with the
     // same name, but distinct label dimensions)
     // Note: There is a unique ptr allocated and referencing the below reference
     // during Register().
 
-    for (REMOTE_EP_METRICS metric=REMOTE_EP_METRICS_MIN;
-            metric <= REMOTE_EP_METRICS_MAX;
-                metric = REMOTE_EP_METRICS(metric+1)) {
-        auto& gauge_remote_ep_family = BuildGauge()
-                             .Name(remote_ep_family_names[metric])
-                             .Help(remote_ep_family_help[metric])
+    for (MODB_COUNT_METRICS metric=MODB_COUNT_METRICS_MIN;
+            metric <= MODB_COUNT_METRICS_MAX;
+                metric = MODB_COUNT_METRICS(metric+1)) {
+        auto& gauge_modb_count_family = BuildGauge()
+                             .Name(modb_count_family_names[metric])
+                             .Help(modb_count_family_help[metric])
                              .Labels({})
                              .Register(*registry_ptr);
-        gauge_remote_ep_family_ptr[metric] = &gauge_remote_ep_family;
+        gauge_modb_count_family_ptr[metric] = &gauge_modb_count_family;
 
         // metrics per family will be created later
-        remote_ep_gauge_map[metric] = nullptr;
+        modb_count_gauge_map[metric] = nullptr;
     }
 }
 
@@ -546,14 +561,6 @@ void AgentPrometheusManager::createStaticGaugeFamiliesEp (void)
     // same name, but distinct label dimensions)
     // Note: There is a unique ptr allocated and referencing the below reference
     // during Register().
-
-    auto& gauge_ep_total_family = BuildGauge()
-                         .Name("opflex_endpoint_active_total")
-                         .Help("Total active local end point count")
-                         .Labels({})
-                         .Register(*registry_ptr);
-    gauge_ep_total_family_ptr = &gauge_ep_total_family;
-
     for (EP_METRICS metric=EP_METRICS_MIN;
             metric < EP_METRICS_MAX;
                 metric = EP_METRICS(metric+1)) {
@@ -593,14 +600,6 @@ void AgentPrometheusManager::createStaticGaugeFamiliesSvc (void)
     // same name, but distinct label dimensions)
     // Note: There is a unique ptr allocated and referencing the below reference
     // during Register().
-
-    auto& gauge_svc_total_family = BuildGauge()
-                         .Name("opflex_svc_active_total")
-                         .Help("Total active service count")
-                         .Labels({})
-                         .Register(*registry_ptr);
-    gauge_svc_total_family_ptr = &gauge_svc_total_family;
-
     for (SVC_METRICS metric=SVC_METRICS_MIN;
             metric <= SVC_METRICS_MAX;
                 metric = SVC_METRICS(metric+1)) {
@@ -701,8 +700,8 @@ void AgentPrometheusManager::createStaticGaugeFamilies (void)
     }
 
     {
-        const lock_guard<mutex> lock(remote_ep_mutex);
-        createStaticGaugeFamiliesRemoteEp();
+        const lock_guard<mutex> lock(modb_count_mutex);
+        createStaticGaugeFamiliesMoDBCount();
     }
 
     {
@@ -723,66 +722,9 @@ void AgentPrometheusManager::createStaticGaugeFamilies (void)
     }
 }
 
-// create EpCounter gauges during start
-void AgentPrometheusManager::createStaticGaugesEp ()
-{
-    auto& gauge_ep_total = gauge_ep_total_family_ptr->Add({});
-    gauge_ep_total_ptr = &gauge_ep_total;
-}
-
-// create SvcCounter gauges during start
-void AgentPrometheusManager::createStaticGaugesSvc ()
-{
-    auto& gauge_svc_total = gauge_svc_total_family_ptr->Add({});
-    gauge_svc_total_ptr = &gauge_svc_total;
-}
-
-// create gauges during start
-void AgentPrometheusManager::createStaticGauges ()
-{
-    // EpCounter related gauges
-    {
-        const lock_guard<mutex> lock(ep_counter_mutex);
-        createStaticGaugesEp();
-    }
-
-    // SvcCounter related gauges
-    {
-        const lock_guard<mutex> lock(svc_counter_mutex);
-        createStaticGaugesSvc();
-    }
-}
-
-// remove ep gauges during stop
-void AgentPrometheusManager::removeStaticGaugesEp ()
-{
-    gauge_ep_total_family_ptr->Remove(gauge_ep_total_ptr);
-    gauge_ep_total_ptr = nullptr;
-    gauge_ep_total = 0;
-}
-
-// remove svc gauges during stop
-void AgentPrometheusManager::removeStaticGaugesSvc ()
-{
-    gauge_svc_total_family_ptr->Remove(gauge_svc_total_ptr);
-    gauge_svc_total_ptr = nullptr;
-    gauge_svc_total = 0;
-}
-
 // remove gauges during stop
 void AgentPrometheusManager::removeStaticGauges ()
 {
-
-    // Remove EpCounter related gauge metrics
-    {
-        const lock_guard<mutex> lock(ep_counter_mutex);
-        removeStaticGaugesEp();
-    }
-    // Remove SvcCounter related gauge metrics
-    {
-        const lock_guard<mutex> lock(svc_counter_mutex);
-        removeStaticGaugesSvc();
-    }
     // Remove TableDropCounter related gauges
     removeStaticGaugesTableDrop();
 
@@ -818,7 +760,6 @@ void AgentPrometheusManager::start (bool exposeLocalHostOnly, bool exposeEpSvcNa
 
     // Add static metrics
     createStaticCounters();
-    createStaticGauges();
 
     // ask the exposer to scrape the registry on incoming scrapes
     exposer_ptr->RegisterCollectable(registry_ptr);
@@ -836,10 +777,8 @@ void AgentPrometheusManager::init ()
         const lock_guard<mutex> lock(ep_counter_mutex);
         counter_ep_create_ptr = nullptr;
         counter_ep_remove_ptr = nullptr;
-        gauge_ep_total_ptr = nullptr;
         counter_ep_create_family_ptr = nullptr;
         counter_ep_remove_family_ptr = nullptr;
-        gauge_ep_total_family_ptr = nullptr;
         for (EP_METRICS metric=EP_METRICS_MIN;
                 metric < EP_METRICS_MAX;
                     metric = EP_METRICS(metric+1)) {
@@ -860,10 +799,8 @@ void AgentPrometheusManager::init ()
         const lock_guard<mutex> lock(svc_counter_mutex);
         counter_svc_create_ptr = nullptr;
         counter_svc_remove_ptr = nullptr;
-        gauge_svc_total_ptr = nullptr;
         counter_svc_create_family_ptr = nullptr;
         counter_svc_remove_family_ptr = nullptr;
-        gauge_svc_total_family_ptr = nullptr;
         for (SVC_METRICS metric=SVC_METRICS_MIN;
                 metric <= SVC_METRICS_MAX;
                     metric = SVC_METRICS(metric+1)) {
@@ -890,12 +827,12 @@ void AgentPrometheusManager::init ()
     }
 
     {
-        const lock_guard<mutex> lock(remote_ep_mutex);
-        for (REMOTE_EP_METRICS metric=REMOTE_EP_METRICS_MIN;
-                metric <= REMOTE_EP_METRICS_MAX;
-                    metric = REMOTE_EP_METRICS(metric+1)) {
-            gauge_remote_ep_family_ptr[metric] = nullptr;
-            remote_ep_gauge_map[metric] = nullptr;
+        const lock_guard<mutex> lock(modb_count_mutex);
+        for (MODB_COUNT_METRICS metric=MODB_COUNT_METRICS_MIN;
+                metric <= MODB_COUNT_METRICS_MAX;
+                    metric = MODB_COUNT_METRICS(metric+1)) {
+            gauge_modb_count_family_ptr[metric] = nullptr;
+            modb_count_gauge_map[metric] = nullptr;
         }
     }
 
@@ -979,15 +916,6 @@ void AgentPrometheusManager::incStaticCounterEpRemove ()
     counter_ep_remove_ptr->Increment();
 }
 
-// track total ep count
-void AgentPrometheusManager::updateStaticGaugeEpTotal (bool add)
-{
-    if (add)
-        gauge_ep_total_ptr->Set(++gauge_ep_total);
-    else
-        gauge_ep_total_ptr->Set(--gauge_ep_total);
-}
-
 // Increment Svc count
 void AgentPrometheusManager::incStaticCounterSvcCreate ()
 {
@@ -998,15 +926,6 @@ void AgentPrometheusManager::incStaticCounterSvcCreate ()
 void AgentPrometheusManager::incStaticCounterSvcRemove ()
 {
     counter_svc_remove_ptr->Increment();
-}
-
-// track total svc count
-void AgentPrometheusManager::updateStaticGaugeSvcTotal (bool add)
-{
-    if (add)
-        gauge_svc_total_ptr->Set(++gauge_svc_total);
-    else
-        gauge_svc_total_ptr->Set(--gauge_svc_total);
 }
 
 // Create OFPeerStats gauge given metric type, peer (IP,port) tuple
@@ -1230,18 +1149,18 @@ string AgentPrometheusManager::stringizeClassifier (const string& tenant,
     return compressed;
 }
 
-// Create RemoteEp gauge given metric type
-void AgentPrometheusManager::createDynamicGaugeRemoteEp (REMOTE_EP_METRICS metric)
+// Create MoDBCount gauge given metric type
+void AgentPrometheusManager::createDynamicGaugeMoDBCount (MODB_COUNT_METRICS metric)
 {
     // Retrieve the Gauge if its already created
-    if (getDynamicGaugeRemoteEp(metric))
+    if (getDynamicGaugeMoDBCount(metric))
         return;
 
-    LOG(DEBUG) << "creating remote ep dyn gauge family"
+    LOG(DEBUG) << "creating MoDB Count dyn gauge family"
                << " metric: " << metric;
 
-    auto& gauge = gauge_remote_ep_family_ptr[metric]->Add({});
-    remote_ep_gauge_map[metric] = &gauge;
+    auto& gauge = gauge_modb_count_family_ptr[metric]->Add({});
+    modb_count_gauge_map[metric] = &gauge;
 }
 
 // Create RDDropCounter gauge given metric type, rdURI
@@ -1770,10 +1689,10 @@ Gauge * AgentPrometheusManager::getDynamicGaugeSGClassifier (SGCLASSIFIER_METRIC
     return pgauge;
 }
 
-// Get RemoteEp gauge given the metric
-Gauge * AgentPrometheusManager::getDynamicGaugeRemoteEp (REMOTE_EP_METRICS metric)
+// Get MoDBCount gauge given the metric
+Gauge * AgentPrometheusManager::getDynamicGaugeMoDBCount (MODB_COUNT_METRICS metric)
 {
-    return remote_ep_gauge_map[metric];
+    return modb_count_gauge_map[metric];
 }
 
 // Get RDDropCounter gauge given the metric, rdURI
@@ -1959,26 +1878,26 @@ void AgentPrometheusManager::removeDynamicGaugeSGClassifier ()
     }
 }
 
-// Remove dynamic RemoteEp gauge given a metic type
-bool AgentPrometheusManager::removeDynamicGaugeRemoteEp (REMOTE_EP_METRICS metric)
+// Remove dynamic MoDBCount gauge given a metic type
+bool AgentPrometheusManager::removeDynamicGaugeMoDBCount (MODB_COUNT_METRICS metric)
 {
-    Gauge *pgauge = getDynamicGaugeRemoteEp(metric);
+    Gauge *pgauge = getDynamicGaugeMoDBCount(metric);
     if (pgauge) {
-        gauge_remote_ep_family_ptr[metric]->Remove(pgauge);
+        gauge_modb_count_family_ptr[metric]->Remove(pgauge);
     } else {
-        LOG(TRACE) << "remove dynamic gauge RemoteEp not found";
+        LOG(TRACE) << "remove dynamic gauge MoDBCount not found; metric:" << metric;
         return false;
     }
     return true;
 }
 
-// Remove dynamic RemoteEp gauges for all metrics
-void AgentPrometheusManager::removeDynamicGaugeRemoteEp ()
+// Remove dynamic MoDBCount gauges for all metrics
+void AgentPrometheusManager::removeDynamicGaugeMoDBCount ()
 {
-    for (REMOTE_EP_METRICS metric=REMOTE_EP_METRICS_MIN;
-            metric <= REMOTE_EP_METRICS_MAX;
-                metric = REMOTE_EP_METRICS(metric+1)) {
-        removeDynamicGaugeRemoteEp(metric);
+    for (MODB_COUNT_METRICS metric=MODB_COUNT_METRICS_MIN;
+            metric <= MODB_COUNT_METRICS_MAX;
+                metric = MODB_COUNT_METRICS(metric+1)) {
+        removeDynamicGaugeMoDBCount(metric);
     }
 }
 
@@ -2226,7 +2145,6 @@ void AgentPrometheusManager::removeDynamicGaugeEp (EP_METRICS metric)
 
         if (metric == (EP_METRICS_MAX-1)) {
             incStaticCounterEpRemove();
-            updateStaticGaugeEpTotal(false);
         }
     }
 
@@ -2317,13 +2235,13 @@ void AgentPrometheusManager::removeStaticGaugeFamiliesSGClassifier ()
     }
 }
 
-// Remove all statically allocated RemoteEp gauge families
-void AgentPrometheusManager::removeStaticGaugeFamiliesRemoteEp ()
+// Remove all statically allocated MoDBCount gauge families
+void AgentPrometheusManager::removeStaticGaugeFamiliesMoDBCount ()
 {
-    for (REMOTE_EP_METRICS metric=REMOTE_EP_METRICS_MIN;
-            metric <= REMOTE_EP_METRICS_MAX;
-                metric = REMOTE_EP_METRICS(metric+1)) {
-        gauge_remote_ep_family_ptr[metric] = nullptr;
+    for (MODB_COUNT_METRICS metric=MODB_COUNT_METRICS_MIN;
+            metric <= MODB_COUNT_METRICS_MAX;
+                metric = MODB_COUNT_METRICS(metric+1)) {
+        gauge_modb_count_family_ptr[metric] = nullptr;
     }
 }
 
@@ -2350,7 +2268,6 @@ void AgentPrometheusManager::removeStaticGaugeFamiliesPodSvc()
 // Remove all statically allocated ep gauge families
 void AgentPrometheusManager::removeStaticGaugeFamiliesEp()
 {
-    gauge_ep_total_family_ptr = nullptr;
     for (EP_METRICS metric=EP_METRICS_MIN;
             metric < EP_METRICS_MAX;
                 metric = EP_METRICS(metric+1)) {
@@ -2371,7 +2288,6 @@ void AgentPrometheusManager::removeStaticGaugeFamiliesSvcTarget()
 // Remove all statically allocated svc gauge families
 void AgentPrometheusManager::removeStaticGaugeFamiliesSvc()
 {
-    gauge_svc_total_family_ptr = nullptr;
     for (SVC_METRICS metric=SVC_METRICS_MIN;
             metric <= SVC_METRICS_MAX;
                 metric = SVC_METRICS(metric+1)) {
@@ -2422,10 +2338,10 @@ void AgentPrometheusManager::removeStaticGaugeFamilies()
         removeStaticGaugeFamiliesOFPeer();
     }
 
-    // RemoteEp specific
+    // MoDBCount specific
     {
-        const lock_guard<mutex> lock(remote_ep_mutex);
-        removeStaticGaugeFamiliesRemoteEp();
+        const lock_guard<mutex> lock(modb_count_mutex);
+        removeStaticGaugeFamiliesMoDBCount();
     }
 
     // RDDropCounter specific
@@ -2784,7 +2700,6 @@ void AgentPrometheusManager::incSvcCounter (void)
     RETURN_IF_DISABLED
     const lock_guard<mutex> lock(svc_counter_mutex);
     incStaticCounterSvcCreate();
-    updateStaticGaugeSvcTotal(true);
 }
 
 /* Function called from ServiceManager to decrement service count */
@@ -2793,23 +2708,62 @@ void AgentPrometheusManager::decSvcCounter (void)
     RETURN_IF_DISABLED
     const lock_guard<mutex> lock(svc_counter_mutex);
     incStaticCounterSvcRemove();
-    updateStaticGaugeSvcTotal(false);
 }
 
-/* Function called from EndpointManager to create/update RemoteEp count */
-void AgentPrometheusManager::addNUpdateRemoteEpCount (size_t count)
+/* Function to create/update MoDB counts */
+void AgentPrometheusManager::addNUpdateMoDBCounts (shared_ptr<ModbCounts> pCount)
 {
     RETURN_IF_DISABLED
-    const lock_guard<mutex> lock(remote_ep_mutex);
+    const lock_guard<mutex> lock(modb_count_mutex);
 
-    for (REMOTE_EP_METRICS metric=REMOTE_EP_METRICS_MIN;
-            metric <= REMOTE_EP_METRICS_MAX;
-                metric = REMOTE_EP_METRICS(metric+1)) {
-        // create the metric if its not present
-        createDynamicGaugeRemoteEp(metric);
-        Gauge *pgauge = getDynamicGaugeRemoteEp(metric);
-        if (pgauge)
-            pgauge->Set(static_cast<double>(count));
+    // create the metric if its not present
+    for (MODB_COUNT_METRICS metric=MODB_COUNT_METRICS_MIN;
+            metric <= MODB_COUNT_METRICS_MAX;
+                metric = MODB_COUNT_METRICS(metric+1))
+        createDynamicGaugeMoDBCount(metric);
+
+    for (MODB_COUNT_METRICS metric=MODB_COUNT_METRICS_MIN;
+            metric <= MODB_COUNT_METRICS_MAX;
+                metric = MODB_COUNT_METRICS(metric+1)) {
+        Gauge *pgauge = getDynamicGaugeMoDBCount(metric);
+        optional<uint64_t>   metric_opt;
+        switch (metric) {
+        case MODB_COUNT_EP_LOCAL:
+            metric_opt = pCount->getLocalEP();
+            break;
+        case MODB_COUNT_EP_REMOTE:
+            metric_opt = pCount->getRemoteEP();
+            break;
+        case MODB_COUNT_EP_EXT:
+            metric_opt = pCount->getExtEP();
+            break;
+        case MODB_COUNT_EPG:
+            metric_opt = pCount->getEpg();
+            break;
+        case MODB_COUNT_EXT_INTF:
+            metric_opt = pCount->getExtIntfs();
+            break;
+        case MODB_COUNT_RD:
+            metric_opt = pCount->getRd();
+            break;
+        case MODB_COUNT_SERVICE:
+            metric_opt = pCount->getService();
+            break;
+        case MODB_COUNT_CONTRACT:
+            metric_opt = pCount->getContract();
+            break;
+        case MODB_COUNT_SG:
+            metric_opt = pCount->getSg();
+            break;
+        default:
+            LOG(WARNING) << "Unhandled modb count metric: " << metric;
+        }
+        if (metric_opt && pgauge)
+            pgauge->Set(static_cast<double>(metric_opt.get()));
+        if (!pgauge) {
+            LOG(WARNING) << "Invalid modb count update";
+            break;
+        }
     }
 }
 
@@ -2981,7 +2935,6 @@ void AgentPrometheusManager::addNUpdateEpCounter (const string& uuid,
 
         if (metric == (EP_METRICS_MAX-1)) {
             incStaticCounterEpCreate();
-            updateStaticGaugeEpTotal(true);
         }
     }
 
@@ -3125,8 +3078,21 @@ void AgentPrometheusManager::removeEpCounter (const string& uuid,
 
         if (metric == (EP_METRICS_MAX-1)) {
             incStaticCounterEpRemove();
-            updateStaticGaugeEpTotal(false);
         }
+    }
+}
+
+// Function to remove MoDBCounts
+void AgentPrometheusManager::removeMoDBCounts ()
+{
+    RETURN_IF_DISABLED
+    LOG(DEBUG) << "Deleting MoDBCounts";
+    const lock_guard<mutex> lock(modb_count_mutex);
+    for (MODB_COUNT_METRICS metric=MODB_COUNT_METRICS_MIN;
+            metric <= MODB_COUNT_METRICS_MAX;
+                metric = MODB_COUNT_METRICS(metric+1)) {
+        if (!removeDynamicGaugeMoDBCount(metric))
+            break;
     }
 }
 

--- a/agent-ovs/lib/AgentPrometheusManager.cpp
+++ b/agent-ovs/lib/AgentPrometheusManager.cpp
@@ -172,7 +172,7 @@ static string modb_count_family_names[] =
 static string modb_count_family_help[] =
 {
   "number of local endpoints",
-  "number of remote endpoints under the same uplink port",
+  "number of remote endpoints",
   "number of external endpoints",
   "number of endpoint groups",
   "number of external interfaces",

--- a/agent-ovs/lib/EndpointManager.cpp
+++ b/agent-ovs/lib/EndpointManager.cpp
@@ -580,10 +580,6 @@ void EndpointManager::updateEndpointRemote(const opflex::modb::URI& uri) {
             }
         }
     }
-
-#ifdef HAVE_PROMETHEUS_SUPPORT
-    prometheusManager.addNUpdateRemoteEpCount(remote_ep_uuid_map.size());
-#endif
     guard.unlock();
     if (uuid)
         notifyRemoteListeners(uuid.get());

--- a/agent-ovs/lib/include/opflexagent/EndpointManager.h
+++ b/agent-ovs/lib/include/opflexagent/EndpointManager.h
@@ -345,6 +345,36 @@ public:
      */
     uint32_t getExtEncapId(const opflex::modb::URI& epgURI);
 
+    /**
+     * Get the total number of local endpoints
+     *
+     * @return total local EPs
+     */
+    size_t getEpCount() {
+        std::lock_guard<std::mutex> guard(ep_mutex);
+        return ep_map.size();
+    }
+
+    /**
+     * Get the total number of External endpoints
+     *
+     * @return total external EPs
+     */
+    size_t getEpExternalCount() {
+        std::lock_guard<std::mutex> guard(ep_mutex);
+        return ext_ep_map.size();
+    }
+
+    /**
+     * Get the total number of remote endpoints
+     *
+     * @return total remote EPs
+     */
+    size_t getEpRemoteCount() {
+        std::lock_guard<std::mutex> guard(ep_mutex);
+        return remote_ep_uuid_map.size();
+    }
+
 private:
     /**
      * Add or update the endpoint state with new information about an

--- a/agent-ovs/lib/include/opflexagent/PolicyManager.h
+++ b/agent-ovs/lib/include/opflexagent/PolicyManager.h
@@ -773,6 +773,57 @@ public:
      * Handle Subnets deletion
      */
     void deleteSubnets(const opflex::modb::URI& subnets);
+
+    /**
+     * Get the total number of contracts
+     *
+     * @return total contracts
+     */
+    size_t getContractCount() {
+        std::lock_guard<std::mutex> guard(state_mutex);
+        return contractMap.size();
+    }
+
+    /**
+     * Get the total number of security groups
+     *
+     * @return total security groups
+     */
+    size_t getSecGrpCount() {
+        std::lock_guard<std::mutex> guard(state_mutex);
+        return secGrpMap.size();
+    }
+
+    /**
+     * Get the total number of EPGs
+     *
+     * @return total EPGs
+     */
+    size_t getEPGCount() {
+        std::lock_guard<std::mutex> guard(state_mutex);
+        return group_map.size();
+    }
+
+    /**
+     * Get the total number of External Interfaces
+     *
+     * @return total External Interfaces
+     */
+    size_t getExtIntfCount() {
+        std::lock_guard<std::mutex> guard(state_mutex);
+        return ext_int_map.size();
+    }
+
+    /**
+     * Get the total number of Routing Domains
+     *
+     * @return total Routing Domains
+     */
+    size_t getRDCount() {
+        std::lock_guard<std::mutex> guard(state_mutex);
+        return rd_map.size();
+    }
+
 private:
     opflex::ofcore::OFFramework& framework;
     std::string opflexDomain;

--- a/agent-ovs/lib/include/opflexagent/ServiceManager.h
+++ b/agent-ovs/lib/include/opflexagent/ServiceManager.h
@@ -112,6 +112,16 @@ public:
     void getServicesByDomain(const opflex::modb::URI& domain,
                              /* out */ std::unordered_set<std::string>& servs);
 
+    /**
+     * Get the total number of Services
+     *
+     * @return total Service MODB objects
+     */
+    size_t getServiceCount() {
+        std::lock_guard<std::mutex> guard(serv_mutex);
+        return aserv_map.size();
+    }
+
 private:
     /**
      * Add or update the service state with new information about an

--- a/agent-ovs/lib/test/EndpointManager_test.cpp
+++ b/agent-ovs/lib/test/EndpointManager_test.cpp
@@ -706,8 +706,6 @@ BOOST_FIXTURE_TEST_CASE( fssource, FSEndpointFixture ) {
     const string cmd = "curl --proxy \"\" --compressed --silent http://127.0.0.1:9612/metrics 2>&1;";
     const string& output0 = BaseFixture::getOutputFromCommand(cmd);
     size_t pos = std::string::npos;
-    pos = output0.find("opflex_endpoint_active_total 0.000000");
-    BOOST_CHECK_NE(pos, std::string::npos);
     pos = output0.find("opflex_endpoint_created_total 0.000000");
     BOOST_CHECK_NE(pos, std::string::npos);
     pos = output0.find("opflex_endpoint_removed_total 0.000000");
@@ -722,8 +720,6 @@ BOOST_FIXTURE_TEST_CASE( fssource, FSEndpointFixture ) {
     agent.getEndpointManager().updateEndpointCounters(uuid1, counters);
 
     const string& output1 = BaseFixture::getOutputFromCommand(cmd);
-    pos = output1.find("opflex_endpoint_active_total 1.000000");
-    BOOST_CHECK_NE(pos, std::string::npos);
     pos = output1.find("opflex_endpoint_created_total 1.000000");
     BOOST_CHECK_NE(pos, std::string::npos);
     pos = output1.find("opflex_endpoint_removed_total 0.000000");
@@ -789,8 +785,6 @@ BOOST_FIXTURE_TEST_CASE( fssource, FSEndpointFixture ) {
     agent.getEndpointManager().updateEndpointCounters(uuid1, counters);
 
     const string& output2 = BaseFixture::getOutputFromCommand(cmd);
-    pos = output2.find("opflex_endpoint_active_total 1.000000");
-    BOOST_CHECK_NE(pos, std::string::npos);
     pos = output2.find("opflex_endpoint_created_total 1.000000");
     BOOST_CHECK_NE(pos, std::string::npos);
     pos = output2.find("opflex_endpoint_removed_total 0.000000");
@@ -857,8 +851,6 @@ BOOST_FIXTURE_TEST_CASE( fssource, FSEndpointFixture ) {
     WAIT_FOR(hasPolicyEntry<ReportedEpAttribute>(framework, epattr_1), 500);
 #ifdef HAVE_PROMETHEUS_SUPPORT
     const string& output3 = BaseFixture::getOutputFromCommand(cmd);
-    pos = output3.find("opflex_endpoint_active_total 0.000000");
-    BOOST_CHECK_NE(pos, std::string::npos);
     pos = output3.find("opflex_endpoint_created_total 1.000000");
     BOOST_CHECK_NE(pos, std::string::npos);
     pos = output3.find("opflex_endpoint_removed_total 1.000000");
@@ -871,8 +863,6 @@ BOOST_FIXTURE_TEST_CASE( fssource, FSEndpointFixture ) {
     agent.getEndpointManager().updateEndpointCounters(uuid3, counters);
 
     const string& output4 = BaseFixture::getOutputFromCommand(cmd);
-    pos = output4.find("opflex_endpoint_active_total 1.000000");
-    BOOST_CHECK_NE(pos, std::string::npos);
     pos = output4.find("opflex_endpoint_created_total 2.000000");
     BOOST_CHECK_NE(pos, std::string::npos);
     pos = output4.find("opflex_endpoint_removed_total 1.000000");
@@ -921,8 +911,6 @@ BOOST_FIXTURE_TEST_CASE( fssource, FSEndpointFixture ) {
     WAIT_FOR(hasPolicyEntry<ReportedEpAttribute>(framework, epattr_1), 500);
 #ifdef HAVE_PROMETHEUS_SUPPORT
     const string& output5 = BaseFixture::getOutputFromCommand(cmd);
-    pos = output5.find("opflex_endpoint_active_total 1.000000");
-    BOOST_CHECK_NE(pos, std::string::npos);
     pos = output5.find("opflex_endpoint_created_total 2.000000");
     BOOST_CHECK_NE(pos, std::string::npos);
     pos = output5.find("opflex_endpoint_removed_total 1.000000");
@@ -936,8 +924,6 @@ BOOST_FIXTURE_TEST_CASE( fssource, FSEndpointFixture ) {
     agent.getEndpointManager().updateEndpointCounters(uuid4, counters);
 
     const string& output6 = BaseFixture::getOutputFromCommand(cmd);
-    pos = output6.find("opflex_endpoint_active_total 2.000000");
-    BOOST_CHECK_NE(pos, std::string::npos);
     pos = output6.find("opflex_endpoint_created_total 3.000000");
     BOOST_CHECK_NE(pos, std::string::npos);
     pos = output6.find("opflex_endpoint_removed_total 1.000000");
@@ -968,8 +954,6 @@ BOOST_FIXTURE_TEST_CASE( fssource, FSEndpointFixture ) {
     WAIT_FOR(!hasPolicyEntry<ReportedEpAttribute>(framework, epattr_1), 500);
 #ifdef HAVE_PROMETHEUS_SUPPORT
     const string& output7 = BaseFixture::getOutputFromCommand(cmd);
-    pos = output7.find("opflex_endpoint_active_total 1.000000");
-    BOOST_CHECK_NE(pos, std::string::npos);
     pos = output7.find("opflex_endpoint_created_total 3.000000");
     BOOST_CHECK_NE(pos, std::string::npos);
     pos = output7.find("opflex_endpoint_removed_total 2.000000");
@@ -982,8 +966,6 @@ BOOST_FIXTURE_TEST_CASE( fssource, FSEndpointFixture ) {
     agent.getEndpointManager().updateEndpointCounters(uuid3, counters);
 
     const string& output8 = BaseFixture::getOutputFromCommand(cmd);
-    pos = output8.find("opflex_endpoint_active_total 1.000000");
-    BOOST_CHECK_NE(pos, std::string::npos);
     pos = output8.find("opflex_endpoint_created_total 3.000000");
     BOOST_CHECK_NE(pos, std::string::npos);
     pos = output8.find("opflex_endpoint_removed_total 2.000000");
@@ -1013,8 +995,6 @@ BOOST_FIXTURE_TEST_CASE( fssource, FSEndpointFixture ) {
     WAIT_FOR(!hasPolicyEntry<ReportedEpAttribute>(framework, epattr_1), 500);
 #ifdef HAVE_PROMETHEUS_SUPPORT
     const string& output9 = BaseFixture::getOutputFromCommand(cmd);
-    pos = output9.find("opflex_endpoint_active_total 0.000000");
-    BOOST_CHECK_NE(pos, std::string::npos);
     pos = output9.find("opflex_endpoint_created_total 3.000000");
     BOOST_CHECK_NE(pos, std::string::npos);
     pos = output9.find("opflex_endpoint_removed_total 3.000000");

--- a/agent-ovs/lib/test/ServiceManager_test.cpp
+++ b/agent-ovs/lib/test/ServiceManager_test.cpp
@@ -483,8 +483,6 @@ BOOST_FIXTURE_TEST_CASE(testCreateAnycast, ServiceManagerFixture) {
 #ifdef HAVE_PROMETHEUS_SUPPORT
     const string& output = BaseFixture::getOutputFromCommand(cmd);
     size_t pos = std::string::npos;
-    pos = output.find("opflex_svc_active_total 0.000000");
-    BOOST_CHECK_NE(pos, std::string::npos);
     pos = output.find("opflex_svc_created_total 0.000000");
     BOOST_CHECK_NE(pos, std::string::npos);
     pos = output.find("opflex_svc_removed_total 0.000000");
@@ -503,8 +501,6 @@ BOOST_FIXTURE_TEST_CASE(testCreateLB, ServiceManagerFixture) {
 #ifdef HAVE_PROMETHEUS_SUPPORT
     const string& output = BaseFixture::getOutputFromCommand(cmd);
     size_t pos = std::string::npos;
-    pos = output.find("opflex_svc_active_total 1.000000");
-    BOOST_CHECK_NE(pos, std::string::npos);
     pos = output.find("opflex_svc_created_total 1.000000");
     BOOST_CHECK_NE(pos, std::string::npos);
     pos = output.find("opflex_svc_removed_total 0.000000");
@@ -523,8 +519,6 @@ BOOST_FIXTURE_TEST_CASE(testCreateLBNodePort, ServiceManagerFixture) {
 #ifdef HAVE_PROMETHEUS_SUPPORT
     const string& output = BaseFixture::getOutputFromCommand(cmd);
     size_t pos = std::string::npos;
-    pos = output.find("opflex_svc_active_total 1.000000");
-    BOOST_CHECK_NE(pos, std::string::npos);
     pos = output.find("opflex_svc_created_total 1.000000");
     BOOST_CHECK_NE(pos, std::string::npos);
     pos = output.find("opflex_svc_removed_total 0.000000");
@@ -546,8 +540,6 @@ BOOST_FIXTURE_TEST_CASE(testUpdate, ServiceManagerFixture) {
 #ifdef HAVE_PROMETHEUS_SUPPORT
     const string& output1 = BaseFixture::getOutputFromCommand(cmd);
     size_t pos = std::string::npos;
-    pos = output1.find("opflex_svc_active_total 0.000000");
-    BOOST_CHECK_NE(pos, std::string::npos);
     pos = output1.find("opflex_svc_created_total 1.000000");
     BOOST_CHECK_NE(pos, std::string::npos);
     pos = output1.find("opflex_svc_removed_total 1.000000");
@@ -563,8 +555,6 @@ BOOST_FIXTURE_TEST_CASE(testUpdate, ServiceManagerFixture) {
     checkServiceExists(true, false, true);
     const string& output2 = BaseFixture::getOutputFromCommand(cmd);
     pos = std::string::npos;
-    pos = output2.find("opflex_svc_active_total 1.000000");
-    BOOST_CHECK_NE(pos, std::string::npos);
     pos = output2.find("opflex_svc_created_total 2.000000");
     BOOST_CHECK_NE(pos, std::string::npos);
     pos = output2.find("opflex_svc_removed_total 1.000000");
@@ -580,8 +570,6 @@ BOOST_FIXTURE_TEST_CASE(testUpdate, ServiceManagerFixture) {
     checkServiceExists(true, false, true);
     const string& output3 = BaseFixture::getOutputFromCommand(cmd);
     pos = std::string::npos;
-    pos = output3.find("opflex_svc_active_total 1.000000");
-    BOOST_CHECK_NE(pos, std::string::npos);
     pos = output3.find("opflex_svc_created_total 2.000000");
     BOOST_CHECK_NE(pos, std::string::npos);
     pos = output3.find("opflex_svc_removed_total 1.000000");
@@ -598,8 +586,6 @@ BOOST_FIXTURE_TEST_CASE(testUpdate, ServiceManagerFixture) {
     checkServiceExists(true, false, true);
     const string& output4 = BaseFixture::getOutputFromCommand(cmd);
     pos = std::string::npos;
-    pos = output4.find("opflex_svc_active_total 1.000000");
-    BOOST_CHECK_NE(pos, std::string::npos);
     pos = output4.find("opflex_svc_created_total 2.000000");
     BOOST_CHECK_NE(pos, std::string::npos);
     pos = output4.find("opflex_svc_removed_total 1.000000");
@@ -619,8 +605,6 @@ BOOST_FIXTURE_TEST_CASE(testDeleteLBNodePort, ServiceManagerFixture) {
 #ifdef HAVE_PROMETHEUS_SUPPORT
     const string& output1 = BaseFixture::getOutputFromCommand(cmd);
     size_t pos = std::string::npos;
-    pos = output1.find("opflex_svc_active_total 0.000000");
-    BOOST_CHECK_NE(pos, std::string::npos);
     pos = output1.find("opflex_svc_created_total 1.000000");
     BOOST_CHECK_NE(pos, std::string::npos);
     pos = output1.find("opflex_svc_removed_total 1.000000");
@@ -631,8 +615,6 @@ BOOST_FIXTURE_TEST_CASE(testDeleteLBNodePort, ServiceManagerFixture) {
     checkServiceExists(true);
 #ifdef HAVE_PROMETHEUS_SUPPORT
     const string& output2 = BaseFixture::getOutputFromCommand(cmd);
-    pos = output2.find("opflex_svc_active_total 1.000000");
-    BOOST_CHECK_NE(pos, std::string::npos);
     pos = output2.find("opflex_svc_created_total 2.000000");
     BOOST_CHECK_NE(pos, std::string::npos);
     pos = output2.find("opflex_svc_removed_total 1.000000");
@@ -643,8 +625,6 @@ BOOST_FIXTURE_TEST_CASE(testDeleteLBNodePort, ServiceManagerFixture) {
     checkServiceExists(false);
 #ifdef HAVE_PROMETHEUS_SUPPORT
     const string& output3 = BaseFixture::getOutputFromCommand(cmd);
-    pos = output3.find("opflex_svc_active_total 0.000000");
-    BOOST_CHECK_NE(pos, std::string::npos);
     pos = output3.find("opflex_svc_created_total 2.000000");
     BOOST_CHECK_NE(pos, std::string::npos);
     pos = output3.find("opflex_svc_removed_total 2.000000");
@@ -664,8 +644,6 @@ BOOST_FIXTURE_TEST_CASE(testDeleteLB, ServiceManagerFixture) {
 #ifdef HAVE_PROMETHEUS_SUPPORT
     const string& output1 = BaseFixture::getOutputFromCommand(cmd);
     size_t pos = std::string::npos;
-    pos = output1.find("opflex_svc_active_total 0.000000");
-    BOOST_CHECK_NE(pos, std::string::npos);
     pos = output1.find("opflex_svc_created_total 1.000000");
     BOOST_CHECK_NE(pos, std::string::npos);
     pos = output1.find("opflex_svc_removed_total 1.000000");
@@ -676,8 +654,6 @@ BOOST_FIXTURE_TEST_CASE(testDeleteLB, ServiceManagerFixture) {
     checkServiceExists(true);
 #ifdef HAVE_PROMETHEUS_SUPPORT
     const string& output2 = BaseFixture::getOutputFromCommand(cmd);
-    pos = output2.find("opflex_svc_active_total 1.000000");
-    BOOST_CHECK_NE(pos, std::string::npos);
     pos = output2.find("opflex_svc_created_total 2.000000");
     BOOST_CHECK_NE(pos, std::string::npos);
     pos = output2.find("opflex_svc_removed_total 1.000000");
@@ -688,8 +664,6 @@ BOOST_FIXTURE_TEST_CASE(testDeleteLB, ServiceManagerFixture) {
     checkServiceExists(false);
 #ifdef HAVE_PROMETHEUS_SUPPORT
     const string& output3 = BaseFixture::getOutputFromCommand(cmd);
-    pos = output3.find("opflex_svc_active_total 0.000000");
-    BOOST_CHECK_NE(pos, std::string::npos);
     pos = output3.find("opflex_svc_created_total 2.000000");
     BOOST_CHECK_NE(pos, std::string::npos);
     pos = output3.find("opflex_svc_removed_total 2.000000");
@@ -709,8 +683,6 @@ BOOST_FIXTURE_TEST_CASE(testDeleteAnycast, ServiceManagerFixture) {
 #ifdef HAVE_PROMETHEUS_SUPPORT
     const string& output1 = BaseFixture::getOutputFromCommand(cmd);
     size_t pos = std::string::npos;
-    pos = output1.find("opflex_svc_active_total 0.000000");
-    BOOST_CHECK_NE(pos, std::string::npos);
     pos = output1.find("opflex_svc_created_total 0.000000");
     BOOST_CHECK_NE(pos, std::string::npos);
     pos = output1.find("opflex_svc_removed_total 0.000000");
@@ -731,8 +703,6 @@ BOOST_FIXTURE_TEST_CASE(testCreateExternalLB, ServiceManagerFixture) {
     checkServiceExists(true, true);
     const string& output = BaseFixture::getOutputFromCommand(cmd);
     size_t pos = std::string::npos;
-    pos = output.find("opflex_svc_active_total 1.000000");
-    BOOST_CHECK_NE(pos, std::string::npos);
     pos = output.find("opflex_svc_created_total 1.000000");
     BOOST_CHECK_NE(pos, std::string::npos);
     pos = output.find("opflex_svc_removed_total 0.000000");
@@ -758,8 +728,6 @@ BOOST_FIXTURE_TEST_CASE(testUpdateExtLB, ServiceManagerFixture) {
 #ifdef HAVE_PROMETHEUS_SUPPORT
     const string& output1 = BaseFixture::getOutputFromCommand(cmd);
     size_t pos = std::string::npos;
-    pos = output1.find("opflex_svc_active_total 0.000000");
-    BOOST_CHECK_NE(pos, std::string::npos);
     pos = output1.find("opflex_svc_created_total 1.000000");
     BOOST_CHECK_NE(pos, std::string::npos);
     pos = output1.find("opflex_svc_removed_total 1.000000");
@@ -775,8 +743,6 @@ BOOST_FIXTURE_TEST_CASE(testUpdateExtLB, ServiceManagerFixture) {
     checkServiceExists(true, true, true);
     const string& output2 = BaseFixture::getOutputFromCommand(cmd);
     pos = std::string::npos;
-    pos = output2.find("opflex_svc_active_total 1.000000");
-    BOOST_CHECK_NE(pos, std::string::npos);
     pos = output2.find("opflex_svc_created_total 2.000000");
     BOOST_CHECK_NE(pos, std::string::npos);
     pos = output2.find("opflex_svc_removed_total 1.000000");
@@ -802,8 +768,6 @@ BOOST_FIXTURE_TEST_CASE(testDeleteExtLB, ServiceManagerFixture) {
     checkServiceExists(false, true);
     const string& output1 = BaseFixture::getOutputFromCommand(cmd);
     size_t pos = std::string::npos;
-    pos = output1.find("opflex_svc_active_total 0.000000");
-    BOOST_CHECK_NE(pos, std::string::npos);
     pos = output1.find("opflex_svc_created_total 1.000000");
     BOOST_CHECK_NE(pos, std::string::npos);
     pos = output1.find("opflex_svc_removed_total 1.000000");
@@ -816,8 +780,6 @@ BOOST_FIXTURE_TEST_CASE(testDeleteExtLB, ServiceManagerFixture) {
 #else
     checkServiceExists(true, true);
     const string& output2 = BaseFixture::getOutputFromCommand(cmd);
-    pos = output2.find("opflex_svc_active_total 1.000000");
-    BOOST_CHECK_NE(pos, std::string::npos);
     pos = output2.find("opflex_svc_created_total 2.000000");
     BOOST_CHECK_NE(pos, std::string::npos);
     pos = output2.find("opflex_svc_removed_total 1.000000");
@@ -830,8 +792,6 @@ BOOST_FIXTURE_TEST_CASE(testDeleteExtLB, ServiceManagerFixture) {
 #else
     checkServiceExists(false, true);
     const string& output3 = BaseFixture::getOutputFromCommand(cmd);
-    pos = output3.find("opflex_svc_active_total 0.000000");
-    BOOST_CHECK_NE(pos, std::string::npos);
     pos = output3.find("opflex_svc_created_total 2.000000");
     BOOST_CHECK_NE(pos, std::string::npos);
     pos = output3.find("opflex_svc_removed_total 2.000000");

--- a/agent-ovs/ovs/include/PolicyStatsManager.h
+++ b/agent-ovs/ovs/include/PolicyStatsManager.h
@@ -492,7 +492,8 @@ protected:
 
 private:
     bool handleFlowStats(ofpbuf *msg, const table_map_t& tableMap);
-
+    void updateOpflexPeerStats();
+    void updateMoDBCounts();
 };
 
 } /* namespace opflexagent */

--- a/agent-ovs/ovs/test/IntFlowManager_test.cpp
+++ b/agent-ovs/ovs/test/IntFlowManager_test.cpp
@@ -40,12 +40,6 @@
 #include "FlowBuilder.h"
 #include "ovs-shim.h"
 #include "eth.h"
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-#ifdef HAVE_PROMETHEUS_SUPPORT
-#include <opflexagent/PrometheusManager.h>
-#endif
 
 using namespace boost::assign;
 using namespace opflex::modb;
@@ -1526,13 +1520,6 @@ void BaseIntFlowManagerFixture::remoteEndpointTest() {
     initExpEp(ep2, epg0);
     initExpRemoteEp();
     WAIT_FOR_TABLES("remoteep", 500);
-#ifdef HAVE_PROMETHEUS_SUPPORT
-    const string cmd = "curl --proxy \"\" --compressed --silent http://127.0.0.1:9612/metrics 2>&1;";
-    const string& output1 = BaseFixture::getOutputFromCommand(cmd);
-    size_t pos = std::string::npos;
-    pos = output1.find("opflex_remote_endpoint_count 1.000000");
-    BOOST_CHECK_NE(pos, std::string::npos);
-#endif
 
     rep1->remove();
     m.commit();
@@ -1545,12 +1532,6 @@ void BaseIntFlowManagerFixture::remoteEndpointTest() {
     initExpEp(ep0, epg0);
     initExpEp(ep2, epg0);
     WAIT_FOR_TABLES("cleanup", 500);
-#ifdef HAVE_PROMETHEUS_SUPPORT
-    const string& output2 = BaseFixture::getOutputFromCommand(cmd);
-    pos = std::string::npos;
-    pos = output2.find("opflex_remote_endpoint_count 0.000000");
-    BOOST_CHECK_NE(pos, std::string::npos);
-#endif
 }
 
 BOOST_FIXTURE_TEST_CASE(remoteEndpoint_vxlan, VxlanIntFlowManagerFixture) {

--- a/genie/MODEL/SPECIFIC/OBSERVER/modbcounts.mdl
+++ b/genie/MODEL/SPECIFIC/OBSERVER/modbcounts.mdl
@@ -30,29 +30,14 @@ module[observer]
         # Total number of EPGs
         member[epg; type=scalar/UInt64]
 
-        # Total number of L3 Instp
-        member[l3Instp; type=scalar/UInt64]
-
-        # Total number of FDs
-        member[fd; type=scalar/UInt64]
-
-        # Total number of BDs
-        member[bd; type=scalar/UInt64]
+        # Total number of External Interfaces
+        member[extIntfs; type=scalar/UInt64]
 
         # Total number of RDs
         member[rd; type=scalar/UInt64]
 
-        # Total number of L3Outs
-        member[l3Out; type=scalar/UInt64]
-
-        # Total number of LoadBalancer Services
-        member[serviceLB; type=scalar/UInt64]
-
-        # Total number of NodePort Services
-        member[serviceNodePort; type=scalar/UInt64]
-
-        # Total number of ClusterIP Services
-        member[serviceClusterIP; type=scalar/UInt64]
+        # Total number of Services
+        member[service; type=scalar/UInt64]
 
         # Total number of Contracts
         member[contract; type=scalar/UInt64]


### PR DESCRIPTION
- Added support for modb counts per object type for few objects. More object counts can be added in future.
- Updated MoDBCount MO with what we display now.
- Removed redundant active_ep_count and active_svc_count.
- did some misc cleanup.
- added tests for modb counts

TODO:
Move OFPeer and MoBDCount updates to a new class (currently under PolicyStatsManager)
Remove created/removed counts of EP and SVC - customers can just use total ep and svc counts instead
Update Readme for new metrics
Update grafana db templates
Remove HAVE_PROMETHEUS_SUPPORT #define and configuration from agent

Signed-off-by: Gautam Venkataramanan <gautam.chennai@gmail.com>