### PR TITLE
Fix stale entries seen after deletion of service during make check tests

### DIFF
--- a/agent-ovs/ovs/IntFlowManager.cpp
+++ b/agent-ovs/ovs/IntFlowManager.cpp
@@ -3021,16 +3021,17 @@ void IntFlowManager::handleUpdateSvcStatsFlows (const string& task_id)
     updateSvcNodeStatsFlows(uuid, is_svc, is_add);
     updateSvcExtStatsFlows(uuid, is_svc, is_add);
 
-    if (is_svc && is_add) {
-        // Svc Stats flow programming happens in this low prio thread.
-        // SNAT/DNAT flows will be programmed initially from a different thread.
-        // It will get updated here if needed for stats to work.
-        ServiceManager& srvMgr = agent.getServiceManager();
-        shared_ptr<const Service> asWrapper = srvMgr.getService(uuid);
-        if (!asWrapper || !asWrapper->getDomainURI()) {
-            LOG(DEBUG) << "unable to get service from uuid";
-            return;
-        }
+    if (is_svc) {
+        // - SNAT/DNAT flows will be programmed initially from higher prio Agent thread.
+        // - This low prio Svc Stats thread today programs the flows with stats cookies
+        // later on so that snat/dnat flows become eventually consistent to correlate stats.
+        // - In case svc gets deleted, then agent io thread will delete svc flows immediately.
+        // Since svc stats thread is low priority, it could be in the process of updating
+        // SNAT/DNAT flows after agent thread deleted SNAT/DNAT flows. This can lead to
+        // stale snat/dnat flow entries for that svc.
+        // - To avoid these stale entries, call programServiceSnatDnatFlows() for the deleted
+        // svc so that the stale entries (if any) can be cleared for this service. If there
+        // are no stale entries (already deleted), then the below call is a NO-OP.
         programServiceSnatDnatFlows(uuid);
     } else {
         unordered_set<string> svcUuids;


### PR DESCRIPTION
Issue was happening once every few runs. But then it became unreproducible due to the way threads were scheduled. Tried 25+ times with the fix and things look good.

Description:
- SNAT/DNAT flows will be programmed initially from higher prio Agent thread.
- Low prio Svc Stats thread today programs the flows with stats cookies
later on so that snat/dnat flows become eventually consistent to correlate stats.
- In case svc gets deleted, then agent io thread will delete svc flows immediately.
Since svc stats thread is low priority, it could be in the process of updating
SNAT/DNAT flows after agent thread deleted SNAT/DNAT flows. This can lead to
stale snat/dnat flow entries for that svc.
- To avoid these stale entries, call programServiceSnatDnatFlows() for the deleted
svc so that the stale entries (if any) can be cleared for this service. If there
are no stale entries (already deleted), then the below call is a NO-OP.
- Also, when a svc is deleted, prior to the fix we were looping over list of svcs
to update snat/dnat flows. This loop is needed only for EP updates. For svc updates,
we just need to call programServiceSnatDnatFlows() only once for that svc.

Signed-off-by: Gautam Venkataramanan <gautam.chennai@gmail.com>