### PR TITLE
Reduce scope of direction mask for access flows

### DIFF
--- a/agent-ovs/ovs/include/FlowConstants.h
+++ b/agent-ovs/ovs/include/FlowConstants.h
@@ -182,7 +182,7 @@ extern const uint64_t REMOTE_TUNNEL_BOUNCE_TO_NODE;
 
 namespace access_meta {
 
-const uint64_t MASK =0xff00;
+const uint64_t MASK =0x0300;
 /**
  * Ingress to ep
  */


### PR DESCRIPTION
This mask was introduced as part of fixing the punt of DNS packets
for the egress DNS feature. However the mask should be limited to 0x3
to avoid colliding with droplog metadata.

Signed-off-by: Kiran Shastri <shastrinator@gmail.com>