### PR TITLE
Add DNS v6 record processing.

### DIFF
--- a/agent-ovs/ovs/include/DnsManager.h
+++ b/agent-ovs/ovs/include/DnsManager.h
@@ -107,6 +107,8 @@ public:
         RRTypeHINFO=13,
         RRTypeMINFO=14,
         //V6 Host Address
+        RRTypeA4=28,
+        //V6 Host Address
         RRTypeA6=38
     };
     class DnsQuestion {
@@ -136,6 +138,10 @@ public:
                 //Could be a max of 255 bytes
                 void *data;
             } rrTypeA6Data;
+            //RFC-1886,RFC-3596
+            struct {
+                uint8_t v6Bytes[16];
+            } rrTypeA4Data;
             struct {
                 void *data;
             } rrTypeCNameData;

--- a/agent-ovs/ovs/include/ip.h
+++ b/agent-ovs/ovs/include/ip.h
@@ -14,6 +14,7 @@
 
 namespace opflexagent {
 namespace ip {
+#define IP6_ADDR_LEN 16
 namespace type {
 /**
  * IP UDP type


### PR DESCRIPTION
Recursive resolution is not typically required for hosts.
Will add support if we find we need it.

Signed-off-by: Kiran Shastri <shastrinator@gmail.com>