### PR TITLE
Fix PacketIn for Access Bridge

### DIFF
--- a/agent-ovs/cmd/test/Policies.cpp
+++ b/agent-ovs/cmd/test/Policies.cpp
@@ -116,6 +116,10 @@ void Policies::writeTestPolicy(opflex::ofcore::OFFramework& framework) {
     shared_ptr<L24Classifier> classifier5;
     shared_ptr<L24Classifier> classifier6;
     shared_ptr<L24Classifier> classifier7;
+    shared_ptr<L24Classifier> classifier8;
+    shared_ptr<L24Classifier> classifier9;
+    shared_ptr<L24Classifier> classifier10;
+    shared_ptr<L24Classifier> classifier11;
 
     shared_ptr<Contract> con1;
     shared_ptr<Contract> con2;
@@ -126,6 +130,9 @@ void Policies::writeTestPolicy(opflex::ofcore::OFFramework& framework) {
     shared_ptr<SecGroup> secGrp1;
     shared_ptr<SecGroup> secGrp2;
     shared_ptr<SecGroup> secGrp3;
+    shared_ptr<SecGroup> secGrp4;
+    shared_ptr<SecGroup> secGrp5;
+    shared_ptr<SecGroup> secGrp6;
 
     shared_ptr<RedirectDestGroup> redirDstGrp1;
     shared_ptr<RedirectDest> redirDst1;
@@ -289,6 +296,30 @@ void Policies::writeTestPolicy(opflex::ofcore::OFFramework& framework) {
     classifier7->setOrder(90)
     .setEtherT(EtherTypeEnumT::CONST_IPV4);
 
+    // Pass all Ipv4 packets
+    classifier8 = space->addGbpeL24Classifier("classifier8");
+    classifier8->setOrder(90)
+    .setEtherT(EtherTypeEnumT::CONST_IPV4);
+
+    // Pass all Ipv6 packets
+    classifier9 = space->addGbpeL24Classifier("classifier9");
+    classifier9->setOrder(90)
+    .setEtherT(EtherTypeEnumT::CONST_IPV6);
+
+    // DNS client
+    classifier10 = space->addGbpeL24Classifier("classifier10");
+    classifier10->setEtherT(EtherTypeEnumT::CONST_IPV4)
+        .setProt(17)
+        .setDFromPort(53)
+        .setDToPort(53);
+
+    // DNS server
+    classifier11 = space->addGbpeL24Classifier("classifier11");
+    classifier11->setEtherT(EtherTypeEnumT::CONST_IPV4)
+        .setProt(17)
+        .setSFromPort(53)
+        .setSToPort(53);
+
     // Basic ARP and ICMP
     con1 = space->addGbpContract("contract1");
     con1->addGbpSubject("1_subject1")->addGbpRule("1_1_rule1")
@@ -383,6 +414,46 @@ void Policies::writeTestPolicy(opflex::ofcore::OFFramework& framework) {
         ->addGbpSecGroupRule("3_2_rule1")
         ->setDirection(DirectionEnumT::CONST_IN)
         .addGbpRuleToClassifierRSrc(classifier6->getURI().toString());
+    //DNS client
+    secGrp5 = space->addGbpSecGroup("secGrp5");
+    secGrp5->addGbpSecGroupSubject("5_subject1")
+        ->addGbpSecGroupRule("5_1_rule1")
+        ->setDirection(DirectionEnumT::CONST_OUT)
+        .addGbpRuleToClassifierRSrc(classifier10->getURI().toString());
+    secGrp5->addGbpSecGroupSubject("5_subject1")
+        ->addGbpSecGroupRule("5_1_rule2")
+        ->setDirection(DirectionEnumT::CONST_IN)
+        .addGbpRuleToClassifierRSrc(classifier11->getURI().toString());
+
+    //DNS server
+    secGrp6 = space->addGbpSecGroup("secGrp6");
+    secGrp6->addGbpSecGroupSubject("6_subject1")
+        ->addGbpSecGroupRule("6_1_rule1")
+        ->setDirection(DirectionEnumT::CONST_OUT)
+        .addGbpRuleToClassifierRSrc(classifier11->getURI().toString());
+    secGrp6->addGbpSecGroupSubject("6_subject1")
+        ->addGbpSecGroupRule("6_1_rule2")
+        ->setDirection(DirectionEnumT::CONST_IN)
+        .addGbpRuleToClassifierRSrc(classifier10->getURI().toString());
+
+    secGrp4 = space->addGbpSecGroup("secGrp4");
+    secGrp4->addGbpSecGroupSubject("4_subject1")
+        ->addGbpSecGroupRule("4_1_rule1")
+        ->setDirection(DirectionEnumT::CONST_OUT)
+        .addGbpRuleToClassifierRSrc(classifier8->getURI().toString());
+    secGrp4->addGbpSecGroupSubject("4_subject1")
+        ->addGbpSecGroupRule("4_1_rule1")
+        ->addGbpDnsName(std::string("google.com"));
+    secGrp4->addGbpSecGroupSubject("4_subject1")
+        ->addGbpSecGroupRule("4_1_rule2")
+        ->setDirection(DirectionEnumT::CONST_OUT)
+        .addGbpRuleToClassifierRSrc(classifier9->getURI().toString());
+    secGrp4->addGbpSecGroupSubject("4_subject1")
+        ->addGbpSecGroupRule("4_1_rule2")
+        ->addGbpDnsName(std::string("facebook.com"));
+    secGrp4->addGbpSecGroupSubject("4_subject1")
+        ->addGbpSecGroupRule("4_1_rule2")
+        ->addGbpDnsName(std::string("google.com"));
 
     // Add span related artifacts
     shared_ptr<span::Session> sess =

--- a/agent-ovs/lib/test/PolicyManager_test.cpp
+++ b/agent-ovs/lib/test/PolicyManager_test.cpp
@@ -649,9 +649,9 @@ BOOST_FIXTURE_TEST_CASE( egress_dns_policy_add_remove, PolicyFixture ) {
     PolicyManager& pm = agent.getPolicyManager();
     PolicyManager::rule_list_t rules;
     std::string dnsName1("*.google.com");
-    WAIT_FOR_DO(!rules.empty(), 500,
-        pm.getSecGroupRules(sec1->getURI(), rules));
-    auto dnsAsk1 = DnsAsk::resolve(framework,dnsName1);
+    optional<std::shared_ptr<DnsAsk>> dnsAsk1;
+    WAIT_FOR_DO(dnsAsk1, 500,
+        (dnsAsk1 = DnsAsk::resolve(framework,dnsName1)));
     BOOST_CHECK(dnsAsk1);
     /*Fake resolve DNS*/
     auto dDiscoveredU = DnsDiscovered::resolve(framework);
@@ -664,7 +664,7 @@ BOOST_FIXTURE_TEST_CASE( egress_dns_policy_add_remove, PolicyFixture ) {
     dnsAns1->addEpdrDnsAnswerToResultRSrc(dnsEntry1.get()->getURI().toString());
     dnsAns1->setUuid("1");
     m0.commit();
-    WAIT_FOR_DO(!rules.front()->getNamedAddresses().empty(), 500,
+    WAIT_FOR_DO(!rules.empty(), 500,
         rules.clear(); pm.getSecGroupRules(sec1->getURI(), rules));
     dnsEntry1.get()->addEpdrDnsMappedAddress(mappedAddress2);
     dnsAns1->setUuid("2");
@@ -673,7 +673,7 @@ BOOST_FIXTURE_TEST_CASE( egress_dns_policy_add_remove, PolicyFixture ) {
         rules.clear();pm.getSecGroupRules(sec1->getURI(), rules));
     dnsAns1->remove();
     m0.commit();
-    WAIT_FOR_DO(rules.front()->getNamedAddresses().empty(), 500,
+    WAIT_FOR_DO(rules.empty(), 500,
         rules.clear(); pm.getSecGroupRules(sec1->getURI(), rules));
     Mutator m1(framework, "policyreg");
     sec1->addGbpSecGroupSubject("sec1_sub1")->addGbpSecGroupRule("sec1_sub1_rule1")

--- a/agent-ovs/ovs/DnsManager.cpp
+++ b/agent-ovs/ovs/DnsManager.cpp
@@ -187,7 +187,7 @@ namespace opflexagent {
         io_ctxt.post([=]() {this->processPacket();});
     }
 
-    static bool ValidateDnsPacket(struct dp_packet *pkt,
+    static bool ValidateDnsPacket(const struct dp_packet *pkt,
                                   dns::dns_hdr **hdr,
                                   size_t &dnsOffset)
     {
@@ -461,7 +461,7 @@ namespace opflexagent {
         mutator.commit();
     }
 
-    DnsCachedAddress::DnsCachedAddress(DnsParsingContext::DnsRR dnsRR)
+    DnsCachedAddress::DnsCachedAddress(const DnsParsingContext::DnsRR &dnsRR)
     {
         using namespace boost::posix_time;
         boost::system::error_code ec;
@@ -509,7 +509,7 @@ namespace opflexagent {
         }
     }
 
-    bool DnsManager::handlePacket(struct dp_packet *pkt) {
+    bool DnsManager::handlePacket(const struct dp_packet *pkt) {
         struct dns::dns_hdr *hdr;
         size_t l5_offset = 0;
         if(!ValidateDnsPacket(pkt, &hdr, l5_offset)) {

--- a/agent-ovs/ovs/FlowConstants.cpp
+++ b/agent-ovs/ovs/FlowConstants.cpp
@@ -55,6 +55,7 @@ const uint64_t REMOTE_TUNNEL_BOUNCE_TO_NODE = 0xb;
 
 } // namespace out
 
+const uint64_t ACCESS_MASK = (out::MASK | access_meta::MASK);
 } // namespace meta
 
 } // namespace flow

--- a/agent-ovs/ovs/PacketInHandler.cpp
+++ b/agent-ovs/ovs/PacketInHandler.cpp
@@ -75,11 +75,15 @@ void PacketInHandler::setPortMapper(PortMapper* intMapper,
 void PacketInHandler::start() {
     if (intSwConnection)
         intSwConnection->RegisterMessageHandler(OFPTYPE_PACKET_IN, this);
+    if (accSwConnection)
+        accSwConnection->RegisterMessageHandler(OFPTYPE_PACKET_IN, this);
 }
 
 void PacketInHandler::stop() {
     if (intSwConnection)
         intSwConnection->UnregisterMessageHandler(OFPTYPE_PACKET_IN, this);
+    if (accSwConnection)
+        accSwConnection->UnregisterMessageHandler(OFPTYPE_PACKET_IN, this);
 }
 
 typedef std::function<void (ActionBuilder&)> output_act_t;

--- a/agent-ovs/ovs/include/DnsManager.h
+++ b/agent-ovs/ovs/include/DnsManager.h
@@ -158,7 +158,7 @@ public:
 
 class DnsCachedAddress {
 public:
-    DnsCachedAddress(DnsParsingContext::DnsRR dnsRR);
+    DnsCachedAddress(const DnsParsingContext::DnsRR &dnsRR);
     DnsCachedAddress(const std::string &addrStr):
 	expiryTime(boost::posix_time::second_clock::local_time()) {
 	boost::system::error_code ec;
@@ -174,7 +174,7 @@ class DnsManager;
 
 class DnsCacheEntry {
 public:
-    DnsCacheEntry(DnsParsingContext::DnsRR &dnsRR):
+    DnsCacheEntry(const DnsParsingContext::DnsRR &dnsRR):
         domainName(dnsRR.domainName),
         lastUpdated(dnsRR.currTime) {
         DnsCachedAddress cachedAddr(dnsRR);
@@ -274,7 +274,7 @@ private:
     void processURI(class_id_t class_id,
                     std::mutex &qMutex, std::queue<URI> &uriQ,
                     std::function<void (URI&, std::unordered_set<URI>&)> func);
-    bool handlePacket(struct dp_packet *pkt);
+    bool handlePacket(const struct dp_packet *pkt);
     void processPacket();
     void onExpiryTimer(const boost::system::error_code &e);
 };

--- a/agent-ovs/ovs/include/FlowConstants.h
+++ b/agent-ovs/ovs/include/FlowConstants.h
@@ -180,6 +180,19 @@ extern const uint64_t REMOTE_TUNNEL_BOUNCE_TO_CSR;
 extern const uint64_t REMOTE_TUNNEL_BOUNCE_TO_NODE;
 } // namespace out
 
+namespace access_meta {
+
+const uint64_t MASK =0xff00;
+/**
+ * Ingress to ep
+ */
+const uint64_t INGRESS_DIR = 0x100;
+/**
+ * Egress from ep
+ */
+const uint64_t EGRESS_DIR = 0x200;
+
+} // namespace access_meta
 
 namespace access_out {
 
@@ -198,8 +211,9 @@ const uint64_t PUSH_VLAN = 0x2;
  */
 const uint64_t UNTAGGED_AND_PUSH_VLAN = 0x3;
 
-} // namespace access
+} // namespace access_out
 
+extern const uint64_t ACCESS_MASK;
 } // namespace meta
 
 } // namespace flow

--- a/agent-ovs/ovs/test/AccessFlowManager_test.cpp
+++ b/agent-ovs/ovs/test/AccessFlowManager_test.cpp
@@ -539,31 +539,46 @@ void AccessFlowManagerFixture::initExpStatic() {
     ADDF(Bldr().table(OUT).priority(1).isMdAct(0)
          .actions().out(OUTPORT).done());
     ADDF(Bldr().table(OUT).priority(1)
-         .isMdAct(opflexagent::flow::meta::access_out::PUSH_VLAN)
+         .isMdAct(opflexagent::flow::meta::access_out::PUSH_VLAN,
+                  opflexagent::flow::meta::out::MASK)
          .actions().pushVlan().move(FD12, VLAN).out(OUTPORT).done());
     ADDF(Bldr().table(OUT).priority(1)
-         .isMdAct(opflexagent::flow::meta::access_out::UNTAGGED_AND_PUSH_VLAN)
+         .isMdAct(opflexagent::flow::meta::access_out::UNTAGGED_AND_PUSH_VLAN,
+                  opflexagent::flow::meta::out::MASK)
          .actions().out(OUTPORT).pushVlan()
          .move(FD12, VLAN).out(OUTPORT).done());
     ADDF(Bldr().table(OUT).priority(1)
-         .isMdAct(opflexagent::flow::meta::access_out::POP_VLAN)
+         .isMdAct(opflexagent::flow::meta::access_out::POP_VLAN,
+                  opflexagent::flow::meta::out::MASK)
          .isVlanTci("0x1000/0x1000")
          .actions().popVlan().out(OUTPORT).done());
     ADDF(Bldr().table(TAP).priority(2)
          .cookie(ovs_ntohll(opflexagent::flow::cookie::DNS_RESPONSE_V4))
-         .tcp().isTpSrc(53)
+         .tcp()
+         .isMdAct(opflexagent::flow::meta::access_meta::INGRESS_DIR,
+                  opflexagent::flow::meta::access_meta::MASK)
+         .isTpSrc(53)
          .actions().controller(65535).go(OUT).done());
     ADDF(Bldr().table(TAP).priority(2)
          .cookie(ovs_ntohll(opflexagent::flow::cookie::DNS_RESPONSE_V6))
-         .tcp6().isTpSrc(53)
+         .tcp6()
+         .isMdAct(opflexagent::flow::meta::access_meta::INGRESS_DIR,
+                  opflexagent::flow::meta::access_meta::MASK)
+         .isTpSrc(53)
          .actions().controller(65535).go(OUT).done());
     ADDF(Bldr().table(TAP).priority(2)
          .cookie(ovs_ntohll(opflexagent::flow::cookie::DNS_RESPONSE_V4))
-         .udp().isTpSrc(53)
+         .udp()
+         .isMdAct(opflexagent::flow::meta::access_meta::INGRESS_DIR,
+                  opflexagent::flow::meta::access_meta::MASK)
+         .isTpSrc(53)
          .actions().controller(65535).go(OUT).done());
     ADDF(Bldr().table(TAP).priority(2)
          .cookie(ovs_ntohll(opflexagent::flow::cookie::DNS_RESPONSE_V6))
-         .udp6().isTpSrc(53)
+         .udp6()
+         .isMdAct(opflexagent::flow::meta::access_meta::INGRESS_DIR,
+                  opflexagent::flow::meta::access_meta::MASK)
+         .isTpSrc(53)
          .actions().controller(65535).go(OUT).done());
     ADDF(Bldr().table(TAP).priority(1)
          .actions().go(OUT).done());
@@ -597,7 +612,9 @@ void AccessFlowManagerFixture::initExpDhcpEp(shared_ptr<Endpoint>& ep) {
              .isTpSrc(68).isTpDst(67)
              .actions()
              .load(OUTPORT, uplink)
-             .mdAct(opflexagent::flow::meta::access_out::POP_VLAN)
+             .meta((opflexagent::flow::meta::access_meta::EGRESS_DIR|
+                    opflexagent::flow::meta::access_out::POP_VLAN),
+                   opflexagent::flow::meta::ACCESS_MASK)
              .go(TAP).done());
         if (ep->isAccessAllowUntagged() && ep->getAccessIfaceVlan()) {
             ADDF(Bldr()
@@ -606,6 +623,8 @@ void AccessFlowManagerFixture::initExpDhcpEp(shared_ptr<Endpoint>& ep) {
                  .isTpSrc(68).isTpDst(67)
                  .actions()
                  .load(OUTPORT, uplink)
+                 .meta(opflexagent::flow::meta::access_meta::EGRESS_DIR,
+                       opflexagent::flow::meta::ACCESS_MASK)
                  .go(TAP).done());
         }
     }
@@ -616,7 +635,9 @@ void AccessFlowManagerFixture::initExpDhcpEp(shared_ptr<Endpoint>& ep) {
              .isTpSrc(546).isTpDst(547)
              .actions()
              .load(OUTPORT, uplink)
-             .mdAct(opflexagent::flow::meta::access_out::POP_VLAN)
+             .meta((opflexagent::flow::meta::access_meta::EGRESS_DIR|
+                    opflexagent::flow::meta::access_out::POP_VLAN),
+                   opflexagent::flow::meta::ACCESS_MASK)
              .go(TAP).done());
         if (ep->isAccessAllowUntagged() && ep->getAccessIfaceVlan()) {
             ADDF(Bldr()
@@ -625,6 +646,8 @@ void AccessFlowManagerFixture::initExpDhcpEp(shared_ptr<Endpoint>& ep) {
                  .isTpSrc(546).isTpDst(547)
                  .actions()
                  .load(OUTPORT, uplink)
+                 .meta(opflexagent::flow::meta::access_meta::EGRESS_DIR,
+                       opflexagent::flow::meta::ACCESS_MASK)
                  .go(TAP).done());
         }
     }
@@ -643,7 +666,9 @@ void AccessFlowManagerFixture::initExpEp(shared_ptr<Endpoint>& ep) {
              .actions()
              .load(RD, zoneId).load(SEPG, 1)
              .load(OUTPORT, uplink)
-             .mdAct(opflexagent::flow::meta::access_out::POP_VLAN)
+             .meta((opflexagent::flow::meta::access_out::POP_VLAN|
+                    opflexagent::flow::meta::access_meta::EGRESS_DIR),
+                   opflexagent::flow::meta::ACCESS_MASK)
              .go(OUT_POL).done());
         if (ep->isAccessAllowUntagged()) {
             ADDF(Bldr().table(GRP).priority(99).in(access)
@@ -651,21 +676,31 @@ void AccessFlowManagerFixture::initExpEp(shared_ptr<Endpoint>& ep) {
                  .actions()
                  .load(RD, zoneId).load(SEPG, 1)
                  .load(OUTPORT, uplink)
+                 .meta(opflexagent::flow::meta::access_meta::EGRESS_DIR,
+                       opflexagent::flow::meta::access_meta::MASK)
                  .go(OUT_POL).done());
         }
         ADDF(Bldr().table(GRP).priority(100).in(uplink)
              .actions().load(RD, zoneId).load(SEPG, 1).load(OUTPORT, access)
              .load(FD, ep->getAccessIfaceVlan().get())
-             .mdAct(opflexagent::flow::meta::access_out::PUSH_VLAN)
+             .meta((opflexagent::flow::meta::access_out::PUSH_VLAN|
+                    opflexagent::flow::meta::access_meta::INGRESS_DIR),
+                   opflexagent::flow::meta::ACCESS_MASK)
              .go(IN_POL).done());
     } else {
         ADDF(Bldr().table(GRP).priority(100).in(access)
              .noVlan()
              .actions().load(RD, zoneId).load(SEPG, 1)
-             .load(OUTPORT, uplink).go(OUT_POL).done());
+             .load(OUTPORT, uplink)
+             .meta(opflexagent::flow::meta::access_meta::EGRESS_DIR,
+                   opflexagent::flow::meta::access_meta::MASK)
+             .go(OUT_POL).done());
         ADDF(Bldr().table(GRP).priority(100).in(uplink)
              .actions().load(RD, zoneId).load(SEPG, 1)
-             .load(OUTPORT, access).go(IN_POL).done());
+             .load(OUTPORT, access)
+             .meta(opflexagent::flow::meta::access_meta::INGRESS_DIR,
+                   opflexagent::flow::meta::access_meta::MASK)
+             .go(IN_POL).done());
     }
 }
 

--- a/agent-ovs/ovs/test/include/FlowManagerFixture.h
+++ b/agent-ovs/ovs/test/include/FlowManagerFixture.h
@@ -207,6 +207,9 @@ public:
     Bldr& isMdAct(uint8_t a) {
         m("metadata", str(a, true) + "/0xff"); return *this;
     }
+    Bldr& isMdAct(uint32_t a, uint32_t mask) {
+        m("metadata", str(a, true) + "/" + str(mask, true)); return *this;
+    }
     Bldr& isPolicyApplied() { m("metadata", "0x100/0x100"); return *this; }
     Bldr& isToHostAccess() { m("metadata", "0x8/0xff"); return *this; }
     Bldr& isFromServiceIface(bool yes = true) {


### PR DESCRIPTION
Register packetin handler for access bridge.
Avoid duplicate packet punting by adding a metadata flag for direction
in access bridge.
EGRESS_DIR -> from ep
INGRESS_DIR -> to ep
Skip programming DNS rules till atleast one name in the set is resolved,
otherwise all ip/v6 flows will be allowed till first DNS name in rule is resolved.
Fix LGTM warning.

Signed-off-by: Kiran Shastri <shastrinator@gmail.com>