### PR TITLE
Fix prefixlen matching in prunefilter

### DIFF
--- a/agent-ovs/ovs/include/PacketLogHandler.h
+++ b/agent-ovs/ovs/include/PacketLogHandler.h
@@ -223,7 +223,7 @@ public:
         if(!prefixLen.empty()) {
             pfxLen = stoul(prefixLen);
         }
-        if((pfxLen > 32) || (pfxLen == 0))
+        if((pfxLen > 128) || (pfxLen == 0))
            return false;
         return network::prefix_match( addr1, pfxLen,
                                  addr2, pfxLen, is_exact_match);
@@ -269,7 +269,7 @@ public:
         for (auto &i:ip_fields) {
             if(!fields[i].second.empty()) {
                 if(!compareIps(fields[i].second,p.fields[i].second,
-                            fields[i+8].second)) {
+                            fields[i+7].second)) {
                     return false;
                 }
             }


### PR DESCRIPTION
Incorrect field was being used for ip prefixlen in prunefilter.

Signed-off-by: Kiran Shastri <shastrinator@gmail.com>
(cherry picked from commit 3d7cc7320312fd9a77740529afb8786208fa72c0)