### PR TITLE
handle remoteIp delete properly (#373)

### DIFF
--- a/agent-ovs/lib/EndpointManager.cpp
+++ b/agent-ovs/lib/EndpointManager.cpp
@@ -73,6 +73,7 @@ void EndpointManager::start() {
     EpAttributeSet::registerListener(framework, &epgMappingListener);
     RemoteEndpointInventory::registerListener(framework, &epgMappingListener);
     RemoteInventoryEp::registerListener(framework, &epgMappingListener);
+    RemoteIp::registerListener(framework, &epgMappingListener);
     policyManager.registerListener(this);
 }
 
@@ -1042,7 +1043,14 @@ void EndpointManager::EPGMappingListener::objectUpdated(class_id_t classId,
         }
     } else if (classId == modelgbp::inv::RemoteInventoryEp::CLASS_ID) {
         epmanager.updateEndpointRemote(uri);
-    }
+    } else if (classId == modelgbp::inv::RemoteIp::CLASS_ID) {
+        boost::filesystem::path puri(uri.toString());
+        puri = puri.parent_path()
+                   .parent_path()
+                   .parent_path();
+        URI curi(puri.string() + "/");
+        epmanager.updateEndpointRemote(curi);
+   }
 }
 
 void EndpointManager::configUpdated(const URI& uri) {


### PR DESCRIPTION
There are 2 ways to delete a remoteIp
1. send update / replace for the remoteEp without the remoteIp

Is handled correctly because the notif code gets the correct
remoteEp Mo which then triggers the remoteEp update

2. delete the remoteIp alone

This case is not handled today. there is no listener to this update
so no notif happens.

Based on the logs CSCvx60417 / 	690770038 this is whats happening here.

This is normally not an issue if the same remoteIp is updated later,
in this case the remoteIp is a VIP. But if the VIP to VTEP mapping
changes and update does not come through we end up with a flow
for the VIP thats using a stale VTEP.

This fix ensures we handle this case and delete the stale flow
right away, any time you see this log

[2021-Mar-25 22:41:12.968729] [debug] [Processor.cpp:524:processItem] Purging state for /InvUniverse/InvRemoteEndpointInventory/InvRemoteInventoryEp/2f40f94e-6d15-490a-ae36-cdaf21862d59%7cfa-16-3e-6b-03-cf/InvRemoteIp/10.60.30.250/ in state remote

Even if update does not come, the flow table is consistent and the worst that
will happen is the packet that should use the new mapping from the VIP -> new VTEP
ends up going to leaf where its forwarded correctly in the absense of the stale flow.

testing
=======

Initial:
=======

root@mchalla-X570-I-AORUS-PRO-WIFI:~# ovs-ofctl dump-flows br-fabric -OOpenFlow13 | grep 10.60.30.250
 cookie=0x0, duration=1.161s, table=5, n_packets=0, n_bytes=0, priority=40,arp,reg4=0x21,reg6=0x5,dl_dst=ff:ff:ff:ff:ff:ff,arp_tpa=10.60.30.250,arp_op=1 actions=move:NXM_OF_ETH_SRC[]->NXM_OF_ETH_DST[],load:0xfa163e6b03cf->NXM_OF_ETH_SRC[],load:0x2->NXM_OF_ARP_OP[],move:NXM_NX_ARP_SHA[]->NXM_NX_ARP_THA[],load:0xfa163e6b03cf->NXM_NX_ARP_SHA[],move:NXM_OF_ARP_SPA[]->NXM_OF_ARP_TPA[],load:0xa3c1efa->NXM_OF_ARP_SPA[],IN_PORT
 cookie=0x0, duration=1.134s, table=7, n_packets=0, n_bytes=0, priority=500,ip,reg6=0x5,dl_dst=00:22:bd:f8:19:ff,nw_dst=10.60.30.250 actions=load:0xac117841->NXM_NX_REG7[],load:0x748000->NXM_NX_REG2[],write_metadata:0x7/0xff,goto_table:12

On Delete:
==========

root@mchalla-X570-I-AORUS-PRO-WIFI:~/work/opflex/agent-ovs# gbp_client_stress_del 10 100 del.json
[2021-Apr-22 16:17:40.144706] [debug] [OpflexPEHandler.cpp:409:handlePolicyUpdateReq] [
    {
        "replace": [],
        "merge_children": [],
        "delete": [
            {
                "subject": "InvRemoteIp",
                "uri": "/InvUniverse/InvRemoteEndpointInventory/InvRemoteInventoryEp/2f40f94e-6d15-490a-ae36-cdaf21862d59%7cfa-16-3e-6b-03-cf/InvRemoteIp/10.60.30.250/"
            }
        ]
    }
]
[2021-Apr-22 16:17:40.145264] [debug] [lib/EndpointManager.cpp:520:updateEndpointRemote] Remote endpoint updated /InvUniverse/InvRemoteEndpointInventory/InvRemoteInventoryEp/2f40f94e-6d15-490a-ae36-cdaf21862d59%7cfa-16-3e-6b-03-cf/
[2021-Apr-22 16:17:40.145435] [debug] [Processor.cpp:373:processItem] Processing nonlocal item /InvUniverse/InvRemoteEndpointInventory/InvRemoteInventoryEp/2f40f94e-6d15-490a-ae36-cdaf21862d59%7cfa-16-3e-6b-03-cf/InvRemoteIp/10.60.30.250/ of class InvRemoteIp and type 4 in state remote
[2021-Apr-22 16:17:40.145532] [debug] [Processor.cpp:524:processItem] Purging state for /InvUniverse/InvRemoteEndpointInventory/InvRemoteInventoryEp/2f40f94e-6d15-490a-ae36-cdaf21862d59%7cfa-16-3e-6b-03-cf/InvRemoteIp/10.60.30.250/ in state remote
[2021-Apr-22 16:17:40.145627] [debug] [ovs/IntFlowManager.cpp:1466:handleRemoteEndpointUpdate] Updating remote endpoint 2f40f94e-6d15-490a-ae36-cdaf21862d59|fa-16-3e-6b-03-cf
[2021-Apr-22 16:17:40.146096] [debug] [ovs/TableState.cpp:496:apply] ObjId=2f40f94e-6d15-490a-ae36-cdaf21862d59|fa-16-3e-6b-03-cf, #diffs = 1
[2021-Apr-22 16:17:40.146215] [debug] [ovs/TableState.cpp:498:apply] DEL|cookie=0x0, duration=0s, table=5, n_packets=0, n_bytes=0, idle_age=0, priority=40,arp,reg4=0x21,reg6=0x5,dl_dst=ff:ff:ff:ff:ff:ff,arp_tpa=10.60.30.250,arp_op=1 actions=move:NXM_OF_ETH_SRC[]->NXM_OF_ETH_DST[],load:0xfa163e6b03cf->NXM_OF_ETH_SRC[],load:0x2->NXM_OF_ARP_OP[],move:NXM_NX_ARP_SHA[]->NXM_NX_ARP_THA[],load:0xfa163e6b03cf->NXM_NX_ARP_SHA[],move:NXM_OF_ARP_SPA[]->NXM_OF_ARP_TPA[],load:0xa3c1efa->NXM_OF_ARP_SPA[],IN_PORT
[2021-Apr-22 16:17:40.146333] [debug] [ovs/FlowExecutor.cpp:212:DoExecuteNoBlock] [br-fabric] Executing xid=2607, DEL|cookie=0x0, duration=0s, table=5, n_packets=0, n_bytes=0, idle_age=0, priority=40,arp,reg4=0x21,reg6=0x5,dl_dst=ff:ff:ff:ff:ff:ff,arp_tpa=10.60.30.250,arp_op=1 actions=move:NXM_OF_ETH_SRC[]->NXM_OF_ETH_DST[],load:0xfa163e6b03cf->NXM_OF_ETH_SRC[],load:0x2->NXM_OF_ARP_OP[],move:NXM_NX_ARP_SHA[]->NXM_NX_ARP_THA[],load:0xfa163e6b03cf->NXM_NX_ARP_SHA[],move:NXM_OF_ARP_SPA[]->NXM_OF_ARP_TPA[],load:0xa3c1efa->NXM_OF_ARP_SPA[],IN_PORT
[2021-Apr-22 16:17:40.146410] [debug] [ovs/FlowExecutor.cpp:228:WaitOnBarrier] [br-fabric] Sending barrier request xid=772407296
[2021-Apr-22 16:17:40.146997] [debug] [ovs/TableState.cpp:496:apply] ObjId=2f40f94e-6d15-490a-ae36-cdaf21862d59|fa-16-3e-6b-03-cf, #diffs = 1
[2021-Apr-22 16:17:40.147106] [debug] [ovs/TableState.cpp:498:apply] DEL|cookie=0x0, duration=0s, table=7, n_packets=0, n_bytes=0, idle_age=0, priority=500,ip,reg6=0x5,dl_dst=00:22:bd:f8:19:ff,nw_dst=10.60.30.250 actions=load:0xac117841->NXM_NX_REG7[],load:0x748000->NXM_NX_REG2[],write_metadata:0x7/0xff,goto_table:12
[2021-Apr-22 16:17:40.147201] [debug] [ovs/FlowExecutor.cpp:212:DoExecuteNoBlock] [br-fabric] Executing xid=2609, DEL|cookie=0x0, duration=0s, table=7, n_packets=0, n_bytes=0, idle_age=0, priority=500,ip,reg6=0x5,dl_dst=00:22:bd:f8:19:ff,nw_dst=10.60.30.250 actions=load:0xac117841->NXM_NX_REG7[],load:0x748000->NXM_NX_REG2[],write_metadata:0x7/0xff,goto_table:12
[2021-Apr-22 16:17:40.147265] [debug] [ovs/FlowExecutor.cpp:228:WaitOnBarrier] [br-fabric] Sending barrier request xid=805961728
[2021-Apr-22 16:17:47.851912] [debug] [Processor.cpp:373:processItem] Processing local item /ObserverSysStatUniverse/ of class ObserverSysStatUniverse and type 4 in state updated
[2021-Apr-22 16:17:48.105010] [debug] [Processor.cpp:373:processItem] Processing local item /ObserverPolicyStatUniverse/ of class ObserverPolicyStatUniverse and type 4 in state updated
[2021-Apr-22 16:17:48.105465] [debug] [Processor.cpp:373:processItem] Processing local item / of class DmtreeRoot and type 4 in state updated

root@mchalla-X570-I-AORUS-PRO-WIFI:~# ovs-ofctl dump-flows br-fabric -OOpenFlow13 | grep 10.60.30.250
root@mchalla-X570-I-AORUS-PRO-WIFI:~#

On Add
======

[2021-Apr-22 16:19:05.196269] [debug] [OpflexPEHandler.cpp:409:handlePolicyUpdateReq] [
    {
        "replace": [],
        "merge_children": [
            {
                "subject": "InvRemoteIp",
                "uri": "/InvUniverse/InvRemoteEndpointInventory/InvRemoteInventoryEp/2f40f94e-6d15-490a-ae36-cdaf21862d59%7cfa-16-3e-6b-03-cf/InvRemoteIp/10.60.30.250/",
                "properties": [
                    {
                        "name": "ip",
                        "data": "10.60.30.250"
                    }
                ],
                "children": [],
                "parent_subject": "InvRemoteInventoryEp",
                "parent_uri": "/InvUniverse/InvRemoteEndpointInventory/InvRemoteInventoryEp/2f40f94e-6d15-490a-ae36-cdaf21862d59%7cfa-16-3e-6b-03-cf/",
                "parent_relation": "InvRemoteIp"
            }
        ],
        "delete": []
    }
]
[2021-Apr-22 16:19:05.196555] [debug] [MOSerializer.cpp:331:deserialize] Updated object /InvUniverse/InvRemoteEndpointInventory/InvRemoteInventoryEp/2f40f94e-6d15-490a-ae36-cdaf21862d59%7cfa-16-3e-6b-03-cf/InvRemoteIp/10.60.30.250/
[2021-Apr-22 16:19:05.196891] [debug] [lib/EndpointManager.cpp:520:updateEndpointRemote] Remote endpoint updated /InvUniverse/InvRemoteEndpointInventory/InvRemoteInventoryEp/2f40f94e-6d15-490a-ae36-cdaf21862d59%7cfa-16-3e-6b-03-cf/
[2021-Apr-22 16:19:05.197054] [debug] [Processor.cpp:373:processItem] Processing nonlocal item /InvUniverse/InvRemoteEndpointInventory/InvRemoteInventoryEp/2f40f94e-6d15-490a-ae36-cdaf21862d59%7cfa-16-3e-6b-03-cf/ of class InvRemoteInventoryEp and type 4 in state remote
[2021-Apr-22 16:19:05.197221] [debug] [ovs/IntFlowManager.cpp:1466:handleRemoteEndpointUpdate] Updating remote endpoint 2f40f94e-6d15-490a-ae36-cdaf21862d59|fa-16-3e-6b-03-cf
[2021-Apr-22 16:19:05.197319] [debug] [Processor.cpp:654:objectUpdated] Tracking new nonlocal item /InvUniverse/InvRemoteEndpointInventory/InvRemoteInventoryEp/2f40f94e-6d15-490a-ae36-cdaf21862d59%7cfa-16-3e-6b-03-cf/InvRemoteIp/10.60.30.250/ from update
[2021-Apr-22 16:19:05.197446] [debug] [lib/EndpointManager.cpp:520:updateEndpointRemote] Remote endpoint updated /InvUniverse/InvRemoteEndpointInventory/InvRemoteInventoryEp/2f40f94e-6d15-490a-ae36-cdaf21862d59%7cfa-16-3e-6b-03-cf/
[2021-Apr-22 16:19:05.197500] [debug] [Processor.cpp:373:processItem] Processing nonlocal item /InvUniverse/InvRemoteEndpointInventory/InvRemoteInventoryEp/2f40f94e-6d15-490a-ae36-cdaf21862d59%7cfa-16-3e-6b-03-cf/InvRemoteIp/10.60.30.250/ of class InvRemoteIp and type 4 in state remote
[2021-Apr-22 16:19:05.197730] [debug] [ovs/TableState.cpp:496:apply] ObjId=2f40f94e-6d15-490a-ae36-cdaf21862d59|fa-16-3e-6b-03-cf, #diffs = 1
[2021-Apr-22 16:19:05.197848] [debug] [ovs/TableState.cpp:498:apply] ADD|cookie=0x0, duration=0s, table=5, n_packets=0, n_bytes=0, idle_age=0, priority=40,arp,reg4=0x21,reg6=0x5,dl_dst=ff:ff:ff:ff:ff:ff,arp_tpa=10.60.30.250,arp_op=1 actions=move:NXM_OF_ETH_SRC[]->NXM_OF_ETH_DST[],load:0xfa163e6b03cf->NXM_OF_ETH_SRC[],load:0x2->NXM_OF_ARP_OP[],move:NXM_NX_ARP_SHA[]->NXM_NX_ARP_THA[],load:0xfa163e6b03cf->NXM_NX_ARP_SHA[],move:NXM_OF_ARP_SPA[]->NXM_OF_ARP_TPA[],load:0xa3c1efa->NXM_OF_ARP_SPA[],IN_PORT
[2021-Apr-22 16:19:05.197970] [debug] [ovs/FlowExecutor.cpp:212:DoExecuteNoBlock] [br-fabric] Executing xid=2728, ADD|cookie=0x0, duration=0s, table=5, n_packets=0, n_bytes=0, idle_age=0, priority=40,arp,reg4=0x21,reg6=0x5,dl_dst=ff:ff:ff:ff:ff:ff,arp_tpa=10.60.30.250,arp_op=1 actions=move:NXM_OF_ETH_SRC[]->NXM_OF_ETH_DST[],load:0xfa163e6b03cf->NXM_OF_ETH_SRC[],load:0x2->NXM_OF_ARP_OP[],move:NXM_NX_ARP_SHA[]->NXM_NX_ARP_THA[],load:0xfa163e6b03cf->NXM_NX_ARP_SHA[],move:NXM_OF_ARP_SPA[]->NXM_OF_ARP_TPA[],load:0xa3c1efa->NXM_OF_ARP_SPA[],IN_PORT
[2021-Apr-22 16:19:05.198047] [debug] [ovs/FlowExecutor.cpp:228:WaitOnBarrier] [br-fabric] Sending barrier request xid=2802450432
[2021-Apr-22 16:19:05.198254] [debug] [Processor.cpp:373:processItem] Processing nonlocal item /InvUniverse/InvRemoteEndpointInventory/ of class InvRemoteEndpointInventory and type 0 in state resolved
[2021-Apr-22 16:19:05.198376] [debug] [ovs/TableState.cpp:496:apply] ObjId=2f40f94e-6d15-490a-ae36-cdaf21862d59|fa-16-3e-6b-03-cf, #diffs = 1
[2021-Apr-22 16:19:05.198495] [debug] [ovs/TableState.cpp:498:apply] ADD|cookie=0x0, duration=0s, table=7, n_packets=0, n_bytes=0, idle_age=0, priority=500,ip,reg6=0x5,dl_dst=00:22:bd:f8:19:ff,nw_dst=10.60.30.250 actions=load:0xac117841->NXM_NX_REG7[],load:0x748000->NXM_NX_REG2[],write_metadata:0x7/0xff,goto_table:12
[2021-Apr-22 16:19:05.198604] [debug] [ovs/FlowExecutor.cpp:212:DoExecuteNoBlock] [br-fabric] Executing xid=2730, ADD|cookie=0x0, duration=0s, table=7, n_packets=0, n_bytes=0, idle_age=0, priority=500,ip,reg6=0x5,dl_dst=00:22:bd:f8:19:ff,nw_dst=10.60.30.250 actions=load:0xac117841->NXM_NX_REG7[],load:0x748000->NXM_NX_REG2[],write_metadata:0x7/0xff,goto_table:12
[2021-Apr-22 16:19:05.198680] [debug] [ovs/FlowExecutor.cpp:228:WaitOnBarrier] [br-fabric] Sending barrier request xid=2836004864

root@mchalla-X570-I-AORUS-PRO-WIFI:~# ovs-ofctl dump-flows br-fabric -OOpenFlow13 | grep 10.60.30.250
 cookie=0x0, duration=61.459s, table=5, n_packets=0, n_bytes=0, priority=40,arp,reg4=0x21,reg6=0x5,dl_dst=ff:ff:ff:ff:ff:ff,arp_tpa=10.60.30.250,arp_op=1 actions=move:NXM_OF_ETH_SRC[]->NXM_OF_ETH_DST[],load:0xfa163e6b03cf->NXM_OF_ETH_SRC[],load:0x2->NXM_OF_ARP_OP[],move:NXM_NX_ARP_SHA[]->NXM_NX_ARP_THA[],load:0xfa163e6b03cf->NXM_NX_ARP_SHA[],move:NXM_OF_ARP_SPA[]->NXM_OF_ARP_TPA[],load:0xa3c1efa->NXM_OF_ARP_SPA[],IN_PORT
 cookie=0x0, duration=61.460s, table=7, n_packets=0, n_bytes=0, priority=500,ip,reg6=0x5,dl_dst=00:22:bd:f8:19:ff,nw_dst=10.60.30.250 actions=load:0xac117841->NXM_NX_REG7[],load:0x748000->NXM_NX_REG2[],write_metadata:0x7/0xff,goto_table:12

Signed-off-by: Madhu Challa <challa@gmail.com>