### PR TITLE
Make policy retry delay configurable

### DIFF
--- a/agent-ovs/lib/include/opflexagent/Agent.h
+++ b/agent-ovs/lib/include/opflexagent/Agent.h
@@ -328,6 +328,8 @@ private:
     // timers
     // prr timer - policy resolve request timer
     boost::uint_t<64>::fast prr_timer = 7200;  /* seconds */
+    // initial policy retry delay
+    boost::uint_t<64>::fast policy_retry_delay_timer = 10;  /* seconds */
     /* handshake timeout */
     uint32_t peerHandshakeTimeout = 45000;
     /* keepalive timeout */

--- a/agent-ovs/opflex-agent-ovs.conf.in
+++ b/agent-ovs/opflex-agent-ovs.conf.in
@@ -97,6 +97,11 @@
            // default 7200 secs, min 15 secs
            // "prr": 7200,
            //
+           // How long to wait for initial re-request, either
+           // due to a backoff, or for no response, in seconds.
+           // default 10 secs, min 1 second
+           // "policy-retry-delay": 10
+           //
            // How long to wait for the initial peer
            // handshake to complete (in ms)
            // "handshake-timeout" : 45000,

--- a/libopflex/include/opflex/ofcore/OFFramework.h
+++ b/libopflex/include/opflex/ofcore/OFFramework.h
@@ -736,6 +736,12 @@ public:
     void setPrrTimerDuration(const uint64_t duration);
 
     /**
+     * set the policy resolve retry delay (prrd) timer durarion.
+     * @param duration timer duration in milliseconds
+     */
+    void setPolicyRetryDelayTimerDuration(const uint64_t duration);
+
+    /**
      * Set the peer handshake timeout
      * @param timeout peer handshake timeout in milliseconds
      */

--- a/libopflex/ofcore/OFFramework.cpp
+++ b/libopflex/ofcore/OFFramework.cpp
@@ -111,6 +111,10 @@ void OFFramework::setPrrTimerDuration(const uint64_t duration) {
     pimpl->processor.setPrrTimerDuration(duration);
 }
 
+void OFFramework::setPolicyRetryDelayTimerDuration(const uint64_t duration) {
+    pimpl->processor.setRetryDelay(duration);
+}
+
 void OFFramework::setHandshakeTimeout(const uint32_t timeout) {
     pimpl->processor.setHandshakeTimeout(timeout);
 }


### PR DESCRIPTION
The retry delay should be configurable, with a default initial backoff value of 10 seconds, and a minimum value of 1 second (the processor can actually do milliseconds, but we don't see a need to support this). This can be set to larger amounts for servers that crash under heavy loads from frequent re-requests.

The patch also introduces an internal class for creating randomized deltas, which are used to provide some dithering for retries.

(cherry picked from commit e5d0b8959adac24d4208179f65bc5f657015909f)