### PR TITLE
Add support for 1.1 compat with openssl 3.x

### DIFF
--- a/docker/travis/Dockerfile-opflex
+++ b/docker/travis/Dockerfile-opflex
@@ -4,7 +4,7 @@ RUN yum update -y --nogpgcheck --disablerepo=* --repofrompath=centos,https://mir
 RUN yum install -y --nogpgcheck --disablerepo=* --repofrompath=centos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os \
   libstdc++ libuv \
   boost-program-options boost-system boost-date-time boost-filesystem \
-  boost-iostreams libnetfilter_conntrack openssl net-tools procps-ng ca-certificates \
+  boost-iostreams libnetfilter_conntrack compat-openssl11 net-tools procps-ng ca-certificates vi \
   && yum clean all
 # Required OpenShift Labels
 LABEL name="ACI CNI Opflex" \


### PR DESCRIPTION
This package installs /etc/pki/openssl11.cnf that can be selected at process startup time via OPENSSL_CONF env

For k8s it can be done via
          image: challa/opflex:11
          env:
          - name: OPENSSL_CONF
            value: "/etc/pki/openssl11.cnf"

The variable makes the openssl3 libs compatible with 1.1 If not set the behavior is same as openssl3

(cherry picked from commit 6468f2faba3db5b3b858bd9472736f80669087c9)