### PR TITLE
Revert crash fix for kmr2

### DIFF
--- a/libopflex/comms/active_connection.cpp
+++ b/libopflex/comms/active_connection.cpp
@@ -161,6 +161,13 @@ void on_active_connection(uv_connect_t *req, int status) {
         return;
     }
 
+    if (peer->_.ai) { /* we succeeded connecting before the last attempt */
+        uv_freeaddrinfo(peer->_.ai);
+    }
+#ifdef OVERZEALOUS_ABOUT_CLEANNESS
+    peer->ai_next = NULL;
+#endif
+
     if (peer->unchoke()) {
         retry_later(peer);
         return;


### PR DESCRIPTION
Bosch wants no changes and this was a fix added along with async json parse, the feature itself is enabled under a config option, except the fix for the double free. So reverting this fix which if hit will cause opflex to crash and restart.

This revert is specific to this branch and master still has this fix.

Signed-off-by: Madhu Challa <challa@gmail.com>