### PR TITLE
Remove conditional compilation of prometheus support

### DIFF
--- a/agent-ovs/lib/FSEndpointSource.cpp
+++ b/agent-ovs/lib/FSEndpointSource.cpp
@@ -28,9 +28,7 @@
 #include <opflexagent/Agent.h>
 #include <opflexagent/EndpointManager.h>
 #include <opflexagent/logging.h>
-#ifdef HAVE_PROMETHEUS_SUPPORT
 #include <opflexagent/PrometheusManager.h>
-#endif
 
 namespace opflexagent {
 
@@ -278,7 +276,6 @@ void FSEndpointSource::updated(const fs::path& filePath) {
             }
         }
 
-#ifdef HAVE_PROMETHEUS_SUPPORT
         optional<string> isOpenStack = properties.get_optional<string>(NEUTRON_NW);
         if (isOpenStack) {
             newep.setAnnotateEpName(true);
@@ -292,7 +289,6 @@ void FSEndpointSource::updated(const fs::path& filePath) {
                                             newep.getAttributes(),
                                             manager->getAgent().getPrometheusEpAttributes()));
         }
-#endif
 
         optional<ptree&> dhcp4 = properties.get_child_optional(DHCP4);
         if (dhcp4) {

--- a/agent-ovs/lib/ModelEndpointSource.cpp
+++ b/agent-ovs/lib/ModelEndpointSource.cpp
@@ -22,9 +22,7 @@
 #include <modelgbp/inv/IfaceSecurityEnumT.hpp>
 #include <modelgbp/inv/DiscoveryModeEnumT.hpp>
 #include <modelgbp/domain/Config.hpp>
-#ifdef HAVE_PROMETHEUS_SUPPORT
 #include <opflexagent/PrometheusManager.h>
-#endif
 
 namespace opflexagent {
 
@@ -165,7 +163,6 @@ void ModelEndpointSource::objectUpdated (opflex::modb::class_id_t class_id,
                 newep.addAttribute(attr->getName().get(),
                                    attr->getValue(""));
             }
-#ifdef HAVE_PROMETHEUS_SUPPORT
             auto acc_intf = newep.getAccessInterface();
             if (acc_intf) {
                 newep.setAttributeHash(
@@ -175,7 +172,6 @@ void ModelEndpointSource::objectUpdated (opflex::modb::class_id_t class_id,
                                             newep.getAttributes(),
                                             manager->getAgent().getPrometheusEpAttributes()));
             }
-#endif
         }
 
         {

--- a/agent-ovs/lib/SysStatsManager.cpp
+++ b/agent-ovs/lib/SysStatsManager.cpp
@@ -23,9 +23,7 @@ using namespace modelgbp::observer;
 
 SysStatsManager::SysStatsManager (Agent* agent_) :
                                   agent(agent_),
-#ifdef HAVE_PROMETHEUS_SUPPORT
     prometheusManager(agent->getPrometheusManager()),
-#endif
                                   stopping(true) {
 }
 
@@ -113,9 +111,7 @@ void SysStatsManager::updateOpflexPeerStats()
                     .setStateReportResps(peerStat.second->getStateReportResps())
                     .setStateReportErrs(peerStat.second->getStateReportErrs())
                     .setPolUnresolvedCount(peerStat.second->getPolUnresolvedCount());
-#ifdef HAVE_PROMETHEUS_SUPPORT
             prometheusManager.addNUpdateOFPeerStats(peerStat.first, peerStat.second);
-#endif
         }
         // Remove mos for deleted connections
         std::vector<std::shared_ptr<modelgbp::observer::OpflexAgentCounter> > out;
@@ -126,9 +122,7 @@ void SysStatsManager::updateOpflexPeerStats()
             if (peer) {
                 if (stats.find(peer.get()) == stats.end()) {
                     peerCounter->remove();
-#ifdef HAVE_PROMETHEUS_SUPPORT
                     prometheusManager.removeOFPeerStats(peer.get());
-#endif
                 }
             }
         }
@@ -153,9 +147,7 @@ void SysStatsManager::updateMoDBCounts()
                  .setService(agent->getServiceManager().getServiceCount())
                  .setContract(agent->getPolicyManager().getContractCount())
                  .setSg(agent->getPolicyManager().getSecGrpCount());
-#ifdef HAVE_PROMETHEUS_SUPPORT
         prometheusManager.addNUpdateMoDBCounts(pMoDBCounts);
-#endif
     }
     mutator.commit();
 }

--- a/agent-ovs/lib/include/opflexagent/Agent.h
+++ b/agent-ovs/lib/include/opflexagent/Agent.h
@@ -29,9 +29,7 @@
 #include <opflexagent/QosManager.h>
 #include <opflexagent/SysStatsManager.h>
 
-#ifdef HAVE_PROMETHEUS_SUPPORT
 #include <opflexagent/PrometheusManager.h>
-#endif
 
 #include <boost/property_tree/ptree.hpp>
 #include <boost/optional.hpp>
@@ -135,12 +133,10 @@ public:
      */
     SpanManager& getSpanManager() { return spanManager; }
 
-#ifdef HAVE_PROMETHEUS_SUPPORT
     /**
      * Get the prometheus manager object for this agent
      */
     AgentPrometheusManager& getPrometheusManager() { return prometheusManager; }
-#endif
 
     /**
      *  Get the netflow manager object for this agent
@@ -278,7 +274,6 @@ public:
      */
     void clearFeatureFlags();
 
-#ifdef HAVE_PROMETHEUS_SUPPORT
     /**
      * get allowed ep attributes specified in agent config file
      * @return true if feature is enabled, false otherwise.
@@ -287,7 +282,7 @@ public:
     {
         return prometheusEpAttributes;
     }
-#endif
+
     /**
      * Get packet event notification socket file name
      */
@@ -304,9 +299,7 @@ private:
     std::unique_ptr<boost::asio::io_service::work> io_work;
 
     opflex::ofcore::OFFramework& framework;
-#ifdef HAVE_PROMETHEUS_SUPPORT
     AgentPrometheusManager prometheusManager;
-#endif
     PolicyManager policyManager;
     EndpointManager endpointManager;
     ServiceManager serviceManager;
@@ -394,13 +387,11 @@ private:
     // feature flag array
     bool featureFlag[FeatureList::MAX];
 
-#ifdef HAVE_PROMETHEUS_SUPPORT
     // Prometheus related parameters
     bool prometheusEnabled;
     bool prometheusExposeLocalHostOnly;
     bool prometheusExposeEpSvcNan;
     std::unordered_set<std::string> prometheusEpAttributes;
-#endif
     bool behaviorL34FlowsWithoutSubnet;
     LogParams logParams;
 };

--- a/agent-ovs/lib/include/opflexagent/Endpoint.h
+++ b/agent-ovs/lib/include/opflexagent/Endpoint.h
@@ -40,10 +40,8 @@ public:
     Endpoint() : promiscuousMode(false), discoveryProxyMode(false), natMode(false),
                  external(false), aapModeAA(false), disableAdv(false),
                  accessAllowUntagged(false), extEncap(0) {
-#ifdef HAVE_PROMETHEUS_SUPPORT
         annotateEpName = false;
         attr_hash = 0;
-#endif
     }
 
     /**
@@ -57,10 +55,8 @@ public:
         : uuid(uuid_), promiscuousMode(false), discoveryProxyMode(false), natMode(false),
           external(false), aapModeAA(false), disableAdv(false),
           accessAllowUntagged(false), extEncap(0) {
-#ifdef HAVE_PROMETHEUS_SUPPORT
         annotateEpName = false;
         attr_hash = 0;
-#endif
     }
 
     /**
@@ -549,7 +545,6 @@ public:
      */
     typedef std::unordered_map<std::string, std::string> attr_map_t;
 
-#ifdef HAVE_PROMETHEUS_SUPPORT
     /**
       * Add EP name as annotation to avoid dup metric
       * issues in Openshift on openstack use case
@@ -579,7 +574,6 @@ public:
     const size_t& getAttributeHash () const {
         return attr_hash;
     }
-#endif
 
     /**
      * Get a reference to a map of name/value attributes
@@ -1351,7 +1345,6 @@ private:
     bool disableAdv;
     bool accessAllowUntagged;
     attr_map_t attributes;
-#ifdef HAVE_PROMETHEUS_SUPPORT
     bool annotateEpName;
     /**
      * Hash of all the ep attributes. Will be used to detect any
@@ -1359,7 +1352,6 @@ private:
      * manager.
      */
     size_t    attr_hash;
-#endif
     boost::optional<DHCPv4Config> dhcpv4Config;
     boost::optional<DHCPv6Config> dhcpv6Config;
     ipam_set ipAddressMappings;

--- a/agent-ovs/lib/include/opflexagent/EndpointManager.h
+++ b/agent-ovs/lib/include/opflexagent/EndpointManager.h
@@ -20,9 +20,7 @@
 #include <opflexagent/Endpoint.h>
 #include <opflexagent/EndpointListener.h>
 #include <opflexagent/PolicyManager.h>
-#ifdef HAVE_PROMETHEUS_SUPPORT
 #include <opflexagent/PrometheusManager.h>
-#endif
 
 #include <opflex/ofcore/OFFramework.h>
 #include <opflex/modb/ObjectListener.h>
@@ -122,16 +120,10 @@ public:
      * Instantiate a new endpoint manager using the specified framework
      * instance.
      */
-#ifdef HAVE_PROMETHEUS_SUPPORT
     EndpointManager(Agent& agent,
                     opflex::ofcore::OFFramework& framework,
                     PolicyManager& policyManager,
                     AgentPrometheusManager& prometheusManager);
-#else
-    EndpointManager(Agent& agent,
-                    opflex::ofcore::OFFramework& framework,
-                    PolicyManager& policyManager);
-#endif
 
     /**
      * Destroy the endpoint manager and clean up all state
@@ -426,9 +418,7 @@ private:
     Agent& agent;
     opflex::ofcore::OFFramework& framework;
     PolicyManager& policyManager;
-#ifdef HAVE_PROMETHEUS_SUPPORT
     AgentPrometheusManager& prometheusManager;
-#endif
 
     class EndpointState {
     public:

--- a/agent-ovs/lib/include/opflexagent/ServiceManager.h
+++ b/agent-ovs/lib/include/opflexagent/ServiceManager.h
@@ -27,9 +27,7 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
-#ifdef HAVE_PROMETHEUS_SUPPORT
 #include <opflexagent/PrometheusManager.h>
-#endif
 #include <modelgbp/observer/SvcStatUniverse.hpp>
 
 namespace opflexagent {
@@ -45,14 +43,9 @@ public:
     /**
      * Instantiate a new service manager
      */
-#ifdef HAVE_PROMETHEUS_SUPPORT
     ServiceManager(Agent& agent_,
                    opflex::ofcore::OFFramework& framework_,
                    AgentPrometheusManager& prometheusManager_);
-#else
-    ServiceManager(Agent& agent,
-                   opflex::ofcore::OFFramework& framework);
-#endif
 
     /**
      * Register a listener for service change events
@@ -175,10 +168,8 @@ private:
     // reference to opflex framework
     opflex::ofcore::OFFramework& framework;
 
-#ifdef HAVE_PROMETHEUS_SUPPORT
     // reference to prometheus manager
     AgentPrometheusManager& prometheusManager;
-#endif
 
     class ServiceState {
     public:

--- a/agent-ovs/lib/include/opflexagent/SysStatsManager.h
+++ b/agent-ovs/lib/include/opflexagent/SysStatsManager.h
@@ -20,9 +20,7 @@
 #include "config.h"
 #endif
 
-#ifdef HAVE_PROMETHEUS_SUPPORT
 #include <opflexagent/PrometheusManager.h>
-#endif
 
 namespace opflexagent {
 
@@ -71,12 +69,10 @@ private:
      */
     Agent* agent;
 
-#ifdef HAVE_PROMETHEUS_SUPPORT
     /**
      * The prometheus manager that exports stats to prometheus server
      */
     AgentPrometheusManager& prometheusManager;
-#endif
 
     /**
      * mutex for timer

--- a/agent-ovs/lib/include/opflexagent/test/BaseFixture.h
+++ b/agent-ovs/lib/include/opflexagent/test/BaseFixture.h
@@ -93,7 +93,6 @@ typedef opflex::ofcore::OFConstants::OpflexElementMode opflex_elem_t;
         return output;
     }
 
-#ifdef HAVE_PROMETHEUS_SUPPORT
     /**
      * Function to check if given position of metric is expected or not
      * in the prometheus curl output
@@ -108,7 +107,6 @@ typedef opflex::ofcore::OFConstants::OpflexElementMode opflex_elem_t;
         else
             BOOST_CHECK_EQUAL(pos, std::string::npos);
     }
-#endif
 
     /**
      * A framework object

--- a/agent-ovs/lib/test/EndpointManager_test.cpp
+++ b/agent-ovs/lib/test/EndpointManager_test.cpp
@@ -25,9 +25,7 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
-#ifdef HAVE_PROMETHEUS_SUPPORT
 #include <opflexagent/PrometheusManager.h>
-#endif
 
 namespace opflexagent {
 
@@ -702,7 +700,6 @@ BOOST_FIXTURE_TEST_CASE( fssource, FSEndpointFixture ) {
     WAIT_FOR(hasPolicyEntry<ReportedEpAttribute>(framework, epattr_1), 500);
     WAIT_FOR(hasPolicyEntry<ReportedEpAttribute>(framework, epattr_2), 500);
 
-#ifdef HAVE_PROMETHEUS_SUPPORT
     const string cmd = "curl --proxy \"\" --compressed --silent http://127.0.0.1:9612/metrics 2>&1;";
     const string& output0 = BaseFixture::getOutputFromCommand(cmd);
     size_t pos = std::string::npos;
@@ -732,7 +729,6 @@ BOOST_FIXTURE_TEST_CASE( fssource, FSEndpointFixture ) {
     BOOST_CHECK_NE(pos, std::string::npos);
     pos = output1.find("opflex_endpoint_tx_packets{if=\"veth0-acc\",name=\"veth0-acc\"} 100");
     BOOST_CHECK_NE(pos, std::string::npos);
-#endif
 
     // Check updates to existing file: attr delete, sec grp delete, IP delete
     fs::ofstream os2(path1);
@@ -777,7 +773,6 @@ BOOST_FIXTURE_TEST_CASE( fssource, FSEndpointFixture ) {
     WAIT_FOR(!hasPolicyEntry<SecurityGroupContext>(framework, l32sgc_2), 500);
     WAIT_FOR(hasPolicyEntry<ReportedEpAttribute>(framework, epattr_1), 500);
     WAIT_FOR(!hasPolicyEntry<ReportedEpAttribute>(framework, epattr_2), 500);
-#ifdef HAVE_PROMETHEUS_SUPPORT
     counters.txPackets = 200;
     counters.rxPackets = 200;
     counters.txBytes = 12800;
@@ -797,7 +792,6 @@ BOOST_FIXTURE_TEST_CASE( fssource, FSEndpointFixture ) {
     BOOST_CHECK_NE(pos, std::string::npos);
     pos = output2.find("opflex_endpoint_tx_packets{name=\"acc-veth0\"} 200");
     BOOST_CHECK_NE(pos, std::string::npos);
-#endif
 
     // check for overwriting existing file with new ep
     fs::ofstream os3(path1);
@@ -849,7 +843,6 @@ BOOST_FIXTURE_TEST_CASE( fssource, FSEndpointFixture ) {
 
     WAIT_FOR(hasEPREntry<L2Ep>(framework, l2epr3, uuid3), 500);
     WAIT_FOR(hasPolicyEntry<ReportedEpAttribute>(framework, epattr_1), 500);
-#ifdef HAVE_PROMETHEUS_SUPPORT
     const string& output3 = BaseFixture::getOutputFromCommand(cmd);
     pos = output3.find("opflex_endpoint_created_total 1");
     BOOST_CHECK_NE(pos, std::string::npos);
@@ -875,7 +868,6 @@ BOOST_FIXTURE_TEST_CASE( fssource, FSEndpointFixture ) {
     BOOST_CHECK_NE(pos, std::string::npos);
     pos = output4.find("opflex_endpoint_tx_packets{name=\"acc-veth0\"} 300");
     BOOST_CHECK_NE(pos, std::string::npos);
-#endif
 
     // check for a new EP added to watch directory
     URI l2epr2 = URIBuilder()
@@ -909,7 +901,6 @@ BOOST_FIXTURE_TEST_CASE( fssource, FSEndpointFixture ) {
     WAIT_FOR(hasEPREntry<L2Ep>(framework, l2epr2), 500);
     WAIT_FOR(hasPolicyEntry<LocalL3Ep>(framework, l3epdr_3), 500);
     WAIT_FOR(hasPolicyEntry<ReportedEpAttribute>(framework, epattr_1), 500);
-#ifdef HAVE_PROMETHEUS_SUPPORT
     const string& output5 = BaseFixture::getOutputFromCommand(cmd);
     pos = output5.find("opflex_endpoint_created_total 2");
     BOOST_CHECK_NE(pos, std::string::npos);
@@ -944,7 +935,6 @@ BOOST_FIXTURE_TEST_CASE( fssource, FSEndpointFixture ) {
     BOOST_CHECK_NE(pos, std::string::npos);
     pos = output6.find("opflex_endpoint_tx_packets{name=\"acc-veth1\"} 400");
     BOOST_CHECK_NE(pos, std::string::npos);
-#endif
 
     // check for removing an endpoint
     fs::remove(path2);
@@ -952,7 +942,6 @@ BOOST_FIXTURE_TEST_CASE( fssource, FSEndpointFixture ) {
     WAIT_FOR(!hasEPREntry<L2Ep>(framework, l2epr2), 500);
     WAIT_FOR(!hasPolicyEntry<LocalL3Ep>(framework, l3epdr_3), 500);
     WAIT_FOR(!hasPolicyEntry<ReportedEpAttribute>(framework, epattr_1), 500);
-#ifdef HAVE_PROMETHEUS_SUPPORT
     const string& output7 = BaseFixture::getOutputFromCommand(cmd);
     pos = output7.find("opflex_endpoint_created_total 3");
     BOOST_CHECK_NE(pos, std::string::npos);
@@ -986,14 +975,12 @@ BOOST_FIXTURE_TEST_CASE( fssource, FSEndpointFixture ) {
     BOOST_CHECK_EQUAL(pos, std::string::npos);
     pos = output8.find("opflex_endpoint_tx_packets{name=\"acc-veth1\"}");
     BOOST_CHECK_EQUAL(pos, std::string::npos);
-#endif
 
     // check for removing an endpoint
     fs::remove(path1);
     WAIT_FOR(!hasPolicyEntry<LocalL3Ep>(framework, l3epdr_4), 500);
     WAIT_FOR(!hasEPREntry<L2Ep>(framework, l2epr3, uuid3), 500);
     WAIT_FOR(!hasPolicyEntry<ReportedEpAttribute>(framework, epattr_1), 500);
-#ifdef HAVE_PROMETHEUS_SUPPORT
     const string& output9 = BaseFixture::getOutputFromCommand(cmd);
     pos = output9.find("opflex_endpoint_created_total 3");
     BOOST_CHECK_NE(pos, std::string::npos);
@@ -1015,7 +1002,6 @@ BOOST_FIXTURE_TEST_CASE( fssource, FSEndpointFixture ) {
     BOOST_CHECK_EQUAL(pos, std::string::npos);
     pos = output9.find("opflex_endpoint_tx_packets{name=\"acc-veth1\"}");
     BOOST_CHECK_EQUAL(pos, std::string::npos);
-#endif
 
     watcher.stop();
 }

--- a/agent-ovs/lib/test/PolicyManagerIvLeaf_test.cpp
+++ b/agent-ovs/lib/test/PolicyManagerIvLeaf_test.cpp
@@ -11,7 +11,6 @@
 
 #include <list>
 #include <boost/test/unit_test.hpp>
-#include <boost/assign/list_of.hpp>
 #include <modelgbp/dmtree/Root.hpp>
 #include <opflex/modb/Mutator.h>
 #include <modelgbp/gbp/DirectionEnumT.hpp>
@@ -35,7 +34,6 @@ using namespace std;
 using namespace modelgbp;
 using namespace modelgbp::gbp;
 using namespace modelgbp::gbpe;
-using namespace boost::assign;
 using namespace modelgbp::epdr;
 
 class PolicyIvLeafFixture : public BaseFixture {

--- a/agent-ovs/lib/test/SysStatsManager_test.cpp
+++ b/agent-ovs/lib/test/SysStatsManager_test.cpp
@@ -19,9 +19,7 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
-#ifdef HAVE_PROMETHEUS_SUPPORT
 #include <opflexagent/PrometheusManager.h>
-#endif
 
 namespace opflexagent {
 
@@ -40,16 +38,13 @@ public:
     virtual ~SysStatsManagerFixture() {
     }
 
-#ifdef HAVE_PROMETHEUS_SUPPORT
     void updateOFPeerStats(std::shared_ptr<OFAgentStats> opflexStats);
     void verifyOFPeerMetrics(const std::string& peer, uint32_t count, bool del);
     void updateMoDBCounts(std::shared_ptr<ModbCounts> pCounts, int count);
     void verifyMoDBCounts(uint32_t count, bool del);
     const string cmd = "curl --proxy \"\" --compressed --silent http://127.0.0.1:9612/metrics 2>&1;";
-#endif
 };
 
-#ifdef HAVE_PROMETHEUS_SUPPORT
 void SysStatsManagerFixture::
 updateMoDBCounts (std::shared_ptr<ModbCounts> pCounts, int count)
 {
@@ -222,11 +217,9 @@ verifyOFPeerMetrics (const std::string& peer, uint32_t count, bool del)
     pos = output.find(unres_count);
     BaseFixture::expPosition(!del, pos);
 }
-#endif
 
 BOOST_AUTO_TEST_SUITE(SysStatsManager_test)
 
-#ifdef HAVE_PROMETHEUS_SUPPORT
 BOOST_FIXTURE_TEST_CASE(testOFPeer, SysStatsManagerFixture) {
 
     LOG(DEBUG) << "### OfPeer start";
@@ -273,7 +266,6 @@ BOOST_FIXTURE_TEST_CASE(testMoDBCounts, SysStatsManagerFixture) {
     verifyMoDBCounts(0, true);
     LOG(DEBUG) << "### MoDBCounts end";
 }
-#endif
 
 BOOST_AUTO_TEST_SUITE_END()
 }

--- a/agent-ovs/ovs/PolicyStatsManager.cpp
+++ b/agent-ovs/ovs/PolicyStatsManager.cpp
@@ -14,10 +14,8 @@
 #include <opflexagent/Agent.h>
 #include "FlowConstants.h"
 #include "IntFlowManager.h"
-#include "TableState.h"
 #include "PolicyStatsManager.h"
 
-#include "ovs-shim.h"
 #include "ovs-ofputil.h"
 
 #include <lib/util.h>
@@ -48,9 +46,7 @@ PolicyStatsManager::PolicyStatsManager(Agent* agent_, IdGenerator& idGen_,
                                        SwitchManager& switchManager_,
                                        long timer_interval_)
     : idGen(idGen_), agent(agent_),
-#ifdef HAVE_PROMETHEUS_SUPPORT
-    prometheusManager(agent->getPrometheusManager()),
-#endif
+      prometheusManager(agent->getPrometheusManager()),
       switchManager(switchManager_),
       connection(NULL),
       timer_interval(timer_interval_),
@@ -63,7 +59,7 @@ void PolicyStatsManager::registerConnection(SwitchConnection* connection) {
 }
 
 void PolicyStatsManager::start(bool register_listener,
-                               boost::optional<boost::asio::io_service&> io_service) {
+                               optional<boost::asio::io_service&> io_service) {
     stopping = false;
 
     LOG(DEBUG) << "Starting policy stats manager " << this;
@@ -583,7 +579,7 @@ generatePolicyStatsObjects(PolicyCounterMap_t *newCountersMap1,
                 continue;
             }
         }
-        boost::optional<std::string> idStr =
+        optional<string> idStr =
             idGen.getStringForId(IntFlowManager::
                                  getIdNamespace(L24Classifier::CLASS_ID),
                                  flowKey.cookie);
@@ -614,7 +610,7 @@ generatePolicyStatsObjects(PolicyCounterMap_t *newCountersMap1,
             const PolicyFlowMatchKey_t& flowKey = itr->first;
             FlowStats_t&  outCounters = itr->second;
             FlowStats_t   inCounters;
-            boost::optional<std::string> idStr =
+            optional<string> idStr =
                 idGen.getStringForId(IntFlowManager::
                                      getIdNamespace(L24Classifier::CLASS_ID),
                                      flowKey.cookie);
@@ -629,7 +625,7 @@ generatePolicyStatsObjects(PolicyCounterMap_t *newCountersMap1,
     }
 }
 
-void PolicyStatsManager::removeAllCounterObjects(const std::string& key) {
+void PolicyStatsManager::removeAllCounterObjects(const string& key) {
     if (!genIdList_.count(key)) return;
     Mutator mutator(agent->getFramework(), "policyelement");
     for (size_t i = 0; i < genIdList_[key]->uidList.size(); i++)
@@ -638,7 +634,7 @@ void PolicyStatsManager::removeAllCounterObjects(const std::string& key) {
     mutator.commit();
 }
 
-void PolicyStatsManager::clearOldCounters(const std::string& key,
+void PolicyStatsManager::clearOldCounters(const string& key,
                                           uint64_t nextId) {
     if (!genIdList_.count(key)) {
         genIdList_[key] =

--- a/agent-ovs/ovs/SecGrpStatsManager.cpp
+++ b/agent-ovs/ovs/SecGrpStatsManager.cpp
@@ -120,7 +120,7 @@ void SecGrpStatsManager::on_timer(const error_code& ec) {
     }
 }
 
-void SecGrpStatsManager::clearCounterObject(const std::string& key,
+void SecGrpStatsManager::clearCounterObject(const string& key,
                                             uint8_t index) {
     SecGrpClassifierCounter::remove(agent->getFramework(),
                                     getAgentUUID(),
@@ -128,7 +128,7 @@ void SecGrpStatsManager::clearCounterObject(const std::string& key,
 }
 
 void SecGrpStatsManager::
-updatePolicyStatsCounters(const std::string& l24Classifier,
+updatePolicyStatsCounters(const string& l24Classifier,
                           FlowStats_t& newVals1,
                           FlowStats_t& newVals2) {
     Mutator mutator(agent->getFramework(), "policyelement");
@@ -145,50 +145,42 @@ updatePolicyStatsCounters(const std::string& l24Classifier,
                 .setTxbytes(newVals2.byte_count.get())
                 .setRxpackets(newVals1.packet_count.get())
                 .setRxbytes(newVals1.byte_count.get());
-#ifdef HAVE_PROMETHEUS_SUPPORT
             prometheusManager.addNUpdateSGClassifierCounter(l24Classifier,
                                                             newVals1.byte_count.get(),
                                                             newVals1.packet_count.get(),
                                                             newVals2.byte_count.get(),
                                                             newVals2.packet_count.get());
-#endif
         } else if (newVals1.byte_count) {
             su.get()->addGbpeSecGrpClassifierCounter(getAgentUUID(),
                                                      nextId,
                                                      l24Classifier)
                 ->setRxpackets(newVals1.packet_count.get())
                 .setRxbytes(newVals1.byte_count.get());
-#ifdef HAVE_PROMETHEUS_SUPPORT
             prometheusManager.addNUpdateSGClassifierCounter(l24Classifier,
                                                             newVals1.byte_count.get(),
                                                             newVals1.packet_count.get(),
                                                             0, 0);
-#endif
         } else if (newVals2.byte_count) {
             su.get()->addGbpeSecGrpClassifierCounter(getAgentUUID(),
                                                      nextId,
                                                      l24Classifier)
                 ->setTxpackets(newVals2.packet_count.get())
                 .setTxbytes(newVals2.byte_count.get());
-#ifdef HAVE_PROMETHEUS_SUPPORT
             prometheusManager.addNUpdateSGClassifierCounter(l24Classifier,
                                                             0, 0,
                                                             newVals2.byte_count.get(),
                                                             newVals2.packet_count.get());
-#endif
         }
     }
     mutator.commit();
 }
 
 void SecGrpStatsManager::objectUpdated(opflex::modb::class_id_t class_id,
-                                       const opflex::modb::URI& uri) {
+                                       const URI& uri) {
     if (class_id == L24Classifier::CLASS_ID) {
         if (!L24Classifier::resolve(agent->getFramework(),uri)) {
             removeAllCounterObjects(uri.toString());
-#ifdef HAVE_PROMETHEUS_SUPPORT
             prometheusManager.removeSGClassifierCounter(uri.toString());
-#endif
         }
     }
 }

--- a/agent-ovs/ovs/TableDropStatsManager.cpp
+++ b/agent-ovs/ovs/TableDropStatsManager.cpp
@@ -17,9 +17,7 @@
 #include "TableDropStatsManager.h"
 
 #include "ovs-ofputil.h"
-#ifdef HAVE_PROMETHEUS_SUPPORT
 #include <opflexagent/PrometheusManager.h>
-#endif
 extern "C" {
 #include <openvswitch/ofp-msgs.h>
 }
@@ -30,8 +28,6 @@ extern "C" {
 
 namespace opflexagent {
 
-using std::string;
-using boost::optional;
 using boost::make_optional;
 using std::shared_ptr;
 using opflex::modb::URI;
@@ -102,11 +98,9 @@ void BaseTableDropStatsManager::start(bool register_listener) {
                 .setBytes(0);
        }
        mutator.commit();
-#ifdef HAVE_PROMETHEUS_SUPPORT
        AgentPrometheusManager &prometheusManager = agent->getPrometheusManager();
        prometheusManager.addTableDropGauge(connection->getSwitchName(),
                                             tbl_it.second.first);
-#endif
        CurrentDropCounterState[tbl_it.first];
        auto &counter = TableDropCounterState[tbl_it.first];
        counter.packet_count = boost::make_optional(false, 0);
@@ -126,14 +120,12 @@ void BaseTableDropStatsManager::stop(bool unregister_listener) {
     LOG(DEBUG) << "Stopping "
                << connection->getSwitchName()
                << " Table Drop stats manager";
-#ifdef HAVE_PROMETHEUS_SUPPORT
     AgentPrometheusManager &prometheusManager = agent->getPrometheusManager();
     for (const auto& tbl_it: tableDescMap) {
         prometheusManager.removeTableDropGauge(
                 connection->getSwitchName(),
                 tbl_it.second.first);
     }
-#endif
     stopping = true;
 
     PolicyStatsManager::stop(unregister_listener);
@@ -310,14 +302,11 @@ void BaseTableDropStatsManager::on_timer(const boost::system::error_code& ec) {
                 .setBytes(byte_count);
         }
         mutator.commit();
-#ifdef HAVE_PROMETHEUS_SUPPORT
         AgentPrometheusManager &prometheusManager = agent->getPrometheusManager();
         prometheusManager.updateTableDropGauge(connection->getSwitchName(),
                                                 tbl_it.second.first,
                                                 byte_count,
                                                 packet_count);
-#endif
-
     }
 
     for(const auto& tbl_it: tableDescMap) {

--- a/agent-ovs/ovs/include/IntFlowManager.h
+++ b/agent-ovs/ovs/include/IntFlowManager.h
@@ -22,9 +22,7 @@
 #include <opflexagent/TunnelEpManager.h>
 #include <opflexagent/RDConfig.h>
 #include <opflexagent/TaskQueue.h>
-#ifdef HAVE_PROMETHEUS_SUPPORT
 #include <opflexagent/PrometheusManager.h>
-#endif
 #include "SwitchStateHandler.h"
 
 #include <opflex/ofcore/PeerStatusListener.h>
@@ -260,13 +258,6 @@ public:
     bool getServiceStatsFlowDisabled() {
         return serviceStatsFlowDisabled;
     }
-
-    /**
-     * Get the multicast tunnel destination
-     * @return the tunnel destination
-     */
-    boost::asio::ip::address& getMcastTunDst()
-    { return mcastTunDst ? mcastTunDst.get() : tunnelDst; }
 
     /**
      * Get the router MAC address as an array of 6 bytes
@@ -883,24 +874,19 @@ private:
     IdGenerator& idGen;
     CtZoneManager& ctZoneManager;
     TunnelEpManager& tunnelEpManager;
-#ifdef HAVE_PROMETHEUS_SUPPORT
     AgentPrometheusManager& prometheusManager;
-#endif
     TaskQueue taskQueue;
 
     EncapType encapType;
     std::string encapIface, uplinkIface;
     FloodScope floodScope;
     boost::asio::ip::address tunnelDst;
-    std::string tunnelPortStr;
-    boost::optional<boost::asio::ip::address> mcastTunDst;
     bool virtualRouterEnabled;
     uint8_t routerMac[6];
     bool routerAdv;
     bool virtualDHCPEnabled;
     bool conntrackEnabled;
     uint8_t dhcpMac[6];
-    std::string flowIdCache;
     std::string mcastGroupFile;
     std::string dropLogIface;
     boost::asio::ip::address dropLogDst;

--- a/agent-ovs/ovs/include/PolicyStatsManager.h
+++ b/agent-ovs/ovs/include/PolicyStatsManager.h
@@ -29,9 +29,7 @@
 #include "config.h"
 #endif
 
-#ifdef HAVE_PROMETHEUS_SUPPORT
 #include <opflexagent/PrometheusManager.h>
-#endif
 
 namespace opflexagent {
 
@@ -349,12 +347,10 @@ protected:
      */
     Agent* agent;
 
-#ifdef HAVE_PROMETHEUS_SUPPORT
     /**
      * The prometheus manager that exports stats to prometheus server
      */
     AgentPrometheusManager& prometheusManager;
-#endif
 
     /**
      * The switch manager that owns the bridges

--- a/agent-ovs/ovs/test/ContractStatsManager_test.cpp
+++ b/agent-ovs/ovs/test/ContractStatsManager_test.cpp
@@ -83,13 +83,11 @@ public:
                                       uint32_t packet_count,
                                       uint32_t byte_count);
     void waitForRdDropEntry(void);
-#ifdef HAVE_PROMETHEUS_SUPPORT
     virtual void verifyPromMetrics(shared_ptr<L24Classifier> classifier,
                             uint32_t pkts,
                             uint32_t bytes,
                             bool isTx=false) override;
     void verifyRdDropPromMetrics(uint32_t pkts, uint32_t bytes);
-#endif
     IntFlowManager  intFlowManager;
     MockContractStatsManager contractStatsManager;
     PolicyManager& policyManager;
@@ -97,7 +95,6 @@ private:
     bool checkNewFlowMapSize(size_t pol_table_size);
 };
 
-#ifdef HAVE_PROMETHEUS_SUPPORT
 void ContractStatsManagerFixture::
 verifyPromMetrics (shared_ptr<L24Classifier> classifier,
                    uint32_t pkts,
@@ -139,7 +136,6 @@ verifyRdDropPromMetrics (uint32_t pkts,
     pos = output.find(s_bytes);
     BOOST_CHECK_NE(pos, std::string::npos);
 }
-#endif
 
 void ContractStatsManagerFixture::
 verifyRoutingDomainDropStats(shared_ptr<RoutingDomain> rd,
@@ -163,9 +159,7 @@ verifyRoutingDomainDropStats(shared_ptr<RoutingDomain> rd,
     BOOST_CHECK_EQUAL(myCounter.get()->getPackets().get(), packet_count);
     BOOST_CHECK_EQUAL(myCounter.get()->getBytes().get(), byte_count);
 
-#ifdef HAVE_PROMETHEUS_SUPPORT
     verifyRdDropPromMetrics(packet_count, byte_count);
-#endif
 }
 
 struct ofpbuf *makeFlowStatReplyMessage(uint32_t priority, uint64_t cookie,

--- a/agent-ovs/ovs/test/SecGrpStatsManager_test.cpp
+++ b/agent-ovs/ovs/test/SecGrpStatsManager_test.cpp
@@ -78,16 +78,13 @@ public:
     virtual ~SecGrpStatsManagerFixture() {
         stop();
     }
-#ifdef HAVE_PROMETHEUS_SUPPORT
     virtual void verifyPromMetrics(shared_ptr<L24Classifier> classifier,
                             uint32_t pkts,
                             uint32_t bytes,
                             bool isTx=false) override;
-#endif
     MockSecGrpStatsManager secGrpStatsManager;
 };
 
-#ifdef HAVE_PROMETHEUS_SUPPORT
 void SecGrpStatsManagerFixture::
 verifyPromMetrics (shared_ptr<L24Classifier> classifier,
                    uint32_t pkts,
@@ -150,7 +147,6 @@ verifyPromMetrics (shared_ptr<L24Classifier> classifier,
         BOOST_CHECK_NE(pos, std::string::npos);
     }
 }
-#endif
 
 BOOST_AUTO_TEST_SUITE(SecGrpStatsManager_test)
 

--- a/agent-ovs/ovs/test/ServiceStatsManager_test.cpp
+++ b/agent-ovs/ovs/test/ServiceStatsManager_test.cpp
@@ -17,7 +17,6 @@
 #include <opflexagent/logging.h>
 #include <opflexagent/test/ModbFixture.h>
 #include "ovs-ofputil.h"
-#include <lib/util.h>
 #include "IntFlowManager.h"
 #include "ServiceStatsManager.h"
 #include "TableState.h"
@@ -123,10 +122,8 @@ public:
     void testFlowAge(PolicyStatsManager *statsManager,
                      bool isOld, bool isFlowStateReAdd);
 
-#ifdef HAVE_PROMETHEUS_SUPPORT
     void checkSvcTgtPromMetrics(uint64_t pkts, uint64_t bytes, const string& ip, bool isNodePort=false);
     void checkPodSvcPromMetrics(uint64_t pkts, uint64_t bytes);
-#endif
 private:
     Service as;
     Service::ServiceMapping sm1;
@@ -864,7 +861,6 @@ ServiceStatsManagerFixture::testFlowRemovedPodSvc (MockConnection& portConn,
     checkPodSvcObjectStats(epToSvcUuid, svcToEpUuid, expPkts, expBytes);
 }
 
-#ifdef HAVE_PROMETHEUS_SUPPORT
 // Check prom dyn gauge service metrics along with stats
 void ServiceStatsManagerFixture::checkSvcTgtPromMetrics (uint64_t pkts,
                                                          uint64_t bytes,
@@ -966,7 +962,6 @@ void ServiceStatsManagerFixture::checkPodSvcPromMetrics (uint64_t pkts,
         BOOST_CHECK_NE(pos4, std::string::npos);
     }
 }
-#endif
 
 void
 ServiceStatsManagerFixture::checkNodeSvcTgtObjectStats (const std::string& svcUuid,
@@ -1055,9 +1050,7 @@ ServiceStatsManagerFixture::checkNodeSvcTgtObjectStats (const std::string& svcUu
                    BOOST_CHECK_EQUAL(opSvcTgtCntr.get()->getNodePortTxbytes().get(), byte_count);
                });
         }
-#ifdef HAVE_PROMETHEUS_SUPPORT
         checkSvcTgtPromMetrics(packet_count, byte_count, nhip, true);
-#endif
     }
 }
 
@@ -1148,9 +1141,7 @@ ServiceStatsManagerFixture::checkAnySvcTgtObjectStats (const std::string& svcUui
                    BOOST_CHECK_EQUAL(opSvcTgtCntr.get()->getTxbytes().get(), byte_count);
                });
         }
-#ifdef HAVE_PROMETHEUS_SUPPORT
         checkSvcTgtPromMetrics(packet_count, byte_count, nhip);
-#endif
     }
 }
 
@@ -1216,9 +1207,7 @@ ServiceStatsManagerFixture::checkPodSvcObjectStats (const std::string& epToSvcUu
     } else {
         LOG(ERROR) << "SvcToEpCounter obj not present";
     }
-#ifdef HAVE_PROMETHEUS_SUPPORT
     checkPodSvcPromMetrics(packet_count, byte_count);
-#endif
 }
 
 void ServiceStatsManagerFixture::checkSvcTgtObsObj (bool add)

--- a/agent-ovs/ovs/test/TableDropStatsManager_test.cpp
+++ b/agent-ovs/ovs/test/TableDropStatsManager_test.cpp
@@ -172,15 +172,12 @@ public:
                              MockConnection& portConn,
                              PolicyStatsManager &statsManager);
 
-#ifdef HAVE_PROMETHEUS_SUPPORT
     void checkPrometheusCounters(uint64_t exp_packet_count,
                                  uint64_t exp_byte_count,
                                  const std::string &bridgeName,
                                  const std::string &tableName);
-#endif
 };
 
-#ifdef HAVE_PROMETHEUS_SUPPORT
 void TableDropStatsManagerFixture::checkPrometheusCounters(uint64_t exp_packet_count,
                              uint64_t exp_byte_count,
                              const std::string &bridgeName,
@@ -195,9 +192,7 @@ void TableDropStatsManagerFixture::checkPrometheusCounters(uint64_t exp_packet_c
     BOOST_CHECK_NE(pos, string::npos);
     pos = output.find(bytes_key);
     BOOST_CHECK_NE(pos, string::npos);
-    return;
 }
-#endif
 
 void TableDropStatsManagerFixture::verifyDropFlowStats (
                                     uint64_t exp_packet_count,
@@ -363,14 +358,12 @@ void TableDropStatsManagerFixture::testOneStaticDropFlow (
     verifyDropFlowStats(expected_pkt_count,
                         expected_byte_count,
                         table_id, portConn, statsManager);
-#ifdef HAVE_PROMETHEUS_SUPPORT
     SwitchManager::TableDescriptionMap fwdTableMap;
     swMgr.getForwardingTableList(fwdTableMap);
     checkPrometheusCounters(expected_pkt_count,
                             expected_byte_count,
                             portConn.getSwitchName(),
                             fwdTableMap[table_id].first);
-#endif
 
 }
 

--- a/agent-ovs/ovs/test/include/PolicyStatsManagerFixture.h
+++ b/agent-ovs/ovs/test/include/PolicyStatsManagerFixture.h
@@ -80,14 +80,12 @@ public:
             FlowManagerFixture (mode) {
     };
 
-#ifdef HAVE_PROMETHEUS_SUPPORT
     const string cmd = "curl --proxy \"\" --compressed --silent http://127.0.0.1:9612/metrics 2>&1;";
     virtual void verifyPromMetrics (shared_ptr<L24Classifier> classifier,
                             uint32_t pkts,
                             uint32_t bytes,
                             bool isTx=false) {
     }
-#endif
 
     // New counter objects get created for every diff in flow. Prometheus
     // maintains an aggregatiion of all these updates. On the second update
@@ -133,9 +131,7 @@ public:
                } else {
                    LOG(DEBUG) << "L24classifiercounter mo isnt present";
                });
-#ifdef HAVE_PROMETHEUS_SUPPORT
             verifyPromMetrics(classifier, t_packet_count, t_byte_count);
-#endif
         } else {
             auto uuid = statsManager->getAgentUUID();
             optional<shared_ptr<SecGrpClassifierCounter> > myCounter =
@@ -182,10 +178,8 @@ public:
                 } else {
                     LOG(DEBUG) << "SGclassifiercounter mo isnt present";
                 });
-#ifdef HAVE_PROMETHEUS_SUPPORT
             verifyPromMetrics(classifier, t_packet_count, t_byte_count,
                               table_id == AccessFlowManager::SEC_GROUP_OUT_TABLE_ID);
-#endif
         }
     }
 

--- a/agent-ovs/server/StatsIO.cpp
+++ b/agent-ovs/server/StatsIO.cpp
@@ -24,7 +24,6 @@ using namespace modelgbp::dmtree;
 
 namespace opflexagent {
 
-#ifdef HAVE_PROMETHEUS_SUPPORT
 StatsIO::StatsIO (ServerPrometheusManager& prometheusManager_,
                   opflex::test::GbpOpflexServer& server_,
                   opflex::ofcore::OFFramework& framework_,
@@ -35,16 +34,6 @@ StatsIO::StatsIO (ServerPrometheusManager& prometheusManager_,
                   stats_interval_secs(stats_interval_secs_),
                   stopping(false) {
 }
-#else
-StatsIO::StatsIO (opflex::test::GbpOpflexServer& server_,
-                  const opflex::ofcore::OFFramework& framework_,
-                  int stats_interval_secs_) :
-                  server(server_),
-                  framework(framework_),
-                  stats_interval_secs(stats_interval_secs_),
-                  stopping(false) {
-}
-#endif
 
 StatsIO::~StatsIO() {
 }
@@ -117,9 +106,7 @@ void StatsIO::on_timer_stats (const boost::system::error_code& ec) {
                     .setEpUnresolveErrs(peerStat.second->getEpUnresolveErrs())
                     .setStateReports(peerStat.second->getStateReports())
                     .setStateReportErrs(peerStat.second->getStateReportErrs());
-#ifdef HAVE_PROMETHEUS_SUPPORT
             prometheusManager.addNUpdateOFAgentStats(peerStat.first, peerStat.second);
-#endif
         }
         // Remove mos for deleted connections
         std::vector<std::shared_ptr<modelgbp::observer::OpflexServerCounter> > out;
@@ -130,9 +117,7 @@ void StatsIO::on_timer_stats (const boost::system::error_code& ec) {
             if (agent) {
                 if (stats.find(agent.get()) == stats.end()) {
                     serverCounter->remove();
-#ifdef HAVE_PROMETHEUS_SUPPORT
                     prometheusManager.removeOFAgentStats(agent.get());
-#endif
                 }
             }
         }

--- a/agent-ovs/server/include/StatsIO.h
+++ b/agent-ovs/server/include/StatsIO.h
@@ -24,9 +24,7 @@
 #include <boost/asio/io_service.hpp>
 #include <boost/asio/deadline_timer.hpp>
 
-#ifdef HAVE_PROMETHEUS_SUPPORT
 #include <opflexagent/PrometheusManager.h>
-#endif
 #include <opflex/ofcore/OFFramework.h>
 #include <opflex/test/GbpOpflexServer.h>
 
@@ -34,24 +32,16 @@ namespace opflexagent {
 
 class StatsIO {
 public:
-#ifdef HAVE_PROMETHEUS_SUPPORT
     StatsIO(ServerPrometheusManager& prometheusManager_,
             opflex::test::GbpOpflexServer& server_,
             opflex::ofcore::OFFramework& framework_,
             int stats_interval_secs_);
-#else
-    StatsIO(opflex::ofcore::OFFramework& framework_,
-            opflex::test::GbpOpflexServer& server_,
-            int stats_interval_secs_);
-#endif
     ~StatsIO();
     void start();
     void stop();
 private:
     void on_timer_stats(const boost::system::error_code& ec);
-#ifdef HAVE_PROMETHEUS_SUPPORT
     ServerPrometheusManager& prometheusManager;
-#endif
     opflex::test::GbpOpflexServer& server;
     opflex::ofcore::OFFramework& framework;
     int stats_interval_secs;

--- a/agent-ovs/server/test/AgentStats_test.cpp
+++ b/agent-ovs/server/test/AgentStats_test.cpp
@@ -10,7 +10,6 @@
 
 #include <sstream>
 #include <boost/test/unit_test.hpp>
-#include <boost/assign/list_of.hpp>
 
 #if HAVE_CONFIG_H
 #include <config.h>
@@ -19,21 +18,15 @@
 #include <opflexagent/logging.h>
 #include <opflexagent/test/BaseFixture.h>
 #include <lib/util.h>
-#include <opflex/modb/Mutator.h>
-#ifdef HAVE_PROMETHEUS_SUPPORT
 #include <opflexagent/PrometheusManager.h>
-#endif
 #include <opflex/ofcore/OFServerStats.h>
 
-using namespace boost::assign;
-using boost::optional;
 using std::shared_ptr;
 using std::string;
 using namespace modelgbp::gbp;
 using namespace modelgbp::gbpe;
 using modelgbp::observer::PolicyStatUniverse;
 using opflex::modb::class_id_t;
-using opflex::modb::Mutator;
 
 namespace opflexagent {
 
@@ -50,16 +43,14 @@ public:
         prometheusManager.stop();
     }
 
-    void updateOFAgentStats(std::shared_ptr<OFServerStats> opflexStats);
-#ifdef HAVE_PROMETHEUS_SUPPORT
-    void verifyOFAgentMetrics(const std::string& agent, uint32_t count, bool del);
+    void updateOFAgentStats(shared_ptr<OFServerStats> opflexStats);
+    void verifyOFAgentMetrics(const string& agent, uint32_t count, bool del);
     const string cmd = "curl --proxy \"\" --compressed --silent http://127.0.0.1:9632/metrics 2>&1;";
     ServerPrometheusManager prometheusManager;
-#endif
 };
 
 void AgentStatsFixture::
-updateOFAgentStats (std::shared_ptr<OFServerStats> opflexStats)
+updateOFAgentStats (shared_ptr<OFServerStats> opflexStats)
 {
     opflexStats->incrIdentReqs();
     opflexStats->incrPolUpdates();
@@ -80,118 +71,111 @@ updateOFAgentStats (std::shared_ptr<OFServerStats> opflexStats)
     opflexStats->incrStateReportErrs();
 }
 
-#ifdef HAVE_PROMETHEUS_SUPPORT
 void AgentStatsFixture::
-verifyOFAgentMetrics (const std::string& agent, uint32_t count, bool del)
+verifyOFAgentMetrics (const string& agent, uint32_t count, bool del)
 {
-    const std::string& output = BaseFixture::getOutputFromCommand(cmd);
-    size_t pos = std::string::npos;
+    const string& output = BaseFixture::getOutputFromCommand(cmd);
     const auto& val = std::to_string(count);
 
-    const std::string& ident_req = "opflex_agent_identity_req_count{agent=\""
+    const string& ident_req = "opflex_agent_identity_req_count{agent=\""
                                    + agent + "\"} " + val;
-    pos = output.find(ident_req);
+    size_t pos = output.find(ident_req);
     BaseFixture::expPosition(!del, pos);
 
-    const std::string& pol_upd = "opflex_agent_policy_update_count{agent=\""
+    const string& pol_upd = "opflex_agent_policy_update_count{agent=\""
                                    + agent + "\"} " + val;
     pos = output.find(pol_upd);
     BaseFixture::expPosition(!del, pos);
 
-    const std::string& res_un = "opflex_agent_policy_unavailable_resolve_count{agent=\""
+    const string& res_un = "opflex_agent_policy_unavailable_resolve_count{agent=\""
                                    + agent + "\"} " + val;
     pos = output.find(res_un);
     BaseFixture::expPosition(!del, pos);
 
-    const std::string& res_req = "opflex_agent_policy_resolve_count{agent=\""
+    const string& res_req = "opflex_agent_policy_resolve_count{agent=\""
                                    + agent + "\"} " + val;
     pos = output.find(res_req);
     BaseFixture::expPosition(!del, pos);
-    const std::string& res_err = "opflex_agent_policy_resolve_err_count{agent=\""
+    const string& res_err = "opflex_agent_policy_resolve_err_count{agent=\""
                                    + agent + "\"} " + val;
     pos = output.find(res_err);
     BaseFixture::expPosition(!del, pos);
 
-    const std::string& unres_req = "opflex_agent_policy_unresolve_count{agent=\""
+    const string& unres_req = "opflex_agent_policy_unresolve_count{agent=\""
                                    + agent + "\"} " + val;
     pos = output.find(unres_req);
     BaseFixture::expPosition(!del, pos);
-    const std::string& unres_err = "opflex_agent_policy_unresolve_err_count{agent=\""
+    const string& unres_err = "opflex_agent_policy_unresolve_err_count{agent=\""
                                    + agent + "\"} " + val;
     pos = output.find(unres_err);
     BaseFixture::expPosition(!del, pos);
 
-    const std::string& epd_req = "opflex_agent_ep_declare_count{agent=\""
+    const string& epd_req = "opflex_agent_ep_declare_count{agent=\""
                                    + agent + "\"} " + val;
     pos = output.find(epd_req);
     BaseFixture::expPosition(!del, pos);
-    const std::string& epd_err = "opflex_agent_ep_declare_err_count{agent=\""
+    const string& epd_err = "opflex_agent_ep_declare_err_count{agent=\""
                                    + agent + "\"} " + val;
     pos = output.find(epd_err);
     BaseFixture::expPosition(!del, pos);
 
-    const std::string& epud_req = "opflex_agent_ep_undeclare_count{agent=\""
+    const string& epud_req = "opflex_agent_ep_undeclare_count{agent=\""
                                    + agent + "\"} " + val;
     pos = output.find(epud_req);
     BaseFixture::expPosition(!del, pos);
-    const std::string& epud_err = "opflex_agent_ep_undeclare_err_count{agent=\""
+    const string& epud_err = "opflex_agent_ep_undeclare_err_count{agent=\""
                                    + agent + "\"} " + val;
     pos = output.find(epud_err);
     BaseFixture::expPosition(!del, pos);
 
-    const std::string& epr_req = "opflex_agent_ep_resolve_count{agent=\""
+    const string& epr_req = "opflex_agent_ep_resolve_count{agent=\""
                                    + agent + "\"} " + val;
     pos = output.find(epr_req);
     BaseFixture::expPosition(!del, pos);
-    const std::string& epr_err = "opflex_agent_ep_resolve_err_count{agent=\""
+    const string& epr_err = "opflex_agent_ep_resolve_err_count{agent=\""
                                    + agent + "\"} " + val;
     pos = output.find(epr_err);
     BaseFixture::expPosition(!del, pos);
 
-    const std::string& epur_req = "opflex_agent_ep_unresolve_count{agent=\""
+    const string& epur_req = "opflex_agent_ep_unresolve_count{agent=\""
                                    + agent + "\"} " + val;
     pos = output.find(epur_req);
     BaseFixture::expPosition(!del, pos);
-    const std::string& epur_err = "opflex_agent_ep_unresolve_err_count{agent=\""
+    const string& epur_err = "opflex_agent_ep_unresolve_err_count{agent=\""
                                    + agent + "\"} " + val;
     pos = output.find(epur_err);
     BaseFixture::expPosition(!del, pos);
 
-    const std::string& rep_req = "opflex_agent_state_report_count{agent=\""
+    const string& rep_req = "opflex_agent_state_report_count{agent=\""
                                    + agent + "\"} " + val;
     pos = output.find(rep_req);
     BaseFixture::expPosition(!del, pos);
-    const std::string& rep_err = "opflex_agent_state_report_err_count{agent=\""
+    const string& rep_err = "opflex_agent_state_report_err_count{agent=\""
                                    + agent + "\"} " + val;
     pos = output.find(rep_err);
     BaseFixture::expPosition(!del, pos);
 }
-#endif
 
 BOOST_AUTO_TEST_SUITE(AgentStats_test)
 
 BOOST_FIXTURE_TEST_CASE(testOFAgent, AgentStatsFixture) {
 
     LOG(DEBUG) << "### OfAgent start";
-    std::shared_ptr<OFServerStats> opflexStats = std::make_shared<OFServerStats>();
-    const std::string& agent = "127.0.0.1:9999";
+    shared_ptr<OFServerStats> opflexStats = std::make_shared<OFServerStats>();
+    const string& agent = "127.0.0.1:9999";
 
     updateOFAgentStats(opflexStats);
-#ifdef HAVE_PROMETHEUS_SUPPORT
     prometheusManager.addNUpdateOFAgentStats(agent,
                                              opflexStats);
     verifyOFAgentMetrics(agent, 1, false);
-#endif
 
     updateOFAgentStats(opflexStats);
-#ifdef HAVE_PROMETHEUS_SUPPORT
     prometheusManager.addNUpdateOFAgentStats(agent,
                                              opflexStats);
     verifyOFAgentMetrics(agent, 2, false);
 
     prometheusManager.removeOFAgentStats(agent);
     verifyOFAgentMetrics(agent, 0, true);
-#endif
     LOG(DEBUG) << "### OFAgent end";
 }
 


### PR DESCRIPTION
Prometheus support can still be disabled at runtime

Address a number of clang-tidy complaints

Signed-off-by: Tom Flynn <tom.flynn@gmail.com>