### PR TITLE
Add option to gbp_inspect to ignore all observables

### DIFF
--- a/agent-ovs/Makefile.am
+++ b/agent-ovs/Makefile.am
@@ -294,7 +294,7 @@ if RENDERER_OVS
 	ovs/OvsdbMessage.cpp \
 	ovs/OvsdbMonitorMessage.cpp \
 	ovs/CtZoneManager.cpp \
-	ovs/DnsManager.cpp \	
+	ovs/DnsManager.cpp \
 	ovs/NatStatsManager.cpp
 
   librenderer_openvswitch_la_CFLAGS = \

--- a/agent-ovs/cmd/gbp_inspect.cpp
+++ b/agent-ovs/cmd/gbp_inspect.cpp
@@ -86,6 +86,7 @@ int main(int argc, char** argv) {
             ("props,p", "Include object properties in output")
             ("width,w", po::value<int>()->default_value(w.ws_col - 1),
              "Truncate output to the specified number of characters")
+            ("exclude-observables,x", "Exclude observables from output")
             ;
     } catch (const boost::bad_lexical_cast& e) {
         LOG(ERROR) << "exception while processing description: " << e.what();
@@ -107,6 +108,7 @@ int main(int argc, char** argv) {
     bool followRefs = false;
     int truncate = 0;
     bool unresolved = false;
+    bool excludeObservables = false;
     po::variables_map vm;
     try {
         po::store(po::command_line_parser(argc, argv).
@@ -131,6 +133,8 @@ int main(int argc, char** argv) {
             followRefs = true;
         if (vm.count("unresolved"))
             unresolved = true;
+        if (vm.count("exclude-observables"))
+            excludeObservables = true;
 
         log_file = vm["log"].as<string>();
         level_str = vm["level"].as<string>();
@@ -175,6 +179,7 @@ int main(int argc, char** argv) {
                                                 modelgbp::getMetadata()));
         client->setRecursive(recursive);
         client->setFollowRefs(followRefs);
+        client->setExcludeObservables(excludeObservables);
 
         if(unresolved) {
             client->setUnresolved(true);

--- a/agent-ovs/cmd/test/mock_server.cpp
+++ b/agent-ovs/cmd/test/mock_server.cpp
@@ -149,7 +149,7 @@ int main(int argc, char** argv) {
             Policies::writeBasicInit(mframework);
             Policies::writeTestPolicy(mframework);
 
-            mframework.dumpMODB(sample_file);
+            mframework.dumpMODB(sample_file, false);
 
             mframework.stop();
             return 0;

--- a/libopflex/engine/InspectorClientImpl.cpp
+++ b/libopflex/engine/InspectorClientImpl.cpp
@@ -175,7 +175,7 @@ void InspectorClientImpl::dumpToFile(FILE* file) {
     if (unresolved) {
         serializer.dumpUnResolvedMODB(file);
     } else {
-        serializer.dumpMODB(file);
+        serializer.dumpMODB(file, excludeObservables);
     }
 }
 
@@ -191,7 +191,7 @@ void InspectorClientImpl::prettyPrint(std::ostream& output,
     if (unresolved) {
         serializer.displayUnresolved(output, tree, utf8);
     } else {
-        serializer.displayMODB(output, tree, includeProps, utf8, truncate);
+        serializer.displayMODB(output, tree, includeProps, utf8, truncate, excludeObservables);
     }
 }
 
@@ -206,6 +206,10 @@ void InspectorClientImpl::setRecursive(bool enabled) {
 void InspectorClientImpl::setUnresolved(bool enabled) {
     unresolved = enabled;
     followRefs = enabled;
+}
+
+void InspectorClientImpl::setExcludeObservables(bool enabled) {
+    excludeObservables = enabled;
 }
 
 static std::string getRefSubj(const modb::ObjectStore& store,

--- a/libopflex/engine/include/opflex/engine/InspectorClientImpl.h
+++ b/libopflex/engine/include/opflex/engine/InspectorClientImpl.h
@@ -72,6 +72,7 @@ public:
     virtual void setFollowRefs(bool enabled);
     virtual void setRecursive(bool enabled);
     virtual void setUnresolved(bool enabled);
+    virtual void setExcludeObservables(bool enabled);
     virtual void addQuery(const std::string& subject,
                           const modb::URI& uri);
     virtual void addClassQuery(const std::string& subject);
@@ -111,6 +112,7 @@ private:
     bool followRefs;
     bool recursive;
     bool unresolved;
+    bool excludeObservables;
     friend class internal::InspectorClientHandler;
 
     void executeCommands();

--- a/libopflex/engine/test/MOSerialize_test.cpp
+++ b/libopflex/engine/test/MOSerialize_test.cpp
@@ -300,7 +300,7 @@ BOOST_FIXTURE_TEST_CASE( mo_deserialize , BaseFixture ) {
     BOOST_CHECK_EQUAL(0, notifs.size());
 
     string modbFilename("/tmp/mo.db");
-    serializer.dumpMODB(modbFilename);
+    serializer.dumpMODB(modbFilename, true);
     string unresolvedModbFilename("/tmp/unresolvedmo.db");
     FILE* unresolvedMoFile = fopen(unresolvedModbFilename.c_str(), "w");
     if (unresolvedMoFile == NULL) {

--- a/libopflex/include/opflex/ofcore/InspectorClient.h
+++ b/libopflex/include/opflex/ofcore/InspectorClient.h
@@ -80,6 +80,13 @@ public:
     virtual void setUnresolved(bool enabled) = 0;
 
     /**
+     * exclude observables from output
+     *
+     * @param enabled set to true to exclude observables
+     */
+    virtual void setExcludeObservables(bool enabled) = 0;
+
+    /**
      * Query for a particular managed object
      *
      * @param subject the subject (class name) of the object

--- a/libopflex/include/opflex/ofcore/OFFramework.h
+++ b/libopflex/include/opflex/ofcore/OFFramework.h
@@ -782,7 +782,7 @@ public:
      *
      * @param file the file to write to.
      */
-    virtual void dumpMODB(const std::string& file);
+    virtual void dumpMODB(const std::string& file, bool excludeObservables);
 
     /**
      * Dump the managed object database to the file specified as a
@@ -790,7 +790,7 @@ public:
      *
      * @param file the file to write to.
      */
-    virtual void dumpMODB(FILE* file);
+    virtual void dumpMODB(FILE* file, bool excludeObservables);
 
     /**
      * Pretty print the current MODB to the provided output stream.
@@ -806,7 +806,8 @@ public:
                                  bool tree = true,
                                  bool includeProps = true,
                                  bool utf8 = true,
-                                 size_t truncate = 0);
+                                 size_t truncate = 0,
+                                 bool excludeObservables = false);
 
     /**
      * Enable SSL for connections to opflex peers

--- a/libopflex/ofcore/OFFramework.cpp
+++ b/libopflex/ofcore/OFFramework.cpp
@@ -155,23 +155,24 @@ void OFFramework::stop() {
     pimpl->started = false;
 }
 
-void OFFramework::dumpMODB(const string& file) {
+void OFFramework::dumpMODB(const string& file, bool excludeObservables) {
     MOSerializer& serializer = pimpl->processor.getSerializer();
-    serializer.dumpMODB(file);
+    serializer.dumpMODB(file, excludeObservables);
 }
 
-void OFFramework::dumpMODB(FILE* file) {
+void OFFramework::dumpMODB(FILE* file, bool excludeObservables) {
     MOSerializer& serializer = pimpl->processor.getSerializer();
-    serializer.dumpMODB(file);
+    serializer.dumpMODB(file, excludeObservables);
 }
 
 void OFFramework::prettyPrintMODB(std::ostream& output,
                                   bool tree,
                                   bool includeProps,
                                   bool utf8,
-                                  size_t truncate) {
+                                  size_t truncate,
+                                  bool excludeObservables) {
     MOSerializer& serializer = pimpl->processor.getSerializer();
-    serializer.displayMODB(output, tree, includeProps, utf8, truncate);
+    serializer.displayMODB(output, tree, includeProps, utf8, truncate, excludeObservables);
 }
 
 void OFFramework::setOpflexIdentity(const string& name,

--- a/libopflex/ofcore/test/OFFramework_test.cpp
+++ b/libopflex/ofcore/test/OFFramework_test.cpp
@@ -14,9 +14,6 @@
 #  include <config.h>
 #endif
 
-
-#include "config.h"
-
 #include <boost/test/unit_test.hpp>
 
 #include "opflex/ofcore/OFFramework.h"


### PR DESCRIPTION
This is especially useful when dumping MODB

Signed-off-by: Tom Flynn <tom.flynn@gmail.com>
(cherry picked from commit 0e8b72968991529b9a5864aba2465c388301f33a)