### PR TITLE
Call ERR_load_SSL_strings only w/ OpenSSL < 1.1.0

### DIFF
--- a/libopflex/comms/transport/ZeroCopyOpenSSL.cpp
+++ b/libopflex/comms/transport/ZeroCopyOpenSSL.cpp
@@ -440,10 +440,10 @@ int ZeroCopyOpenSSL::initOpenSSL(bool forMultipleThreads) {
     }
     SSL_library_init();
     SSL_load_error_strings();
+    ERR_load_SSL_strings();
 #else
    OPENSSL_init_ssl(0, NULL);
 #endif
-    ERR_load_SSL_strings();
 #if (OPENSSL_VERSION_NUMBER < 0x10100000L)
     OpenSSL_add_all_algorithms();
     if (forMultipleThreads) {


### PR DESCRIPTION
This was causing compilation issues on Ubuntu 22.04

Signed-off-by: Tom Flynn <tom.flynn@gmail.com>