### PR TITLE
Add session-affinity for services

### DIFF
--- a/agent-ovs/lib/FSServiceSource.cpp
+++ b/agent-ovs/lib/FSServiceSource.cpp
@@ -73,6 +73,9 @@ void FSServiceSource::updated(const fs::path& filePath) {
     static const std::string SM_NEXT_HOP_PORT("next-hop-port");
     static const std::string SM_NODE_PORT("node-port");
     static const std::string SM_CONNTRACK("conntrack-enabled");
+    static const std::string SESSION_AFFINITY("session-affinity");
+    static const std::string CLIENT_IP("client-ip");
+    static const std::string TIMEOUT_SECONDS("timeout-seconds");
     static const std::string SVC_ATTRIBUTES("attributes");
     try {
         using boost::property_tree::ptree;
@@ -250,6 +253,18 @@ void FSServiceSource::updated(const fs::path& filePath) {
                 if (conntrack)
                     sm.setConntrackMode(conntrack.get());
 
+                optional<const ptree&> sa =
+                    v.second.get_child_optional(SESSION_AFFINITY);
+                if (sa) {
+                    optional<const ptree&> clientIp =
+                        sa.get().get_child_optional(CLIENT_IP);
+                    if (clientIp) {
+                        optional<uint32_t> timeoutSecs =
+                            clientIp.get().get_optional<uint32_t>(TIMEOUT_SECONDS);
+                        if (timeoutSecs)
+                            sm.setClientAffinity(timeoutSecs.get());
+                    }
+                }
                 newserv.addServiceMapping(sm);
             }
         }

--- a/agent-ovs/lib/Service.cpp
+++ b/agent-ovs/lib/Service.cpp
@@ -81,6 +81,9 @@ std::ostream & operator<<(std::ostream &os, const Service& s) {
 
             if (sm.isConntrackMode())
                 os << " (conntrack)";
+
+            if (sm.getClientAffinity())
+                os << ",session-affinity-timeout:" << sm.getClientAffinity().get();
         }
 
         os << "]";

--- a/agent-ovs/lib/include/opflexagent/Service.h
+++ b/agent-ovs/lib/include/opflexagent/Service.h
@@ -486,6 +486,31 @@ public:
             return ctMode;
         }
 
+       /**
+        * Set the clientIp session affinity timeout
+        *
+        * @param saTimeoutSecs affinity value in seconds
+        */
+        void setClientAffinity(uint32_t saTimeoutSecs) {
+            this->saTimeoutSecs = saTimeoutSecs;
+        }
+
+       /**
+        * Unset the saTimeoutSecs
+        */
+        void unsetClientAffinity() {
+            saTimeoutSecs = boost::none;
+        }
+
+       /**
+        * Get the clientIp session affinity timeout
+        *
+        * @return affinity value in seconds
+        */
+        boost::optional<uint32_t> getClientAffinity() const {
+            return saTimeoutSecs;
+        }
+
     private:
         boost::optional<std::string> serviceIp;
         boost::optional<std::string> serviceProto;
@@ -494,6 +519,7 @@ public:
         std::set<std::string> nextHopIps;
         boost::optional<uint16_t> nextHopPort;
         boost::optional<uint16_t> nodePort;
+        boost::optional<uint32_t> saTimeoutSecs;
         bool ctMode;
     };
 

--- a/agent-ovs/ovs/FlowBuilder.cpp
+++ b/agent-ovs/ovs/FlowBuilder.cpp
@@ -70,6 +70,11 @@ FlowBuilder& FlowBuilder::inPort(uint32_t port) {
     return *this;
 }
 
+FlowBuilder& FlowBuilder::hardTimeout(int timeout) {
+    entry_->entry->hard_timeout = timeout;
+    return *this;
+}
+
 FlowBuilder& FlowBuilder::ethSrc(const uint8_t mac[6], const uint8_t mask[6]) {
     eth_addr macAddr;
     memcpy(&macAddr, mac, sizeof(eth_addr));

--- a/agent-ovs/ovs/FlowExecutor.cpp
+++ b/agent-ovs/ovs/FlowExecutor.cpp
@@ -152,7 +152,8 @@ FlowExecutor::EncodeMod<FlowEdit::Entry>(const FlowEdit::Entry& edit,
     /* fill out defaults */
     flowMod.modify_cookie = false;
     flowMod.idle_timeout = OFP_FLOW_PERMANENT;
-    flowMod.hard_timeout = OFP_FLOW_PERMANENT;
+    flowMod.hard_timeout = flow.hard_timeout ? flow.hard_timeout
+                                             : OFP_FLOW_PERMANENT;
     flowMod.buffer_id = UINT32_MAX;
     flowMod.out_port = OFPP_NONE;
     flowMod.out_group = OFPG_ANY;

--- a/agent-ovs/ovs/TableState.cpp
+++ b/agent-ovs/ovs/TableState.cpp
@@ -417,13 +417,22 @@ void TableState::apply(const std::string& objId,
             }
         } else {
             // there is no existing entry.  Add a new one
+            // Do not save entries with timeouts
+            // These can go away without knowledge of the
+            // agent and it would only be accurate to reprogram
+            // them if needed since there is a very tiny
+            // probability the new timeout is same as the
+            // remaining timeout
             FlowEntryPtr& toadd = e.second.back();
 
-            updateCookieMap(pimpl->cookie_map,
-                            0, toadd->entry->cookie,
-                            e.first);
+            if (toadd->entry->hard_timeout == 0) {
+                updateCookieMap(pimpl->cookie_map,
+                                0, toadd->entry->cookie,
+                                e.first);
 
-            pimpl->match_obj_map[e.first].push_back(make_pair(objId, toadd));
+                pimpl->match_obj_map[e.first].push_back(make_pair(objId, toadd));
+            }
+
             diffs.add(FlowEdit::ADD, toadd);
         }
     }

--- a/agent-ovs/ovs/include/FlowBuilder.h
+++ b/agent-ovs/ovs/include/FlowBuilder.h
@@ -100,6 +100,13 @@ public:
      */
     FlowBuilder& inPort(uint32_t port);
 
+   /**
+     * Set hard_timeout for flow entry
+     * @param timeout hard timeout in seconds
+     * @return this flow builder for chaining
+     */
+    FlowBuilder& hardTimeout(int timeout);
+
     /**
      * Add a match against ethernet source
      * @param mac the mac to match


### PR DESCRIPTION
client-ip affinity with a specified timeout ensures the same client
goes to the same backend using a hash on the nw_src field.
The above flow will be added at a higher prio than the regular 5 tuple
hash flow.
by using hard_timeout we ensure this flow is deleted by ovs once
timeout is reached at which affinity goes away and we start using
5 tuple hash from then on

affinity flow
 cookie=0x0, duration=14.224s, table=5, n_packets=0, n_bytes=0, hard_timeout=30, priority=51,ip,reg6=0xb,nw_dst=169.254.169.254 actions=set_field:00:22:bd:f8:19:ff->eth_src,set_field:e2:35:f9:9e:2c:3b->eth_dst,multipath(nw_src,1024,iter_hash,1,32,NXM_NX_REG7[]),goto_table:6

regular flow
 cookie=0x0, duration=14.224s, table=5, n_packets=0, n_bytes=0, priority=50,ip,reg6=0xb,nw_dst=169.254.169.254 actions=set_field:00:22:bd:f8:19:ff->eth_src,set_field:e2:35:f9:9e:2c:3b->eth_dst,multipath(symmetric_l3l4+udp,1024,iter_hash,1,32,NXM_NX_REG7[]),goto_table:6

Signed-off-by: Madhu Challa <challa@gmail.com>