### PR TITLE
Reset learned peers only when server triggers fallback (#349)

### DIFF
--- a/agent-ovs/lib/EndpointManager.cpp
+++ b/agent-ovs/lib/EndpointManager.cpp
@@ -1571,7 +1571,7 @@ void EndpointManager::configUpdated(const URI& uri) {
 
     if (!config) {
         LOG(WARNING) << "Platform config has been deleted. Disconnect from existing peers and fallback to configured list";
-        framework.resetAllPeers();
+        framework.resetAllUnconfiguredPeers();
     }
 }
 } /* namespace opflexagent */

--- a/libopflex/engine/OpflexPool.cpp
+++ b/libopflex/engine/OpflexPool.cpp
@@ -304,11 +304,13 @@ void OpflexPool::doRemovePeer(const string& hostname, int port) {
     }
 }
 
-void OpflexPool::resetAllPeers() {
+void OpflexPool::resetAllUnconfiguredPeers() {
     const std::lock_guard<std::recursive_mutex> lock(conn_mutex);
     conn_map_t conns(connections);
     for (conn_map_t::value_type& v : conns) {
-        v.second.conn->close();
+        if (!isConfiguredPeer(v.first.first, v.first.second)) {
+            v.second.conn->close();
+        }
     }
 }
 
@@ -473,10 +475,9 @@ bool OpflexPool::isConfiguredPeer(const string& hostname, int port) {
 void OpflexPool::addConfiguredPeers() {
     const std::lock_guard<std::recursive_mutex> lock(conn_mutex);
     for (const peer_name_t& peer_name : configured_peers) {
-        addPeer(peer_name.first, peer_name.second, false);
+        addPeer(peer_name.first, peer_name.second, true);
     }
 }
-
 
 void OpflexPool::getOpflexPeerStats(std::unordered_map<string, std::shared_ptr<OFAgentStats>>& stats) {
     const std::lock_guard<std::recursive_mutex> lock(conn_mutex);

--- a/libopflex/engine/include/opflex/engine/internal/OpflexPool.h
+++ b/libopflex/engine/include/opflex/engine/internal/OpflexPool.h
@@ -198,7 +198,7 @@ public:
      */
     OpflexClientConnection* getPeer(const std::string& hostname, int port);
 
-    void resetAllPeers();
+    void resetAllUnconfiguredPeers();
           
     /**
      * A map of hostname and pending unresolved policies 

--- a/libopflex/include/opflex/ofcore/OFFramework.h
+++ b/libopflex/include/opflex/ofcore/OFFramework.h
@@ -890,7 +890,7 @@ public:
      * Disconnect from all current peers and use the configured
      * peer list to establish new peers.
      */
-     virtual void resetAllPeers();
+     virtual void resetAllUnconfiguredPeers();
 
     /**
      * Retrieve OpFlex client stats for each available peer

--- a/libopflex/ofcore/OFFramework.cpp
+++ b/libopflex/ofcore/OFFramework.cpp
@@ -254,11 +254,11 @@ modb::ObjectStore& OFFramework::getStore() {
     return pimpl->db;
 }
 
-void OFFramework::resetAllPeers() {
+void OFFramework::resetAllUnconfiguredPeers() {
     engine::internal::OpflexPool& pool = pimpl->processor.getPool();
     string location;
     pool.setLocation(location);
-    pool.resetAllPeers();
+    pool.resetAllUnconfiguredPeers();
     pool.addConfiguredPeers();
 }
 


### PR DESCRIPTION
Existing peers are closed asynchronously so disconnects
might be processed after the call to readd the configured
peers. In some cases this resulted in an agent with no peers.
Restarting the agent was the only way to recover

Changing to disconnect the learned peers only. Configured
peers do not need to be disconnected

Signed-off-by: Tom Flynn <tom.flynn@gmail.com>