### PR TITLE
Dynamic switch sync delay

### DIFF
--- a/agent-ovs/lib/Agent.cpp
+++ b/agent-ovs/lib/Agent.cpp
@@ -184,6 +184,7 @@ void Agent::setProperties(const boost::property_tree::ptree& properties) {
     static const std::string OPFLEX_POLICY_RETRY_DELAY("opflex.timers.policy-retry-delay");
     static const std::string OPFLEX_MULTICAST_CACHE_TIMEOUT("opflex.timers.mcast-cache-timeout");
     static const std::string OPFLEX_SWITCH_SYNC_DELAY("opflex.timers.switch-sync-delay");
+    static const std::string OPFLEX_SWITCH_SYNC_DYNAMIC("opflex.timers.switch-sync-dynamic");
     static const std::string DISABLED_FEATURES("feature.disabled");
     static const std::string BEHAVIOR_L34FLOWS_WITHOUT_SUBNET("behavior.l34flows-without-subnet");
     static const std::string OPFLEX_ASYC_JSON("opflex.asyncjson.enabled");
@@ -389,6 +390,13 @@ void Agent::setProperties(const boost::property_tree::ptree& properties) {
     if (switchSyncDelayOpt) {
         switch_sync_delay = switchSyncDelayOpt.get();
         LOG(INFO) << "Switch Sync Delay set to " << switch_sync_delay << " seconds";
+    }
+
+    optional<uint32_t> switchSyncDynamicOpt =
+        properties.get_optional<uint32_t>(OPFLEX_SWITCH_SYNC_DYNAMIC);
+    if (switchSyncDynamicOpt) {
+        switch_sync_dynamic = switchSyncDynamicOpt.get();
+        LOG(INFO) << "Switch Sync Dynamic set to " << switch_sync_dynamic << " seconds";
     }
 
     optional<const ptree&> rendererPlugins =

--- a/agent-ovs/lib/include/opflexagent/Agent.h
+++ b/agent-ovs/lib/include/opflexagent/Agent.h
@@ -299,6 +299,11 @@ public:
     uint32_t getSwitchSyncDelay() { return switch_sync_delay; }
 
     /**
+     * Get if switch sync set to dynamic
+     */
+    uint32_t getSwitchSyncDynamic() { return switch_sync_dynamic; }
+
+    /**
      * Common function b/w Agent and Server to add all supported universes
      * @param root pointer to DmtreeRoot under which the universes will be created
      */
@@ -348,6 +353,7 @@ private:
     uint32_t multicast_cache_timeout = 300; /* seconds */
     /* How long to wait from platform config to switch Sync */
     uint32_t switch_sync_delay = 5; /* seconds */
+    uint32_t switch_sync_dynamic = 0; /* dynamic retry default 0 no retry */
 
     std::set<std::string> endpointSourceFSPaths;
     std::set<std::string> disabledFeaturesSet;

--- a/agent-ovs/opflex-agent-ovs.conf.in
+++ b/agent-ovs/opflex-agent-ovs.conf.in
@@ -108,7 +108,24 @@
            //
            // How long to wait (in ms) for keepalive echo to
            // be ack'd before timing out connection
-           // "keepalive-timeout" : 120000
+           // "keepalive-timeout" : 120000,
+           //
+           // Initial switch sync delay
+           // How long to wait from PlatformConfig resolution
+           // to start the switch sync, default 5 seconds
+           // "switch-sync-delay": 5,
+           //
+           // Subsequent switch sync delay
+           // In case we have subsequent resolutions pending
+           // whats the minimum time any resolution can be
+           // pending before we retry switch sync
+           // default 0, no further wait
+           // If this value is > 0, we keep checking if
+           // every pending MO waited at least this long
+           // before retrying switch sync
+           // Max retries will be 5 so as to not wait
+           // forever
+           // "switch-sync-dynamic": 0
        },
        // Statistics. Counters for various artifacts.
        // mode: can be either

--- a/agent-ovs/ovs/include/SwitchManager.h
+++ b/agent-ovs/ovs/include/SwitchManager.h
@@ -296,6 +296,7 @@ private:
     std::atomic<bool> syncing;
     std::atomic<bool> syncInProgress;
     std::atomic<bool> syncPending;
+    std::atomic<int> sync_retries;
 
     std::vector<FlowEntryList> recvFlows;
     std::vector<bool> tableDone;

--- a/libopflex/engine/OpflexPEHandler.cpp
+++ b/libopflex/engine/OpflexPEHandler.cpp
@@ -385,6 +385,13 @@ void OpflexPEHandler::handlePolicyResolveRes(uint64_t reqId,
 void OpflexPEHandler::handlePolicyResolveErr(uint64_t reqId,
                                              const rapidjson::Value& payload) {
     auto conn = (OpflexClientConnection*)getConnection();
+    OpflexPool& pool = getProcessor()->getPool();
+    std::string uri = "";
+    bool found = pool.getPendingItem(conn, reqId, uri);
+    if (found) {
+        LOG(ERROR) << "Policy resolve failed for request "
+                   << reqId << " : " << uri;
+    }
     conn->getOpflexStats()->incrPolResolveErrs();
     handleError(reqId, payload, "Policy Resolve");
 }

--- a/libopflex/engine/Processor.cpp
+++ b/libopflex/engine/Processor.cpp
@@ -600,6 +600,10 @@ void Processor::setTunnelMac(const opflex::modb::MAC &mac) {
     pool.setTunnelMac(mac);
 }
 
+bool Processor::waitForPendingItems(uint32_t& wait) {
+    return pool.waitForPendingItems(wait);
+}
+
 void Processor::start(ofcore::OFConstants::OpflexElementMode agent_mode) {
     if (proc_active) return;
     proc_active = true;

--- a/libopflex/engine/include/opflex/engine/Processor.h
+++ b/libopflex/engine/include/opflex/engine/Processor.h
@@ -259,6 +259,13 @@ public:
      */
     void setTunnelMac(const opflex::modb::MAC &mac);
 
+   /**
+    * Wait for pending items
+    * @param wait min wait time input and how long to wait as output
+    * @return true wait, false no wait
+    */
+    bool waitForPendingItems(uint32_t& wait);
+
     /**
      * Enable/Disable reporting of observable changes to registered observers
      *

--- a/libopflex/include/opflex/ofcore/OFFramework.h
+++ b/libopflex/include/opflex/ofcore/OFFramework.h
@@ -753,6 +753,13 @@ public:
      */
     void setKeepaliveTimeout(const uint32_t timeout);
 
+   /**
+    * Wait for pending items
+    * @param wait min wait time input and how long to wait as output
+    * @return true wait, false no wait
+    */
+    bool waitForPendingItems(uint32_t& wait);
+
     /**
      * Start the framework.  This will start all the framework threads
      * and attempt to connect to configured OpFlex peers.

--- a/libopflex/ofcore/OFFramework.cpp
+++ b/libopflex/ofcore/OFFramework.cpp
@@ -123,6 +123,10 @@ void OFFramework::setKeepaliveTimeout(const uint32_t timeout) {
     pimpl->processor.setKeepaliveTimeout(timeout);
 }
 
+bool OFFramework::waitForPendingItems(uint32_t& wait) {
+    return pimpl->processor.waitForPendingItems(wait);
+}
+
 void OFFramework::start() {
     LOG(DEBUG) << "Starting OpFlex Framework";
     pimpl->started = true;


### PR DESCRIPTION
Controlled via opflex.timers.switch-sync-dynamic default 0 secs

When configured > 0, in addition to the initial switch sync delay set via opflex.timers.switch-sync-delay (default 5 secs) agent will checking pending MOs not yet resolved and only when we have waited at least switch-sync-dynamic for each MO initiate the sync. Otherwise we will sleep for (switch-sync-dynamic - MO with least wait) and attempt another sync after that time.

The max retries = 5 is hardcoded, so after 5 checks if we still have pending MOs we will no longer wait. So the max additional wait (in addition to switch-sync-delay) will be switch-sync-dynamic * 5

This narrows the window where we are yet to resolve some MOs and prevents us from touching the flow tables till then.

Also changed all Sync logs from DEBUG to INFO since we expect to see them only during start and with the new code it gives a good indication of what MOs are pending and would possibly never be resolved.

Also correlate the XID with the corresponding URI which was an issue with all the cache miss ESTATE errors that would only print the XID

Signed-off-by: Madhu Challa <challa@gmail.com>
(cherry picked from commit fc2d0b1b67b22f55eb1e3fb46987889aa87537df)