### PR TITLE
Drop flooded unhandled packets on service vlan

### DIFF
--- a/agent-ovs/ovs/IntFlowManager.cpp
+++ b/agent-ovs/ovs/IntFlowManager.cpp
@@ -5125,7 +5125,14 @@ void IntFlowManager::createStaticFlows() {
             flowsRevNatICMP(outFlows, true, 11); // time exceeded
             flowsRevNatICMP(outFlows, true, 12); // param
         }
-
+            // Drop all flooded packets from service interface
+            // since we don't build flood lists for the service vlan
+            // and ARP with local target should be consumed in bridge table
+            FlowBuilder().priority(1)
+                .ethDst(packets::MAC_ADDR_BROADCAST)
+                .metadata(flow::meta::FROM_SERVICE_INTERFACE,
+                          flow::meta::FROM_SERVICE_INTERFACE)
+                .build(outFlows);
         switchManager.writeFlow("static", OUT_TABLE_ID, outFlows);
     }
     {

--- a/agent-ovs/ovs/test/IntFlowManager_test.cpp
+++ b/agent-ovs/ovs/test/IntFlowManager_test.cpp
@@ -2034,6 +2034,13 @@ void BaseIntFlowManagerFixture::initExpStatic(uint8_t remoteInventoryType) {
                 .done());
         }
     }
+    string bmac("ff:ff:ff:ff:ff:ff");
+    ADDF(Bldr().table(OUT).priority(1)
+         .isMdAct(opflexagent::flow::meta::FROM_SERVICE_INTERFACE,
+               opflexagent::flow::meta::FROM_SERVICE_INTERFACE)
+         .isEthDst(bmac)
+         .drop()
+         .done());
 
     for(int i=SEC; i<=OUT; i++) {
         ADDF(Bldr().table(i)


### PR DESCRIPTION
    To avoid logging flooded packets which are going to be dropped,
    for broadcast packets on the service vlan, add an explicit drop
    in the out table. Service vlan anyway does not have a flood list.
    Tested with manual flow addition on local setup.

Signed-off-by: Kiran Shastri <shastrinator@gmail.com>