### PR TITLE
clear faults raised for encap mismatch

### DIFF
--- a/agent-ovs/lib/FaultManager.cpp
+++ b/agent-ovs/lib/FaultManager.cpp
@@ -111,6 +111,7 @@ void FaultManager::removeFault(const std::string& uuid){
     Mutator mutator_policyelem(agent.getFramework(), "policyelement");
     auto fu = modelgbp::fault::Instance::resolve(agent.getFramework(),uuid);
     if (fu){
+        LOG(INFO) << "Removing the fault instance using the uuid = "<<uuid;
         fu.get()->remove(agent.getFramework(), uuid);
         mutator_policyelem.commit();
     }

--- a/agent-ovs/lib/include/opflexagent/Fault.h
+++ b/agent-ovs/lib/include/opflexagent/Fault.h
@@ -159,15 +159,25 @@ public:
         return egURI;
     }
 
+
+    void setAffectedObject(const std::string& affectedObject) {
+        this->affectedobject = affectedObject;
+    }
+
+
+    const std::string& getAffectedObject() const {
+        return affectedobject;
+    }
+
    private:
       std::string ep_uuid;
       std::string fs_uuid;
       uint64_t faultcode;
       uint8_t severity;
       std::string description;
+      std::string affectedobject;
       boost::optional<opflex::modb::MAC>  mac;	
       boost::optional<opflex::modb::URI> egURI;
-
 };
 
   /**

--- a/agent-ovs/ovs/include/IntFlowManager.h
+++ b/agent-ovs/ovs/include/IntFlowManager.h
@@ -26,6 +26,7 @@
 #include "SwitchStateHandler.h"
 
 #include <opflex/ofcore/PeerStatusListener.h>
+#include <opflexagent/FaultManager.h>
 
 #include <boost/asio/ip/address.hpp>
 #include <boost/optional.hpp>
@@ -979,6 +980,7 @@ private:
     std::unique_ptr<std::thread> svcStatsThread;
     boost::asio::io_service svcStatsIOService;
     std::unique_ptr<boost::asio::io_service::work> svcStatsIOWork;
+    FaultManager& faultmanager;
     TaskQueue svcStatsTaskQueue;
 };
 

--- a/agent-ovs/ovs/test/IntFlowManager_test.cpp
+++ b/agent-ovs/ovs/test/IntFlowManager_test.cpp
@@ -4601,6 +4601,16 @@ BOOST_FIXTURE_TEST_CASE(testencapfault, BaseIntFlowManagerFixture) {
     WAIT_FOR(modelgbp::platform::Config::resolve(framework, platformCfg->getURI()), 500);
 
     intFlowManager.configUpdated(platformCfg->getURI());
+
+    Mutator mutator_ex(framework, "policyreg");
+    auto polUni2 =
+        modelgbp::policy::Universe::resolve(framework).get();
+    auto platformCfg2 = polUni2->addPlatformConfig("dummy");
+    platformCfg2->setEncapType(EncapTypeEnumT::CONST_VLAN);
+    mutator_ex.commit();
+    WAIT_FOR(modelgbp::platform::Config::resolve(framework, platformCfg2->getURI()), 500);
+    intFlowManager.configUpdated(platformCfg2->getURI());
+
     stop();
 }
 


### PR DESCRIPTION
We raise a fault dynamically if the encap on the fabric side doesn’t match the encap on the agent side. We do not attempt to clear the faults on the fabric after the encap on the agent side and the fabric looks good. The orphan fault keeps hanging on the fabric side and we can verify this on the fault MO opflexpAgentODevFaultInfo on the object store. The issue happened when upgrading from a 4.2 release to 5.2 on a customer setup.

In the below patch, I have attempted to clear the fault if the encap matches on the both sides. One thing to notice is the fault uuid (fsuuid) is not created using a random unique id generator. I have hardcoded it to a constant value. I can use this fsuuid to resolve the fault instance and remove the fault from the modb 
If I had used a random unique id as fsuuid, I should have stored it in a STL containers such as map and to clear the fault instance, I had to depend on the map to retrieve the fsuuid. In some cases, if the agent restarts itself, or we loose the persistence of the agent, the map would have got reinitialized. Hence I used a predefined fsuuid to create the fault instance 