### PR TITLE
Async Json Parser for Opflex and Ovs

### DIFF
--- a/agent-ovs/lib/Agent.cpp
+++ b/agent-ovs/lib/Agent.cpp
@@ -42,6 +42,7 @@
 #include <random>
 
 #include <dlfcn.h>
+#include <cstdlib>
 
 namespace opflexagent {
 
@@ -182,6 +183,8 @@ void Agent::setProperties(const boost::property_tree::ptree& properties) {
     static const std::string OPFLEX_KEEPALIVE("opflex.timers.keepalive-timeout");
     static const std::string DISABLED_FEATURES("feature.disabled");
     static const std::string BEHAVIOR_L34FLOWS_WITHOUT_SUBNET("behavior.l34flows-without-subnet");
+    static const std::string OPFLEX_ASYC_JSON("opflex.asyncjson.enabled");
+    static const std::string OVS_ASYNC_JSON("ovs.asyncjson.enabled");
 
     // set feature flags to true
     clearFeatureFlags();
@@ -471,6 +474,19 @@ void Agent::setProperties(const boost::property_tree::ptree& properties) {
         featureFlag[FeatureList::ERSPAN] = false;
     }
 
+    optional<bool> opflexAsyncJsonEnabled =
+        properties.get_optional<bool>(OPFLEX_ASYC_JSON);
+    if (opflexAsyncJsonEnabled) {
+        if (opflexAsyncJsonEnabled.get() == true)
+            setenv("OPFLEX_USE_ASYNC_JSON", "", true);
+    }
+
+    optional<bool> ovsAsyncJsonEnabled =
+        properties.get_optional<bool>(OVS_ASYNC_JSON);
+    if (ovsAsyncJsonEnabled) {
+        if (ovsAsyncJsonEnabled.get() == true)
+            setenv("OVS_USE_ASYNC_JSON", "", true);
+    }
 }
 
 void Agent::applyProperties() {

--- a/libopflex/Makefile.am
+++ b/libopflex/Makefile.am
@@ -102,7 +102,8 @@ util_include_HEADERS = \
 	include/opflex/util/ThreadManager.h
 yajr_includedir = $(includedir)/opflex/yajr
 yajr_include_HEADERS = \
-    include/opflex/yajr/yajr.hpp
+    include/opflex/yajr/yajr.hpp \
+    include/opflex/yajr/async_doc_parser.hpp
 yajr_internal_includedir = $(includedir)/opflex/yajr/internal
 yajr_internal_include_HEADERS = \
     include/opflex/yajr/internal/comms.hpp

--- a/libopflex/comms/active_connection.cpp
+++ b/libopflex/comms/active_connection.cpp
@@ -161,13 +161,6 @@ void on_active_connection(uv_connect_t *req, int status) {
         return;
     }
 
-    if(peer->_.ai) { /* we succeeded connecting before the last attempt */
-        uv_freeaddrinfo(peer->_.ai);
-    }
-#ifdef OVERZEALOUS_ABOUT_CLEANNESS
-    peer->ai_next = NULL;
-#endif
-
     if (peer->unchoke()) {
         retry_later(peer);
         return;

--- a/libopflex/include/opflex/yajr/async_doc_parser.hpp
+++ b/libopflex/include/opflex/yajr/async_doc_parser.hpp
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2022 Cisco Systems, Inc. and others.  All rights reserved.
+ *
+ * Adopted from rapidjson/examples/parsebyparts.cpp
+ * Modified to make it a continuous stream parser that keeps
+ * parsing into a single document internal to the parser and
+ * invokes a callback after each successful parse. On error
+ * the parser resets the stream to empty and continues the
+ * parse. user is expected to tell the other end to restart
+ * the parse. The parser treats '\0' as end of parse, hence
+ * null characters in the stream are skipped. The parse stops
+ * when the object is destroyed.
+ *
+ * Currently the parser only supports one writer per object. A single
+ * reader thread is also created per object.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ */
+
+#pragma once
+#ifndef _INCLUDE__YAJR__ASYNC_DOC_PARSER_HPP
+#define _INCLUDE__YAJR__ASYNC_DOC_PARSER_HPP
+
+#include "rapidjson/document.h"
+#include "rapidjson/error/en.h"
+#include "rapidjson/writer.h"
+#include "rapidjson/ostreamwrapper.h"
+#include <condition_variable>
+#include <iostream>
+#include <sstream>
+#include <fstream>
+#include <mutex>
+#include <thread>
+#include <functional>
+#include <sys/types.h>
+#include <unistd.h>
+
+namespace yajr {
+
+using namespace rapidjson;
+
+template<unsigned parseFlags = kParseStopWhenDoneFlag>
+class AsyncDocumentParser {
+public:
+    static int instance_count_;
+    explicit AsyncDocumentParser(std::function<int(Document& d)> cb)
+        : stream_(*this)
+        , d_()
+        , cb_(cb)
+        , parseThread_()
+        , mutex_()
+        , notEmpty_()
+        , finish_()
+        , stop_()
+        , id_(instance_count_)
+    {
+        // Create and execute thread after all member variables are initialized.
+        parseThread_ = std::thread(&AsyncDocumentParser::Parse, this);
+        std::string fname = "/var/log/opflex-json.log." + std::to_string(getpid()) + "." + std::to_string(instance_count_);
+        out_.open(fname, std::ofstream::out | std::ofstream::app);
+        instance_count_++;
+    }
+
+    ~AsyncDocumentParser() {
+        if (!parseThread_.joinable())
+            return;
+
+        {
+            std::unique_lock<std::mutex> lock(mutex_);
+
+            stop_ = true;
+            notEmpty_.notify_one();
+        }
+
+        parseThread_.join();
+        if (stream_.buf_)
+            free(stream_.buf_);
+    }
+
+    int ParsePart(const char* buffer, size_t length) {
+
+        std::unique_lock<std::mutex> lock(mutex_);
+
+        // Wait until the buffer is read up (or parsing is completed)
+        while (!stream_.Empty())
+            finish_.wait(lock);
+
+        // Set the buffer to stream and unblock the AsyncStringStream
+        if (!stream_.buf_ || length > stream_.buflen_) {
+            stream_.buf_ = (char *)realloc(stream_.buf_, length + 1);
+            stream_.buflen_ = length;
+            stream_.alloccnt_++;
+        }
+
+        if (!stream_.buf_)
+            return -1;
+
+        memcpy(stream_.buf_, buffer, length);
+        *(char *)(stream_.buf_ + length) = '\0';
+        stream_.src_ = stream_.buf_;
+        stream_.end_ = stream_.buf_ + length;
+        notEmpty_.notify_one();
+
+        return 0;
+    }
+
+    const char* Getbuf() { return stream_.buf_; }
+
+    const char* GetUnparsedbuf() { return stream_.src_; }
+
+    int Tell() { return stream_.count_; }
+
+    int GetAllocs() { return stream_.alloccnt_; }
+
+    int GetInstance() { return id_; }
+private:
+    void Parse() {
+        while (true) {
+            d_.ParseStream<parseFlags>(stream_);
+
+            // The stream may not be fully read, notify finish anyway to unblock ParsePart()
+            std::unique_lock<std::mutex> lock(mutex_);
+
+            if (stop_)
+                break;
+
+            cb_(d_);
+
+            // The user should reset the other side
+            if (d_.HasParseError())
+                stream_.src_ = stream_.end_;
+
+            //out_.put('\n');
+            //out_.flush();
+            d_.SetNull();
+            d_.GetAllocator().Clear();
+            finish_.notify_one();   // Unblock ParsePart() or destructor if they are waiting.
+       }
+    }
+
+    struct AsyncStringStream {
+        typedef char Ch;
+
+        explicit AsyncStringStream(AsyncDocumentParser& parser) : parser_(parser), buf_(), buflen_(), src_(), end_(), count_(), alloccnt_() {}
+        char Peek() {
+            std::unique_lock<std::mutex> lock(parser_.mutex_);
+
+            // Skip '\0'
+            while (!Empty() && *src_ == '\0')
+                src_++;
+
+            if (Empty())
+                parser_.finish_.notify_one();
+
+            // If nothing in stream, block to wait.
+            while (Empty() && !parser_.stop_)
+                parser_.notEmpty_.wait(lock);
+
+            if (parser_.stop_)
+                return '\0';
+
+            return *src_;
+        }
+
+        char Take() {
+            std::unique_lock<std::mutex> lock(parser_.mutex_);
+
+            // Skip '\0'
+            while (!Empty() && *src_ == '\0')
+                src_++;
+
+            if (Empty())
+                parser_.finish_.notify_one();
+
+            // If nothing in stream, block to wait.
+            while (Empty() && !parser_.stop_)
+                parser_.notEmpty_.wait(lock);
+
+            if (parser_.stop_)
+                return '\0';
+
+            count_++;
+            char c = *src_++;
+            //parser_.out_.put(c);
+            //parser_.out_.flush();
+
+            // If all stream is read up, notify that the stream is finish.
+            if (Empty())
+                parser_.finish_.notify_one();
+
+            return c;
+        }
+
+        size_t Tell() const { return count_; }
+
+        // Not implemented
+        char* PutBegin() { return 0; }
+        void Put(char) {}
+        void Flush() {}
+        size_t PutEnd(char*) { return 0; }
+
+        bool Empty() const { return src_ == end_; }
+
+        AsyncDocumentParser& parser_;
+        char *buf_;
+        size_t buflen_;
+        const char* src_;     //!< Current read position.
+        const char* end_;     //!< End of buffer
+        size_t count_;        //!< Number of characters taken so far.
+        size_t alloccnt_;
+    };
+
+    AsyncStringStream stream_;
+    Document d_;
+    std::function<int(Document& d)> cb_;
+    std::thread parseThread_;
+    std::mutex mutex_;
+    std::condition_variable notEmpty_;
+    std::condition_variable finish_;
+    bool stop_;
+    int id_;
+    std::ofstream out_;
+};
+
+} /* yajr namespace */
+
+#endif /* _INCLUDE__YAJR__ASYNC_DOC_PARSER_HPP */

--- a/libopflex/include/opflex/yajr/internal/comms.hpp
+++ b/libopflex/include/opflex/yajr/internal/comms.hpp
@@ -15,6 +15,7 @@
 #include <opflex/yajr/yajr.hpp>
 #include <opflex/yajr/rpc/rpc.hpp>
 #include <opflex/yajr/transport/PlainText.hpp>
+#include <opflex/yajr/async_doc_parser.hpp>
 
 #include <opflex/logging/OFLogHandler.h>
 
@@ -507,7 +508,8 @@ class CommunicationPeer : public Peer, virtual public ::yajr::Peer {
                 nextId_(0),
                 keepAliveInterval_(0),
                 lastHeard_(0),
-                transport_(transport::PlainText::getPlainTextTransport())
+                transport_(transport::PlainText::getPlainTextTransport()),
+                asyncDocParser_([this](Document& d) -> int { return asyncDocParserCb(d); })
             {
                 req_.data = this;
                 getHandle()->loop = uvLoopSelector_(getData());
@@ -834,6 +836,10 @@ class CommunicationPeer : public Peer, virtual public ::yajr::Peer {
         chunk_size += ssIn_.tellp();
         return chunk_size;
     }
+
+    int asyncDocParserCb(rapidjson::Document &d);
+
+    mutable AsyncDocumentParser<> asyncDocParser_;
 };
 static_assert (sizeof(CommunicationPeer) <= 4096, "CommunicationPeer won't fit on one page");
 


### PR DESCRIPTION
Allow parsing partial json messages. Invokes comms callback on parse complete and continues with the parse. Currently supports only one reader and writer per comms object. On error the callback disconnects and reconnects with the client there by preserving the sanity of the json stream.

Controlled via 2 env variables OPFLEX_USE_ASYNC_JSON for leaf <> opflex comms and OVS_USE_ASYNC_JSON for ovsdb <> opflex comms. The usage will be OPFLEX_USE_ASYNC_JSON= OVS_USE_ASYNC_JSON= <opflex command>, the same can be provided via docker env variables when running under docker. If neither env variable is present the code reverts to the old sync way of parsing that would fail if the json comes in partial chunks.

The env variables can be set via config as
    "opflex": {
        "asyncjson" : { "enabled" : "true" }
    },
    "ovs": {
        "asyncjson" : { "enabled" : "true" }
    },

Signed-off-by: Madhu Challa <challa@gmail.com>