### PR TITLE
Add DNS expiry timer

### DIFF
--- a/agent-ovs/Makefile.am
+++ b/agent-ovs/Makefile.am
@@ -70,7 +70,8 @@ libopflex_agent_la_LIBADD = \
 	$(libmodelgbp_LIBS) \
 	$(BOOST_SYSTEM_LIB) \
 	$(BOOST_FILESYSTEM_LIB) \
-	$(BOOST_ASIO_LIB)
+	$(BOOST_ASIO_LIB) \
+	$(BOOST_DATE_TIME_LIB)
 if ENABLE_PROMETHEUS
 libopflex_agent_la_LIBADD += $(PROMETHEUS_CORE_LIBS)
 libopflex_agent_la_LIBADD += $(PROMETHEUS_PULL_LIBS)
@@ -335,6 +336,7 @@ endif
 	$(BOOST_SYSTEM_LIB) \
 	$(BOOST_FILESYSTEM_LIB) \
 	$(BOOST_ASIO_LIB) \
+	$(BOOST_DATE_TIME_LIB) \
 	$(libnfct_LIBS)
   libopflex_agent_renderer_openvswitch_la_LIBADD = \
 	librenderer_openvswitch.la

--- a/agent-ovs/lib/test/PolicyManager_test.cpp
+++ b/agent-ovs/lib/test/PolicyManager_test.cpp
@@ -184,7 +184,6 @@ public:
         Mutator m0(framework, "policyelement");
         dnsEntry1 = dDiscoveredU.get()->addEpdrDnsEntry("maps.google.com");
         dnsEntry1.get()->setUpdated("Thu Mar 18 01:16:28 EDT 2021");
-        dnsEntry1.get()->setExpiry(300);
         std::string mappedAddress1("142.250.68.174"),mappedAddress2("142.250.68.175");
         dnsEntry1.get()->addEpdrDnsMappedAddress(mappedAddress1);
         dnsAns1 = dDiscoveredU.get()->addEpdrDnsAnswer(std::string("*.google.com"));
@@ -659,7 +658,6 @@ BOOST_FIXTURE_TEST_CASE( egress_dns_policy_add_remove, PolicyFixture ) {
     Mutator m0(framework, "policyelement");
     dnsEntry1 = dDiscoveredU.get()->addEpdrDnsEntry("maps.google.com");
     dnsEntry1.get()->setUpdated("Thu Mar 18 01:16:28 EDT 2021");
-    dnsEntry1.get()->setExpiry(300);
     std::string mappedAddress1("142.250.68.174"),mappedAddress2("142.250.68.175");
     dnsEntry1.get()->addEpdrDnsMappedAddress(mappedAddress1);
     dnsAns1 = dDiscoveredU.get()->addEpdrDnsAnswer(dnsName1);

--- a/genie/MODEL/SPECIFIC/EPR/epdr.mdl
+++ b/genie/MODEL/SPECIFIC/EPR/epdr.mdl
@@ -186,6 +186,7 @@ module[epdr]
           concrete]
     {
         member[address; type=address/IP]
+        member[expiry; type=ascii/String]
         named
         {
             parent[class=*;]
@@ -204,7 +205,6 @@ module[epdr]
           concrete]
     {
         member[updated; type=ascii/String]
-        member[expiry; type=scalar/UInt32]
         named
         {
             parent[class=*;]


### PR DESCRIPTION
As of now this is not a wheel timer.
Dns timer runs every 1 secs and expires entries
and updates related resolves.

TODO:
Convert to a wheel timer to handle scale.

Signed-off-by: Kiran Shastri <shastrinator@gmail.com>