### PR TITLE
Fix nat rules priority across all routed prefixes.

### DIFF
--- a/agent-ovs/ovs/IntFlowManager.cpp
+++ b/agent-ovs/ovs/IntFlowManager.cpp
@@ -5647,14 +5647,15 @@ void IntFlowManager::handleRoutingDomainUpdate(const URI& rdURI) {
 
                 {
                     FlowBuilder snr;
-                    matchSubnet(snr, rdId, 150, addr,
+                    matchSubnet(snr, rdId, 40, addr,
                                 extsub->getPrefixLen(0), false);
 
                     if (natRef) {
+                        uint16_t natprio = addr.is_v4() ? 40 : 130;
                         // For external networks mapped to a NAT EPG,
                         // set the next hop action to NAT_OUT
                         if (natEpgVnid) {
-                            snr.priority(151 + extsub->getPrefixLen(0))
+                            snr.priority(40 + natprio + extsub->getPrefixLen(0))
                                 .action()
                                 .reg(MFF_REG2, netVnid)
                                 .reg(MFF_REG7, natEpgVnid.get())

--- a/agent-ovs/ovs/test/IntFlowManager_test.cpp
+++ b/agent-ovs/ovs/test/IntFlowManager_test.cpp
@@ -3001,20 +3001,20 @@ void BaseIntFlowManagerFixture::initExpIpMapping(bool natEpgMap, bool nextHop) {
          .controller(65535).done());
 
     if (natEpgMap) {
-        ADDF(Bldr().table(RT).priority(167).ipv6().reg(RD, 1)
+        ADDF(Bldr().table(RT).priority(186).ipv6().reg(RD, 1)
              .isIpv6Dst("fdf1::/16")
              .actions().load(DEPG, 0x80000001).load(OUTPORT, 0x4242)
              .mdAct(opflexagent::flow::meta::out::NAT).go(POL).done());
-        ADDF(Bldr().table(RT).priority(159).ip().reg(RD, 1)
+        ADDF(Bldr().table(RT).priority(88).ip().reg(RD, 1)
              .isIpDst("5.0.0.0/8")
              .actions().load(DEPG, 0x80000001).load(OUTPORT, 0x4242)
              .mdAct(opflexagent::flow::meta::out::NAT).go(POL).done());
     } else {
-        ADDF(Bldr().table(RT).priority(166).ipv6().reg(RD, 1)
+        ADDF(Bldr().table(RT).priority(56).ipv6().reg(RD, 1)
              .isIpv6Dst("fdf1::/16")
              .actions().mdAct(opflexagent::flow::meta::out::TUNNEL)
              .go(STAT).done());
-        ADDF(Bldr().table(RT).priority(158).ip().reg(RD, 1)
+        ADDF(Bldr().table(RT).priority(48).ip().reg(RD, 1)
              .isIpDst("5.0.0.0/8")
              .actions().mdAct(opflexagent::flow::meta::out::TUNNEL)
              .go(STAT).done());


### PR DESCRIPTION
This is a rework of
https://github.com/noironetworks/opflex/commit/aee03cc208f2733cae3a35478db6d36570baade7

By giving nat flows +1 prio, does not fully solve the problem.
we can have another routed prefix that would fall at the same
priority as the nat one and if the subnets are overlapping the
packets would take the non nat path.

In bosch they had
nw_dst=10.128.0.0/9 non-nat
nw_dst=10.0.0.0/9 non-nat
nw_dst=10.0.0.0/8 nat

with current code this would result in all the 3 flows to use prio=159 which
makes it non deterministic and back to the original problem we had.
I took this approach initially because we did not have a big enough hole
for all the priorities esp for v6.

But since it does not work the fix considered 2 designs
- assign nat priorities dynamically based on subnet/prefix of existing
  routed flows.
- move ext subnet routed prio down from 150 to 40 to create a window
  big enough to satisfy v6.

The first approach needs tracking subnet/prefix and dynamically
computing overlapping nat subnet/prefix prio based on that. however
as far as total priorities we might need in worst case goes its same
as the second approach.

Signed-off-by: Madhu Challa <challa@gmail.com>