### PR TITLE
Try to improve build times on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,3 +51,9 @@ jobs:
         - git clone http://www.github.com/noironetworks/cicd -b main /tmp/cicd
         - /tmp/cicd/travis/check-git-tag.sh; RETURN_CODE=$? ; if [ $RETURN_CODE -eq 140 ]; then travis_terminate 0; elif [ $RETURN_CODE -ne 0 ]; then travis_terminate $RETURN_CODE; fi
         - /tmp/cicd/travis/build-push-opflex-images.sh || travis_terminate 1
+
+cache:
+  directories:
+    - ../grpc
+    - $HOME/.m2
+

--- a/docker/travis/Dockerfile-opflex-build
+++ b/docker/travis/Dockerfile-opflex-build
@@ -5,7 +5,7 @@ ARG BUILDOPTS="--enable-grpc"
 ENV PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:/usr/share/pkgconfig
 WORKDIR /opflex
 COPY opflex.tgz /opflex/opflex.tgz
-ARG make_args=-j1
+ARG make_args=-j2
 RUN cd /opflex && tar xvfz opflex.tgz && cd /opflex/opflex/libopflex \
   && ./autogen.sh && ./configure --disable-assert \
   && make $make_args && make install && make clean \

--- a/docker/travis/Dockerfile-opflex-build-base
+++ b/docker/travis/Dockerfile-opflex-build-base
@@ -48,10 +48,6 @@ RUN git clone -b libnftnl-1.1.7 https://git.netfilter.org/libnftnl \
   && make install && make clean \
   && cd / \
   && rm -rf libuv \
-  && wget -q -O cmake-linux.sh https://github.com/Kitware/CMake/releases/download/v3.17.0/cmake-3.17.0-Linux-x86_64.sh \
-  && mkdir -p cmake-tmp \
-  && sh cmake-linux.sh -- --skip-license --prefix=cmake-tmp \
-  && rm cmake-linux.sh \
   && git clone https://github.com/noironetworks/3rdparty-debian.git \
   && git clone https://github.com/jupp0r/prometheus-cpp.git -b v1.0.1 --depth 1 \
   && cd prometheus-cpp \
@@ -59,18 +55,18 @@ RUN git clone -b libnftnl-1.1.7 https://git.netfilter.org/libnftnl \
   && git submodule update \
   && git apply /3rdparty-debian/prometheus/prometheus-cpp.patch \
   && mkdir _build && cd _build \
-  && ../../cmake-tmp/bin/cmake .. -DBUILD_SHARED_LIBS=ON -DENABLE_PUSH=OFF \
+  && cmake .. -DBUILD_SHARED_LIBS=ON -DENABLE_PUSH=OFF \
   && make $make_args && make install && make clean \
   && mv /usr/local/lib64/libprometheus-cpp-* /usr/local/lib/ \
   && cd / \
   && rm -rf 3rdparty-debian \
   && rm -rf prometheus-cpp \
-  && git clone -b v1.46.0 https://github.com/grpc/grpc --config submodule.third_party/re2.url=https://github.com/google/re2.git --config submodule.third_party/re2.active=true \
+  && git clone -b v1.52.2 https://github.com/grpc/grpc \
   && cd grpc \
   && git submodule update --init \
   && mkdir -p cmake/build \
   && cd cmake/build \
-  && ../../../cmake-tmp/bin/cmake -DgRPC_INSTALL=ON -DgRPC_BUILD_TESTS=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr/local \
+  && cmake -DgRPC_INSTALL=ON -DgRPC_BUILD_TESTS=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr/local \
                                -DgRPC_BUILD_GRPC_PYTHON_PLUGIN=OFF -DgRPC_BUILD_CSHARP_EXT=OFF -DgRPC_BUILD_GRPC_CSHARP_PLUGIN=OFF \
                                -DgRPC_BUILD_GRPC_NODE_PLUGIN=OFF -DgRPC_BUILD_GRPC_OBJECTIVE_C_PLUGIN=OFF -DgRPC_BUILD_GRPC_PHP_PLUGIN=OFF \
                                -DgRPC_BUILD_GRPC_PYTHON_PLUGIN=OFF -DgRPC_BUILD_GRPC_RUBY_PLUGIN=OFF \


### PR DESCRIPTION
Fix grpc dep to 1.52.2
Attempt to reenable cache of grpc builds
Use -j2 when building in UBI env
Stop manually installing cmake. Upstream version is new enough now