### PR TITLE
Move to prometheus-cpp 1.0.1

### DIFF
--- a/.travis/install-dependencies.sh
+++ b/.travis/install-dependencies.sh
@@ -7,7 +7,7 @@ wget https://travisci-static-artifacts-dd485362-9714-11ea-bb37-0242ac130002.s3.u
 tar -xvzf artifacts.tgz
 sudo dpkg -i libnoiro-openvswitch_2.12.0-1_amd64.deb
 sudo dpkg -i libnoiro-openvswitch-dev_2.12.0-1_amd64.deb
-sudo dpkg -i prometheus-cpp_0.12.1_amd64.deb
+sudo dpkg -i prometheus-cpp_1.0.1_amd64.deb
 
 mkdir -p ../grpc
 pushd ../grpc

--- a/agent-ovs/configure.ac
+++ b/agent-ovs/configure.ac
@@ -202,9 +202,9 @@ AM_COND_IF([ENABLE_GRPC], [
 ])
 
 # check for prometheus
-PKG_CHECK_MODULES([PROMETHEUS_CORE], [prometheus-cpp-core >= 0.12.1],
+PKG_CHECK_MODULES([PROMETHEUS_CORE], [prometheus-cpp-core >= 1.0.1],
                   [prometheus_core_found=yes], [prometheus_core_found=no])
-PKG_CHECK_MODULES([PROMETHEUS_PULL], [prometheus-cpp-pull >= 0.12.1],
+PKG_CHECK_MODULES([PROMETHEUS_PULL], [prometheus-cpp-pull >= 1.0.1],
                   [prometheus_pull_found=yes], [prometheus_pull_found=no])
 AS_IF([test x$prometheus_core_found = 'xyes' && test x$prometheus_pull_found = 'xyes'], [
     AC_DEFINE([HAVE_PROMETHEUS_SUPPORT],[1],[Define if prometheus support is enabled])

--- a/agent-ovs/debian/control
+++ b/agent-ovs/debian/control
@@ -6,7 +6,7 @@ Build-Depends:
  debhelper (>= 8.0.0), autotools-dev, libboost-all-dev (>= 1.53),
  libopflex-dev, libmodelgbp-dev, libnoiro-openvswitch-dev (>= 2.12.0) <!norenderer>,
  libnoiro-openvswitch (>= 2.12.0) <!norenderer>, libnetfilter-conntrack-dev (>= 1.0) <!norenderer>,
- rapidjson-dev (>=1.1), pkgconf, dh-systemd, libssl-dev (>= 1.0), prometheus-cpp (>= 0.12.1),
+ rapidjson-dev (>=1.1), pkgconf, dh-systemd, libssl-dev (>= 1.0), prometheus-cpp (>= 1.0.1),
  libcurl4-openssl-dev, curl
 Standards-Version: 3.9.8
 Homepage: https://wiki.opendaylight.org/view/OpFlex:Main
@@ -53,7 +53,7 @@ Build-Profiles: <!norenderer>
 Depends:
  opflex-agent (>= ${binary:Version}),
  opflex-agent-renderer-openvswitch (>= ${binary:Version}),
- prometheus-cpp (>= 0.12.1)
+ prometheus-cpp (>= 1.0.1)
 Description: Transitional package for OpFlex Agent and OVS renderer
  This package depends on opflex-agent and
  opflex-agent-renderer-openvswitch to allow smoother transition from

--- a/agent-ovs/lib/AgentPrometheusManager.cpp
+++ b/agent-ovs/lib/AgentPrometheusManager.cpp
@@ -1221,14 +1221,15 @@ void AgentPrometheusManager::createDynamicGaugeSvcTarget (SVC_TARGET_METRICS met
 
     auto const &label_map = createLabelMapFromSvcTargetAttr(uuid, nhip, svc_attr_map,
                                                             ep_attr_map, isNodePort);
-    auto hash_new = hash_labels(label_map);
+    LabelHasher hasher;
+    auto hash_new = hasher(label_map);
 
     if (mgauge) {
         /**
          * Detect attribute change by comparing hashes of cached label map
          * with new label map
          */
-        if (hash_new == hash_labels(mgauge.get().first))
+        if (hash_new == hasher(mgauge.get().first))
             return;
         else {
             LOG(DEBUG) << "addNupdate svctargetcounter key " << key
@@ -1277,7 +1278,8 @@ void AgentPrometheusManager::createDynamicGaugeSvc (SVC_METRICS metric,
         return;
 
     auto const &label_map = createLabelMapFromSvcAttr(uuid, svc_attr_map, isNodePort);
-    auto hash_new = hash_labels(label_map);
+    LabelHasher hasher;
+    auto hash_new = hasher(label_map);
 
     // Retrieve the Gauge if its already created
     auto const &mgauge = getDynamicGaugeSvc(metric, uuid);
@@ -1286,7 +1288,7 @@ void AgentPrometheusManager::createDynamicGaugeSvc (SVC_METRICS metric,
          * Detect attribute change by comparing hashes of cached label map
          * with new label map
          */
-        if (hash_new == hash_labels(mgauge.get().first))
+        if (hash_new == hasher(mgauge.get().first))
             return;
         else {
             LOG(DEBUG) << "addNupdate svccounter uuid " << uuid
@@ -1333,7 +1335,8 @@ void AgentPrometheusManager::createDynamicGaugePodSvc (PODSVC_METRICS metric,
         return;
 
     auto const &label_map = createLabelMapFromPodSvcAttr(ep_attr_map, svc_attr_map);
-    auto hash_new = hash_labels(label_map);
+    LabelHasher hasher;
+    auto hash_new = hasher(label_map);
 
     // Retrieve the Gauge if its already created
     auto const &mgauge = getDynamicGaugePodSvc(metric, uuid);
@@ -1342,7 +1345,7 @@ void AgentPrometheusManager::createDynamicGaugePodSvc (PODSVC_METRICS metric,
          * Detect attribute change by comparing hashes of cached label map
          * with new label map
          */
-        if (hash_new == hash_labels(mgauge.get().first))
+        if (hash_new == hasher(mgauge.get().first))
             return;
         else {
             LOG(DEBUG) << "addNupdate podsvccounter uuid " << uuid
@@ -1423,7 +1426,8 @@ bool AgentPrometheusManager::createDynamicGaugeEp (EP_METRICS metric,
                                               annotate_ep_name,
                                               attr_map,
                                               agent.getPrometheusEpAttributes());
-    auto hash = hash_labels(label_map);
+    LabelHasher hasher;
+    auto hash = hasher(label_map);
     auto& gauge = gauge_ep_family_ptr[metric]->Add(label_map);
     if (gauge_check.is_dup(&gauge)) {
         // Suppressing below log for all the other metrics of this EP
@@ -2376,7 +2380,8 @@ size_t AgentPrometheusManager::calcHashEpAttributes (const string& ep_name,
                                               annotate_ep_name,
                                               attr_map,
                                               allowed_set);
-    auto hash = hash_labels(label_map);
+    LabelHasher hasher;
+    auto hash = hasher(label_map);
     LOG(DEBUG) << ep_name << ":calculated label hash = " << hash;
     return hash;
 }

--- a/agent-ovs/rpm/opflex-agent.spec.in
+++ b/agent-ovs/rpm/opflex-agent.spec.in
@@ -31,9 +31,9 @@ Requires: boost-system
 Requires: boost-date-time
 Requires: boost-thread
 Requires: boost-filesystem
-Requires: prometheus-cpp-lib >= 0.12.1
-BuildRequires: prometheus-cpp-lib >= 0.12.1
-BuildRequires: prometheus-cpp-devel >= 0.12.1
+Requires: prometheus-cpp-lib >= 1.0.1
+BuildRequires: prometheus-cpp-lib >= 1.0.1
+BuildRequires: prometheus-cpp-devel >= 1.0.1
 BuildRequires: boost-devel
 BuildRequires: boost-test
 BuildRequires: libopflex-devel
@@ -87,7 +87,7 @@ Group: Development/Libraries
 Requires: %{name} = %{epoch}:%{version}-%{release}
 Requires: libopflex >= %{version}
 Requires: libmodelgbp >= %{version}
-Requires: prometheus-cpp-lib >= 0.12.1
+Requires: prometheus-cpp-lib >= 1.0.1
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 
@@ -102,7 +102,7 @@ Requires: %{name} = %{epoch}:%{version}-%{release}
 Requires: pkgconfig
 Requires: libopflex-devel >= %{version}
 Requires: libnetfilter_conntrack-devel >= 1.0
-Requires: prometheus-cpp-devel >= 0.12.1
+Requires: prometheus-cpp-devel >= 1.0.1
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 Provides: libopflex_agent-static = %{version}-%{release}

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -82,7 +82,7 @@ extraction:
       - "git clone https://github.com/noironetworks/3rdparty-debian.git"
       - "git clone https://github.com/jupp0r/prometheus-cpp.git"
       - "pushd prometheus-cpp"
-      - "git checkout v0.12.1"
+      - "git checkout v1.0.1"
       - "git submodule init"
       - "git submodule update"
       - "git apply ../3rdparty-debian/prometheus/prometheus-cpp.patch"


### PR DESCRIPTION
- 0.12.1 uses civetweb 1.13 that has a CVE - https://nvd.nist.gov/vuln/detail/CVE-2020-27304
- According to https://jfrog.com/blog/cve-2020-27304-rce-via-directory-traversal-in-civetweb-http-server/, the relevant CVE is fixed in civet web > 1.14
- latest prometheus-cpp version is 1.1.0, but that needs c++14.
- moving to prometheus-cpp 1.0.1 for now, which uses civetweb 1.15.
- updated configuration script to specify min dep version
- updated debs created and pushed to S3 for travis (thanks Tom)
- lgtm build updated
- todo: to update aci-containers, 3rdparty-rpm

Signed-off-by: Gautam Venkataramanan <gautam.chennai@gmail.com>
(cherry picked from commit d27b96cac8562147fa3c12ba5f7c842a50d966e4)