### PR TITLE
Install cpp-coveralls from source to support service name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,6 @@ jobs:
       # In case we need to run perf, install the below in bionic:
       # linux-tools-common
       # linux-tools-4.15.0-72-generic
-      before_install:
-        - pip install --user cpp-coveralls
       install: bash ./.travis/install-dependencies.sh
       before_script: sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6';
       env:

--- a/.travis/coveralls-deploy.sh
+++ b/.travis/coveralls-deploy.sh
@@ -3,5 +3,6 @@
 if [ "$TEST_SUITE" == "travis-build.sh" ]; then
   lcov --capture --directory . --output-file coverage-all.info > /dev/null
   lcov --remove coverage-all.info -o coverage-all.info '/usr/include/*' '/usr/local/include/*' '*/test/*' > /dev/null
+  export COVERALLS_SERVICE_NAME=travis-pro
   coveralls --lcov-file coverage-all.info --exclude '/usr/include' --exclude '/usr/local/include' --exclude-pattern '.*/test/.*' --gcov-options '\-lp' > /dev/null
 fi

--- a/.travis/install-dependencies.sh
+++ b/.travis/install-dependencies.sh
@@ -3,6 +3,11 @@
 set -o errtrace
 set -x
 
+git clone https://github.com/eddyxu/cpp-coveralls
+pushd cpp-coveralls
+sudo ./setup.py install
+popd
+
 wget https://travisci-static-artifacts-dd485362-9714-11ea-bb37-0242ac130002.s3.us-east-2.amazonaws.com/artifacts.tgz
 tar -xvzf artifacts.tgz
 sudo dpkg -i jammy/libnoiro-openvswitch_2.12.0-1_amd64.deb


### PR DESCRIPTION
coveralls hasn't been including the branch info since we moved to travis-ci.com