### PR TITLE
Cleanups for clean restart

### DIFF
--- a/agent-ovs/cmd/opflex_agent.cpp
+++ b/agent-ovs/cmd/opflex_agent.cpp
@@ -112,6 +112,9 @@ public:
 
                 while (true) {
                     cond.wait(lock, [this]{ return stopped || need_reload || need_reset; });
+                    if (stopped) {
+                        break;
+                    }
                     if (!stopped && need_reload) {
                         LOG(INFO) << "Reloading agent because of " <<
                             "configuration update";

--- a/agent-ovs/ovs/include/PacketLogHandler.h
+++ b/agent-ovs/ovs/include/PacketLogHandler.h
@@ -89,10 +89,22 @@ public:
     void stop() {
         boost::system::error_code ec;
         stopped = true;
-        serverSocket.shutdown(boost::asio::ip::udp::socket::shutdown_both);
-        serverSocket.cancel(ec);
-        serverSocket.close(ec);
-    }
+        try {
+            serverSocket.shutdown(boost::asio::ip::udp::socket::shutdown_both);
+        } catch (const std::runtime_error& e) {
+            LOG(WARNING) << "Packetlogger failed to shutdown UDP socket: " << e.what();
+        }
+        try {
+            serverSocket.cancel(ec);
+        } catch (const std::runtime_error& e) {
+            LOG(WARNING) << "Packetlogger failed to cancel UDP socket: " << e.what();
+        }
+        try {
+            serverSocket.close(ec);
+        } catch (const std::runtime_error& e) {
+            LOG(WARNING) << "Packetlogger failed to close UDP socket: " << e.what();
+        }
+   }
 private:
     /**
      * Handle received UDP packets

--- a/libopflex/include/opflex/yajr/async_doc_parser.hpp
+++ b/libopflex/include/opflex/yajr/async_doc_parser.hpp
@@ -59,8 +59,8 @@ public:
     {
         // Create and execute thread after all member variables are initialized.
         parseThread_ = std::thread(&AsyncDocumentParser::Parse, this);
-        std::string fname = "/var/log/opflex-json.log." + std::to_string(getpid()) + "." + std::to_string(instance_count_);
-        out_.open(fname, std::ofstream::out | std::ofstream::app);
+        //std::string fname = "/var/log/opflex-json.log." + std::to_string(getpid()) + "." + std::to_string(instance_count_);
+        //out_.open(fname, std::ofstream::out | std::ofstream::app);
         instance_count_++;
     }
 
@@ -223,7 +223,7 @@ private:
     std::condition_variable finish_;
     bool stop_;
     int id_;
-    std::ofstream out_;
+    //std::ofstream out_;
 };
 
 } /* yajr namespace */


### PR DESCRIPTION
- earlier fix for reset_opflex missed stop only condition
- handle exceptions in packetlogger when socket not connected that prevents the rest of the agent cleanups due to exception
- comment out creation of debug file for async json. The writes were commented out but realized I missed commenting out the file creation

Signed-off-by: Madhu Challa <challa@gmail.com>
(cherry picked from commit 3660bfa0ceae06e65d4aafa1e4d9cf0174969578)