### PR TITLE
Fix related flow mask

### DIFF
--- a/agent-ovs/ovs/FlowUtils.cpp
+++ b/agent-ovs/ovs/FlowUtils.cpp
@@ -282,8 +282,6 @@ void add_classifier_entries(L24Classifier& clsfr, ClassAction act, bool log,
                                  FlowBuilder::CT_RELATED,
                                  FlowBuilder::CT_TRACKED |
                                  FlowBuilder::CT_RELATED |
-                                 FlowBuilder::CT_REPLY |
-                                 FlowBuilder::CT_ESTABLISHED |
                                  FlowBuilder::CT_INVALID |
                                  FlowBuilder::CT_NEW);
                  flowutils::match_group(f, priority, svnid, dvnid);

--- a/agent-ovs/ovs/test/AccessFlowManager_test.cpp
+++ b/agent-ovs/ovs/test/AccessFlowManager_test.cpp
@@ -903,7 +903,7 @@ void AccessFlowManagerFixture::initExpSysSecGrpSet1(){
          .isCtState("-new+est-rel+rpl-inv+trk").tcp()
          .actions().go(IN_POL).done());
     ADDF(Bldr(SEND_FLOW_REM).table(SYS_IN_POL).priority(prio - 128).cookie(ruleId)
-         .isCtState("-new-est+rel-rpl-inv+trk").ip()
+         .isCtState("-new+rel-inv+trk").ip()
          .actions().go(IN_POL).done());
     ADDF(Bldr(SEND_FLOW_REM).table(SYS_IN_POL).priority(prio - 128)
          .isCtState("-trk").tcp()
@@ -1018,7 +1018,7 @@ uint16_t AccessFlowManagerFixture::initExpSecGrp2(uint32_t setId) {
          .isCtState("-new+est-rel+rpl-inv+trk").tcp().reg(SEPG, setId)
          .actions().go(TAP).done());
     ADDF(Bldr(SEND_FLOW_REM).table(IN_POL).priority(prio - 128).cookie(ruleId)
-         .isCtState("-new-est+rel-rpl-inv+trk").ip().reg(SEPG, setId)
+         .isCtState("-new+rel-inv+trk").ip().reg(SEPG, setId)
          .actions().go(TAP).done());
     ADDF(Bldr(SEND_FLOW_REM).table(IN_POL).priority(prio - 128)
          .isCtState("-trk").tcp().reg(SEPG, setId)


### PR DESCRIPTION
prev fix to ignore reply introduced a regression with masks. when related bit is set, ignore reply and established we do make sure connection is not new AND not invalid.