### PR TITLE
Handle Dns SRV Records

### DIFF
--- a/genie/MODEL/SPECIFIC/EPR/epdr.mdl
+++ b/genie/MODEL/SPECIFIC/EPR/epdr.mdl
@@ -181,6 +181,46 @@ module[epdr]
         }
     }
 
+    class[DnsSrv;
+          super=policy/Definition;
+          concrete]
+    {
+        member[hostName; type=ascii/String]
+        member[port; type=scalar/UInt16]
+        member[expiry; type=ascii/String]
+        named
+        {
+            parent[class=*;]
+            {
+                component[member=hostName]
+                component[prefix=":";member=port]
+            }
+        }
+        contained
+        {
+            parent[class=epdr/DnsEntry]
+        }
+    }
+
+    class[DnsCName;
+          super=policy/Definition;
+          concrete]
+    {
+        member[cname; type=ascii/String]
+        member[expiry; type=ascii/String]
+        named
+        {
+            parent[class=*;]
+            {
+                component[member=cname]
+            }
+        }
+        contained
+        {
+            parent[class=epdr/DnsEntry]
+        }
+    }
+
     class[DnsMappedAddress;
           super=policy/Definition;
           concrete]


### PR DESCRIPTION
Handle SRV record type for headless services
Refactor code to reduce redundancy.
Display Cname and SRV records in the MO
Process additional record section.
TODO: port argument from SRV needs to be added to policy flow

Signed-off-by: Kiran Shastri <shastrinator@gmail.com>