### PR TITLE
Bump OpenSSL version for builds

### DIFF
--- a/.travis/install-dependencies.sh
+++ b/.travis/install-dependencies.sh
@@ -4,13 +4,13 @@ set -o errtrace
 set -x
 
 # Force openssl 1.1 on 22.04 systems, default is 3.0
-wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/openssl_1.1.1f-1ubuntu2.19_amd64.deb
-wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl-dev_1.1.1f-1ubuntu2.19_amd64.deb
-wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.19_amd64.deb
+wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/openssl_1.1.1f-1ubuntu2.20_amd64.deb
+wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl-dev_1.1.1f-1ubuntu2.20_amd64.deb
+wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.20_amd64.deb
 
-sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2.19_amd64.deb
-sudo dpkg -i libssl-dev_1.1.1f-1ubuntu2.19_amd64.deb
-sudo dpkg -i openssl_1.1.1f-1ubuntu2.19_amd64.deb
+sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2.20_amd64.deb
+sudo dpkg -i libssl-dev_1.1.1f-1ubuntu2.20_amd64.deb
+sudo dpkg -i openssl_1.1.1f-1ubuntu2.20_amd64.deb
 
 wget https://travisci-static-artifacts-dd485362-9714-11ea-bb37-0242ac130002.s3.us-east-2.amazonaws.com/artifacts.tgz
 tar -xvzf artifacts.tgz


### PR DESCRIPTION
The OpenSSL libraries need to be bumped for builds.

(cherry picked from commit 556717ba0e241818d8ba2f55bc40a514e076354b)