### PR TITLE
Make local / remote ep flow mods robust

### DIFF
--- a/agent-ovs/ovs/IntFlowManager.cpp
+++ b/agent-ovs/ovs/IntFlowManager.cpp
@@ -1484,6 +1484,13 @@ void IntFlowManager::handleRemoteEndpointUpdate(const string& uuid) {
         switchManager.clearFlows(uuid, ROUTE_TABLE_ID);
         switchManager.clearFlows(uuid, POL_TABLE_ID);
         switchManager.clearFlows(uuid, OUT_TABLE_ID);
+        // If a local ep exists with same name redo the local ep flows
+        EndpointManager& epMgr = agent.getEndpointManager();
+        shared_ptr<const Endpoint> epWrapper = epMgr.getEndpoint(uuid);
+        if (epWrapper) {
+            LOG(DEBUG) << "Redo local endpoint update " << uuid;
+            endpointUpdated(uuid);
+        }
         return;
     }
 
@@ -1955,6 +1962,13 @@ void IntFlowManager::handleEndpointUpdate(const string& uuid) {
         removeEndpointFromFloodGroup(uuid);
         agent.getSnatManager().delEndpoint(uuid);
         updateSvcStatsFlows(uuid, false, false);
+        // If a remote ep exists with same name redo the remote ep flows
+        optional<shared_ptr<modelgbp::inv::RemoteInventoryEp>> ep =
+            modelgbp::inv::RemoteInventoryEp::resolve(agent.getFramework(), uuid);
+        if (ep) {
+            LOG(DEBUG) << "Redo remote endpoint update " << uuid;
+            remoteEndpointUpdated(uuid);
+        }
         return;
     }
     const Endpoint& endPoint = *epWrapper.get();


### PR DESCRIPTION
RPA had an ordering issue when local and remote eps are present with same uuid which are hit during vm migration.

The ordering in which local ep flows are broken is as follows
- remote ep with uuidA present
- local ep with same uuidA added
- remote ep with uuidA is deleted

This would cause local ep flows to be deleted as well because both got added with same uuid

The ordering issue should be prevented at the source itself so the ep file is deleted on src node, all remote eps updated, and then the ep file is created on the dst node. The extra cost with this solution is to check if the other type of ep exists when one is deleted.

somehow with the B series the second part, remote ep delete comes after the ep file is created on target.

For consistency also doing the same when a local ep is deleted and a remote ep with same name present.

The other approaces considered were.
1. add local and remote eps with different uuids, the scope of this solution seems much bigger

The behavior when both local and remote eps are present seems to be that we give pref to the local ep which may or may not be correct depending on the scenario but this situation is transient. eventually one of them should go away.