### PR TITLE
System  security group  changes

### DIFF
--- a/agent-ovs/ovs/IntFlowManager.cpp
+++ b/agent-ovs/ovs/IntFlowManager.cpp
@@ -5938,6 +5938,7 @@ void IntFlowManager::addContractRules(FlowEntryList& entryList,
                                                   OFPUTIL_FF_SEND_FLOW_REM,
                                                   cookie,
                                                   cvnid, pvnid,
+                                                  false,
                                                   entryList);
             } else {
                 flowutils::add_classifier_entries(*cls, act, log,
@@ -5950,6 +5951,7 @@ void IntFlowManager::addContractRules(FlowEntryList& entryList,
                                                   OFPUTIL_FF_SEND_FLOW_REM,
                                                   cookie,
                                                   cvnid, pvnid,
+                                                  false,
                                                   entryList);
               }
         }
@@ -5966,6 +5968,7 @@ void IntFlowManager::addContractRules(FlowEntryList& entryList,
                                                     OFPUTIL_FF_SEND_FLOW_REM,
                                                     cookie,
                                                     pvnid, cvnid,
+                                                    false,
                                                     entryList);
               } else {
                   flowutils::add_classifier_entries(*cls, act, log,
@@ -5978,6 +5981,7 @@ void IntFlowManager::addContractRules(FlowEntryList& entryList,
                                                     OFPUTIL_FF_SEND_FLOW_REM,
                                                     cookie,
                                                     pvnid, cvnid,
+                                                    false,
                                                     entryList);
              }
         }

--- a/agent-ovs/ovs/include/AccessFlowManager.h
+++ b/agent-ovs/ovs/include/AccessFlowManager.h
@@ -140,10 +140,20 @@ public:
          */
         GROUP_MAP_TABLE_ID,
         /**
+         * Enforece system security group policy on packets coming into
+         * the endpoint from switch.
+         */
+        SYS_SEC_GRP_IN_TABLE_ID,
+        /**
          * Enforce security group policy on packets coming in to the
          * endpoint from the switch
          */
         SEC_GROUP_IN_TABLE_ID,
+        /**
+         * Enforce system security group policy on packets coming out of
+         * the endpoints to the switch.
+         */
+        SYS_SEC_GRP_OUT_TABLE_ID,
         /**
          * Enforce security group policy on packets coming out from
          * the endpoint to the switch
@@ -177,7 +187,8 @@ private:
     void handleSecGrpSetUpdate(const EndpointListener::uri_set_t& secGrps,
                                const std::string& secGrpsId);
     void handleDscpQosUpdate(const string& interface, uint8_t dscp);
-
+    bool checkIfSystemSecurityGroup(const string& uri);
+    
     Agent& agent;
     SwitchManager& switchManager;
     IdGenerator& idGen;

--- a/agent-ovs/ovs/include/FlowUtils.h
+++ b/agent-ovs/ovs/include/FlowUtils.h
@@ -121,6 +121,7 @@ void add_classifier_entries(modelgbp::gbpe::L24Classifier& clsfr,
                             uint16_t priority,
                             uint32_t flags, uint64_t cookie,
                             uint32_t svnid, uint32_t dvnid,
+                            bool isSystemRule,
                             /* out */ FlowEntryList& entries);
 
 /**
@@ -145,6 +146,7 @@ void add_l2classifier_entries(modelgbp::gbpe::L24Classifier& clsfr,
                               uint16_t priority,
                               uint32_t flags, uint64_t cookie,
                               uint32_t svnid, uint32_t dvnid,
+                              bool isSystemRule,
                               /* out */ FlowEntryList& entries);
 /**
  * Add a match entry for the DHCP v4 and v6 request

--- a/agent-ovs/ovs/test/TableDropStatsManager_test.cpp
+++ b/agent-ovs/ovs/test/TableDropStatsManager_test.cpp
@@ -290,6 +290,7 @@ void TableDropStatsManagerFixture::testOneStaticDropFlow (
 {
     uint64_t expected_pkt_count = INITIAL_PACKET_COUNT,
             expected_byte_count = INITIAL_PACKET_COUNT * PACKET_SIZE;
+    int ctr = 1;
     FlowEntryList dropLogFlows;
     if(portConn.getSwitchName()=="int_conn") {
         createIntBridgeDropFlowList(table_id,
@@ -299,10 +300,10 @@ void TableDropStatsManagerFixture::testOneStaticDropFlow (
             expected_byte_count *=4;
         }
     } else {
+        ctr = 2;
         createAccBridgeDropFlowList(table_id,
                         dropLogFlows);
     }
-    int ctr = 1;
     if(refresh_aged_flow) {
         ctr++;
     }


### PR DESCRIPTION

System security group is an operator level security group applicable for the entire OpenStack VMM - domain. This operator level / system level security group cannot be overridden by other security groups from the common and other tenants. The system security group rules can be fine-tuned further by other security group rules. 

This patch introduces two new tables  sys_ingress and sys_egress.  Packets which were directed to existing sg tables are directed (from Group_map table ) to these new tables. If they match any flow in system sg table, they are passed to existing sg tables. 
[sys_ingress]  --> [ingress]
[sys_egress]  --> [egress]

Stateful rules are supported in system sg. Packets are matched with different ct_state as done in the existing table, connections are committed in the existing table. Packets with ct_state(+new+trk) are simply forwarded to existing sg table where they are committed. 
