### PR TITLE
Add configurable timeouts for mcast and switch sync

### DIFF
--- a/agent-ovs/lib/Agent.cpp
+++ b/agent-ovs/lib/Agent.cpp
@@ -182,6 +182,8 @@ void Agent::setProperties(const boost::property_tree::ptree& properties) {
     static const std::string OPFLEX_HANDSHAKE("opflex.timers.handshake-timeout");
     static const std::string OPFLEX_KEEPALIVE("opflex.timers.keepalive-timeout");
     static const std::string OPFLEX_POLICY_RETRY_DELAY("opflex.timers.policy-retry-delay");
+    static const std::string OPFLEX_MULTICAST_CACHE_TIMEOUT("opflex.timers.mcast-cache-timeout");
+    static const std::string OPFLEX_SWITCH_SYNC_DELAY("opflex.timers.switch-sync-delay");
     static const std::string DISABLED_FEATURES("feature.disabled");
     static const std::string BEHAVIOR_L34FLOWS_WITHOUT_SUBNET("behavior.l34flows-without-subnet");
     static const std::string OPFLEX_ASYC_JSON("opflex.asyncjson.enabled");
@@ -474,6 +476,20 @@ void Agent::setProperties(const boost::property_tree::ptree& properties) {
     if (keepaliveOpt) {
         keepaliveTimeout = keepaliveOpt.get();
         LOG(INFO) << "keepalive timeout set to " << keepaliveTimeout << " ms";
+    }
+
+    optional<uint32_t> mcastCacheTimeoutOpt =
+        properties.get_optional<uint32_t>(OPFLEX_MULTICAST_CACHE_TIMEOUT);
+    if (mcastCacheTimeoutOpt) {
+        multicast_cache_timeout = mcastCacheTimeoutOpt.get();
+        LOG(INFO) << "Multicast cache timeout set to " << multicast_cache_timeout << " seconds";
+    }
+
+    optional<uint32_t> switchSyncDelayOpt =
+        properties.get_optional<uint32_t>(OPFLEX_SWITCH_SYNC_DELAY);
+    if (switchSyncDelayOpt) {
+        switch_sync_delay = switchSyncDelayOpt.get();
+        LOG(INFO) << "Switch Sync Delay set to " << switch_sync_delay << " seconds";
     }
 
     LOG(INFO) << "Agent mode set to " <<

--- a/agent-ovs/lib/include/opflexagent/Agent.h
+++ b/agent-ovs/lib/include/opflexagent/Agent.h
@@ -289,6 +289,16 @@ public:
     const LogParams& getLogParams() { return logParams; }
 
     /**
+     * Get Multicast cache timeout value
+     */
+    uint32_t getMulticastCacheTimeout() { return multicast_cache_timeout; }
+
+    /**
+     * Get Switch Sync delay value
+     */
+    uint32_t getSwitchSyncDelay() { return switch_sync_delay; }
+
+    /**
      * Common function b/w Agent and Server to add all supported universes
      * @param root pointer to DmtreeRoot under which the universes will be created
      */
@@ -334,6 +344,10 @@ private:
     uint32_t peerHandshakeTimeout = 45000;
     /* keepalive timeout */
     uint32_t keepaliveTimeout = 120000;
+    /* How long to wait before timing out old multicast cache */
+    uint32_t multicast_cache_timeout = 300; /* seconds */
+    /* How long to wait from platform config to switch Sync */
+    uint32_t switch_sync_delay = 5; /* seconds */
 
     std::set<std::string> endpointSourceFSPaths;
     std::set<std::string> disabledFeaturesSet;

--- a/agent-ovs/ovs/SwitchManager.cpp
+++ b/agent-ovs/ovs/SwitchManager.cpp
@@ -24,8 +24,6 @@ using boost::asio::deadline_timer;
 using boost::posix_time::milliseconds;
 using boost::asio::placeholders::error;
 
-const long DEFAULT_SYNC_DELAY_ON_CONNECT_MSEC = 5000;
-
 SwitchManager::SwitchManager(Agent& agent_,
                              FlowExecutor& flowExecutor_,
                              FlowReader& flowReader_,
@@ -34,7 +32,7 @@ SwitchManager::SwitchManager(Agent& agent_,
       flowExecutor(flowExecutor_),
       flowReader(flowReader_),
       portMapper(portMapper_), stateHandler(NULL),
-      connectDelayMs(DEFAULT_SYNC_DELAY_ON_CONNECT_MSEC),
+      connectDelayMs(agent.getSwitchSyncDelay()*1000),
       stopping(false), syncEnabled(false), syncing(false),
       syncInProgress(false), syncPending(false),
       tlvTableDone(false), groupsDone(false) {

--- a/agent-ovs/ovs/include/IntFlowManager.h
+++ b/agent-ovs/ovs/include/IntFlowManager.h
@@ -972,6 +972,10 @@ private:
     /* Map of multi-cast IP addresses to associated managed objects */
     typedef std::unordered_map<std::string, UriSet> MulticastMap;
     MulticastMap mcastMap;
+    /* Persistant multi-cast entries read during startup */
+    std::vector<std::string> oldMcastEntries;
+    // Lock to safe guard access to oldMcastEntries
+    std::mutex oldMcastEntriesMutex;
     /* Set of external flood domain Ids*/
     std::unordered_set<uint32_t> localExternalFdSet;
     /**
@@ -1000,6 +1004,16 @@ private:
      * Write out the current multicast subscriptions
      */
     void writeMulticastGroups();
+
+    /**
+     * Read persistent multicast config from file
+     */
+    void readOldMulticastGroups();
+
+    /**
+     * Clear persistent in-memory groups previously read frm file
+     */
+    void clearOldMulticastGroups();
     /**
      *
      */
@@ -1016,6 +1030,8 @@ private:
     std::unique_ptr<std::thread> svcStatsThread;
     boost::asio::io_service svcStatsIOService;
     std::unique_ptr<boost::asio::io_service::work> svcStatsIOWork;
+    boost::asio::io_service multiCastIOService;
+    std::unique_ptr<std::thread> multiCastIOThread;
     FaultManager& faultmanager;
     TaskQueue svcStatsTaskQueue;   
     // Lock to safe guard natstat related state


### PR DESCRIPTION
Mcast -
On startup agent will cache old values if present
in opflex-groups.json and start a timer to timeout these values. Until the timer expires new values
learned are merged with the old values and added
to the file. Eventually the timer will expire and
new values take effect from then on.
        "timers": {
            "mcast-cache-timeout": 600,
        }
section in opflex-agent.conf controls the timeout
in seconds. Default is 300 secs or 5 mins

Switch-state-sync -
        "timers": {
            "switch-sync-delay": 300
        }
This value was previous hardcoded to 5 seconds,
which is also the default. However it can be
changed via the above config option. It needs
to be increased if we anticipate many flows that
exist and a long delay between getting PlatformConfig Mo and the rest of the Mos that would be needed
to configure the new flowmods. On a fresh system
the value can be 0. (I will see if it can be dynamically adjusted based on the current flow mods)