### PR TITLE
Restore DNS cache on reboot

### DIFF
--- a/agent-ovs/Makefile.am
+++ b/agent-ovs/Makefile.am
@@ -705,9 +705,11 @@ opflex-agent-ovs.conf: $(top_srcdir)/opflex-agent-ovs.conf.in
 
 flowidcachedir=${localstatedir}/lib/opflex-agent-ovs/ids
 mcastgroupfile=${localstatedir}/lib/opflex-agent-ovs/mcast/opflex-groups.json
+dnscachedir=${localstatedir}/lib/opflex-agent-ovs/dns
 plugin-renderer-openvswitch.conf: $(top_srcdir)/plugin-renderer-openvswitch.conf.in
 	sed -e "s|DEFAULT_FLOWID_CACHE_DIR|${flowidcachedir}|" \
 	    -e "s|DEFAULT_MCAST_GROUP_FILE|${mcastgroupfile}|" \
+	    -e "s|DEFAULT_DNS_CACHE_DIR|${dnscachedir}|" \
 	$< > $@
 
 if HAVE_DOXYGEN

--- a/agent-ovs/debian/opflex-agent.dirs
+++ b/agent-ovs/debian/opflex-agent.dirs
@@ -4,5 +4,6 @@ var/lib/opflex-agent-ovs/ids
 var/lib/opflex-agent-ovs/mcast
 var/lib/opflex-agent-ovs/droplog
 var/lib/opflex-agent-ovs/faults
+var/lib/opflex-agent-ovs/dns
 etc/opflex-agent-ovs/conf.d
 etc/opflex-agent-ovs/plugins.conf.d

--- a/agent-ovs/ovs/OVSRenderer.cpp
+++ b/agent-ovs/ovs/OVSRenderer.cpp
@@ -99,6 +99,8 @@ void OVSRenderer::start() {
         LOG(WARNING) << "No flow ID cache directory specified";
     if (mcastGroupFile == "")
         LOG(WARNING) << "No multicast group file specified";
+    if (dnsCacheDir == "")
+        LOG(WARNING) << "No DNS cached directory specified";
 
     started = true;
     LOG(INFO) << "Starting stitched-mode renderer using"
@@ -161,6 +163,7 @@ void OVSRenderer::start() {
     if (accessBridgeName != "") {
         accessFlowManager.start();
     }
+    dnsManager.setCacheDir(dnsCacheDir);
     dnsManager.start();
 
     pktInHandler.registerConnection(intSwitchManager.getConnection(),
@@ -297,6 +300,8 @@ void OVSRenderer::stop() {
     LOCALSTATEDIR"/lib/opflex-agent-ovs/ids"
 #define DEF_MCAST_GROUPFILE \
     LOCALSTATEDIR"/lib/opflex-agent-ovs/mcast/opflex-groups.json"
+#define DEF_DNS_CACHEDIR \
+    LOCALSTATEDIR"/lib/opflex-agent-ovs/dns"
 
 void OVSRenderer::setProperties(const ptree& properties) {
     static const std::string OVS_BRIDGE_NAME("ovs-bridge-name");
@@ -339,6 +344,7 @@ void OVSRenderer::setProperties(const ptree& properties) {
 
     static const std::string FLOWID_CACHE_DIR("flowid-cache-dir");
     static const std::string MCAST_GROUP_FILE("mcast-group-file");
+    static const std::string DNS_CACHE_DIR("dns-cache-dir");
 
     static const std::string CONN_TRACK("forwarding.connection-tracking."
                                         "enabled");
@@ -479,6 +485,9 @@ void OVSRenderer::setProperties(const ptree& properties) {
 
     mcastGroupFile = properties.get<std::string>(MCAST_GROUP_FILE,
                                                  DEF_MCAST_GROUPFILE);
+
+    dnsCacheDir = properties.get<std::string>(DNS_CACHE_DIR,
+                                              DEF_DNS_CACHEDIR);
 
     ovsdbUseLocalTcpPort = properties.get<bool>(OVSDB_USE_LOCAL_TCPPORT, false);
 

--- a/agent-ovs/ovs/PacketInHandler.cpp
+++ b/agent-ovs/ovs/PacketInHandler.cpp
@@ -898,8 +898,7 @@ static void handleICMPEchoPktIn(bool v4,
 void PacketInHandler::handleDNSPktIn(struct ofputil_packet_in& pi,
                                 ofputil_protocol& proto,
                                 struct dp_packet* pkt) {
-    struct dp_packet *copiedPkt = dp_packet_clone(pkt);
-    dnsManager.handlePacketIn(copiedPkt);
+    dnsManager.handlePacketIn(pkt);
 }
 
 /**

--- a/agent-ovs/ovs/include/DnsManager.h
+++ b/agent-ovs/ovs/include/DnsManager.h
@@ -261,13 +261,13 @@ public:
     void setCName(const std::string &_cName) {
         cachedCName.cName = _cName;
     }
-    std::string getCName() {
+    std::string getCName() const {
         return cachedCName.cName;
     }
-    bool isCName() {
+    bool isCName() const {
         return !cachedCName.cName.empty();
     }
-    bool canExpire() {
+    bool canExpire() const {
         if(isCName()) {
             return (!isHolder && aNames.empty());
         } else {
@@ -332,7 +332,16 @@ public:
      */
     virtual void objectUpdated (opflex::modb::class_id_t class_id,
                                     const opflex::modb::URI& uri);
-
+    /* *
+     * Set the path to store learnt dns cache entries.
+     * On restart, used to restore cache.
+     */
+    void setCacheDir(const std::string &_cacheDir) {
+        cacheDir = _cacheDir;
+    };
+    bool isStarted() const {
+        return started;
+    }
     friend DnsCacheEntry;
 private:
     boost::asio::io_service io_ctxt;
@@ -352,6 +361,7 @@ private:
     std::unique_ptr<boost::uuids::basic_random_generator<boost::mt19937>> uuidGen;
     std::atomic<bool> started;
     boost::mt19937 randomSeed;
+    std::string cacheDir;
     void notifyListeners(class_id_t cid, const URI& notifyURI);
     void updateMOs(DnsCacheEntry &entry, bool updated);
     void updateMOs(const std::string &alias);
@@ -365,6 +375,11 @@ private:
     bool handlePacket(const struct dp_packet *pkt);
     void processPacket();
     void onExpiryTimer(const boost::system::error_code &e);
+    std::string getStorePath(const DnsCacheEntry &entry) {
+        return (cacheDir + "/" + entry.domainName + ".dns");
+    }
+    void commitToStore(const DnsCacheEntry &entry, bool erase=false);
+    void restoreFromStore();
 };
 
 /**

--- a/agent-ovs/ovs/include/OVSRenderer.h
+++ b/agent-ovs/ovs/include/OVSRenderer.h
@@ -110,6 +110,7 @@ private:
     std::string virtualDHCPMac;
     std::string flowIdCache;
     std::string mcastGroupFile;
+    std::string dnsCacheDir;
     bool connTrack;
     uint16_t ctZoneRangeStart;
     uint16_t ctZoneRangeEnd;

--- a/agent-ovs/plugin-renderer-openvswitch.conf.in
+++ b/agent-ovs/plugin-renderer-openvswitch.conf.in
@@ -154,6 +154,10 @@
         //     // Default: "DEFAULT_MCAST_GROUP_FILE"
         //     "mcast-group-file": "DEFAULT_MCAST_GROUP_FILE"
         //
+        //     // Location to write DNS cache held by datapath
+        //     // Default: "DEFAULT_DNS_CACHE_DIR"
+        //     "dns-cache-dir": "DEFAULT_DNS_CACHE_DIR"
+        //
         //     // OVSDB connection to use local ptcp port 6640
         //     // instead of the local socket
         //     // Default: false

--- a/agent-ovs/rpm/opflex-agent.spec.in
+++ b/agent-ovs/rpm/opflex-agent.spec.in
@@ -224,6 +224,7 @@ getent group opflexep >/dev/null || groupadd -r opflexep
 %dir %{_localstatedir}/lib/opflex-agent-ovs/ids
 %dir %{_localstatedir}/lib/opflex-agent-ovs/droplog
 %dir %{_localstatedir}/lib/opflex-agent-ovs/faults
+%dir %{_localstatedir}/lib/opflex-agent-ovs/dns
 
 %files -n agent-ovs
 


### PR DESCRIPTION
Backup DNS entries on a host-mounted store
and restore on restart to prevent blackholing.

Signed-off-by: Kiran Shastri <shastrinator@gmail.com>