### PR TITLE
Fix retry dithering call

### DIFF
--- a/libopflex/engine/Processor.cpp
+++ b/libopflex/engine/Processor.cpp
@@ -249,7 +249,7 @@ void Processor::sendToRole(const item& i, uint64_t& newexp,
             (uint64_t)std::pow(2, i.details->retry_count) * retryDelay;
 
 	// Randomize the backoff by plus or minus ten percent
-	nextRetryDelay += ditherBackoff(nextRetryDelay, 10);
+	nextRetryDelay = ditherBackoff(nextRetryDelay, 10);
 
         if (nextRetryDelay > policyRefTimerDuration)
             nextRetryDelay = policyRefTimerDuration;


### PR DESCRIPTION
Commit e5d0b8959adac24d4208179f65bc5f657015909f added dithering to the retry timeout, but introduced a bug: the base time gets included twice in the calculation, leading to double the intended timeout. This patch fixes that issue.