### PR TITLE
Remove dh-systemd (#491)

### DIFF
--- a/agent-ovs/debian/control
+++ b/agent-ovs/debian/control
@@ -6,7 +6,7 @@ Build-Depends:
  debhelper (>= 8.0.0), autotools-dev, libboost-all-dev (>= 1.53),
  libopflex-dev, libmodelgbp-dev, libnoiro-openvswitch-dev (>= 2.12.0) <!norenderer>,
  libnoiro-openvswitch (>= 2.12.0) <!norenderer>, libnetfilter-conntrack-dev (>= 1.0) <!norenderer>,
- rapidjson-dev (>=1.1), pkgconf, dh-systemd, libssl-dev (>= 1.0), prometheus-cpp (>= 1.0.1),
+ rapidjson-dev (>=1.1), pkgconf, libssl-dev (>= 1.0), prometheus-cpp (>= 1.0.1),
  libcurl4-openssl-dev, curl
 Standards-Version: 3.9.8
 Homepage: https://wiki.opendaylight.org/view/OpFlex:Main


### PR DESCRIPTION
This was only needed in older ubuntu distros. In newer distros such as jammy, it causes build failures due to a missing dh-system dependency.

(cherry picked from commit 17199baa1425dfb4abec14461586d71573ffe283)