### PR TITLE
Fix min prometheus-cpp version required for deb/rpm builds

### DIFF
--- a/agent-ovs/debian/control
+++ b/agent-ovs/debian/control
@@ -6,7 +6,7 @@ Build-Depends:
  debhelper (>= 8.0.0), autotools-dev, libboost-all-dev (>= 1.53),
  libopflex-dev, libmodelgbp-dev, libnoiro-openvswitch-dev (>= 2.12.0) <!norenderer>,
  libnoiro-openvswitch (>= 2.12.0) <!norenderer>, libnetfilter-conntrack-dev (>= 1.0) <!norenderer>,
- rapidjson-dev (>=1.1), pkgconf, dh-systemd, libssl-dev (>= 1.0), prometheus-cpp (>= 0.9.0),
+ rapidjson-dev (>=1.1), pkgconf, dh-systemd, libssl-dev (>= 1.0), prometheus-cpp (>= 0.12.1),
  libcurl4-openssl-dev, curl
 Standards-Version: 3.9.8
 Homepage: https://wiki.opendaylight.org/view/OpFlex:Main
@@ -53,7 +53,7 @@ Build-Profiles: <!norenderer>
 Depends:
  opflex-agent (>= ${binary:Version}),
  opflex-agent-renderer-openvswitch (>= ${binary:Version}),
- prometheus-cpp (>= 0.9.0)
+ prometheus-cpp (>= 0.12.1)
 Description: Transitional package for OpFlex Agent and OVS renderer
  This package depends on opflex-agent and
  opflex-agent-renderer-openvswitch to allow smoother transition from

--- a/agent-ovs/rpm/opflex-agent.spec.in
+++ b/agent-ovs/rpm/opflex-agent.spec.in
@@ -31,9 +31,9 @@ Requires: boost-system
 Requires: boost-date-time
 Requires: boost-thread
 Requires: boost-filesystem
-Requires: prometheus-cpp-lib >= 0.9.0
-BuildRequires: prometheus-cpp-lib >= 0.9.0
-BuildRequires: prometheus-cpp-devel >= 0.9.0
+Requires: prometheus-cpp-lib >= 0.12.1
+BuildRequires: prometheus-cpp-lib >= 0.12.1
+BuildRequires: prometheus-cpp-devel >= 0.12.1
 BuildRequires: boost-devel
 BuildRequires: boost-test
 BuildRequires: libopflex-devel
@@ -87,7 +87,7 @@ Group: Development/Libraries
 Requires: %{name} = %{epoch}:%{version}-%{release}
 Requires: libopflex >= %{version}
 Requires: libmodelgbp >= %{version}
-Requires: prometheus-cpp-lib >= 0.9.0
+Requires: prometheus-cpp-lib >= 0.12.1
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 
@@ -102,7 +102,7 @@ Requires: %{name} = %{epoch}:%{version}-%{release}
 Requires: pkgconfig
 Requires: libopflex-devel >= %{version}
 Requires: libnetfilter_conntrack-devel >= 1.0
-Requires: prometheus-cpp-devel >= 0.9.0
+Requires: prometheus-cpp-devel >= 0.12.1
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 Provides: libopflex_agent-static = %{version}-%{release}


### PR DESCRIPTION
Signed-off-by: Tom Flynn <tom.flynn@gmail.com>