### PR TITLE
Fix pre-handshake policy resolve refresh timeouts

### DIFF
--- a/libopflex/engine/test/Processor_test.cpp
+++ b/libopflex/engine/test/Processor_test.cpp
@@ -732,6 +732,23 @@ BOOST_FIXTURE_TEST_CASE( policy_resolve_flaky, PolicyFixture ) {
     WAIT_FOR(opflexServer->getListener().applyConnPred(resolutions_pred, NULL), 1000);
 }
 
+// test policy resolve retry after connection ready
+BOOST_FIXTURE_TEST_CASE( policy_resolve_retry, PolicyFixture ) {
+    opflexServer->getListener().applyConnPred(make_flaky_pred, NULL);
+    setup();
+    WAIT_FOR(processor.getRefCount(c4u) > 0, 1000);
+    WAIT_FOR(!processor.isObjNew(c5u), 1000);
+    startClient();
+    WAIT_FOR(connReady(processor.getPool(), LOCALHOST, 8009), 1000);
+
+    WAIT_FOR(itemPresent(client2, 4, c4u), 1000);
+    WAIT_FOR(itemPresent(client2, 6, c6u), 1000);
+    BOOST_CHECK_EQUAL("test", client2->get(4, c4u)->getString(9));
+    BOOST_CHECK_EQUAL("test2", client2->get(6, c6u)->getString(13));
+
+    WAIT_FOR(opflexServer->getListener().applyConnPred(resolutions_pred, NULL), 1000);
+}
+
 class StateFixture : public ServerFixture {
 public:
     StateFixture()


### PR DESCRIPTION
If an MO reference is added locally, the refresh timeout for that MO is in most cases set to half the PRR, or 1 hour with the default timeout values. If the Processor invokes the OpflexPool's sendToRole handler before the peer has completed the identity request handshake, then the OpflexPool won't send the message, and the MO's timeout is unchanged. When the handshake does happen, the processor re-sends the policy resolve requests for those MOs, but it doesn't update the timeouts for those MOs. This can lead to excessive timeout values in some cases (e.g. request gets rejected with an error, even if the error state is short-lived).

This patch adds updates of the refresh time for the handshake succeeded callback, in order to avoid the excessive timeout described above.