### PR TITLE
Avoid invalid read when buffer is full

### DIFF
--- a/libopflex/comms/CommunicationPeer.cpp
+++ b/libopflex/comms/CommunicationPeer.cpp
@@ -190,9 +190,7 @@ void CommunicationPeer::readBufNoNull(char* buffer, size_t nread) {
         return;
     }
 
-    buffer[nread++] = '\0';
-
-    while ((--nread > 0) && connected_) {
+    while ((nread != 0 && --nread > 0) && connected_) {
         size_t chunk_size = readChunk(buffer);
         if (chunk_size == 0) {
             break;

--- a/libopflex/comms/transport/PlainText.cpp
+++ b/libopflex/comms/transport/PlainText.cpp
@@ -89,6 +89,10 @@ void Cb< PlainText >::on_read(uv_stream_t * h, ssize_t nread, uv_buf_t const * b
                 (buf->len > static_cast< size_t >(nread))
             );
         } else {
+            // add null terminator to indicate end of message
+            if (buf->len > (size_t)nread) {
+                buf->base[nread++] = '\0';
+            }
             peer->readBufNoNull(buf->base, nread);
         }
     }


### PR DESCRIPTION
nread is an unsigned value and was overflowing causing
buffer read issues
add null terminator at end only if full msg has been read

Signed-off-by: Tom Flynn <tom.flynn@gmail.com>