### PR TITLE
Fix out of bounds crash in bbva

### DIFF
--- a/agent-ovs/ovs/ContractStatsManager.cpp
+++ b/agent-ovs/ovs/ContractStatsManager.cpp
@@ -288,8 +288,7 @@ void ContractStatsManager::objectUpdated(opflex::modb::class_id_t class_id,
                  i++) {
                 RoutingDomainDropCounter::
                     remove(agent->getFramework(),getAgentUUID(),
-                           dropCounterList_[rdName]->
-                           uidList[dropCounterList_[rdName]->count],
+                           dropCounterList_[rdName]->uidList[i],
                            rdName);
             }
             if (dropCounterList_.count(rdName))


### PR DESCRIPTION
Fix the incorrect array dereference leading to the crash

Signed-off-by: Madhu Challa <challa@gmail.com>