### PR TITLE
Add support for coming up with a persist policy

### DIFF
--- a/agent-ovs/lib/include/opflexagent/Agent.h
+++ b/agent-ovs/lib/include/opflexagent/Agent.h
@@ -354,6 +354,9 @@ private:
     /* How long to wait from platform config to switch Sync */
     uint32_t switch_sync_delay = 5; /* seconds */
     uint32_t switch_sync_dynamic = 0; /* dynamic retry default 0 no retry */
+    // startup policy duration from new connection in seconds
+    uint64_t startupPolicyDuration = 0; /* seconds */
+    bool localResolveAftConn = false; /* local resolve after conn estb */
 
     std::set<std::string> endpointSourceFSPaths;
     std::set<std::string> disabledFeaturesSet;
@@ -418,6 +421,8 @@ private:
     std::unordered_set<std::string> prometheusEpAttributes;
     bool behaviorL34FlowsWithoutSubnet;
     LogParams logParams;
+    /* Persistent policy from disk */
+    boost::optional<std::string> opflexPolicyFile;
 };
 
 } /* namespace opflexagent */

--- a/agent-ovs/opflex-agent-ovs.conf.in
+++ b/agent-ovs/opflex-agent-ovs.conf.in
@@ -11,6 +11,25 @@
 
     // Configuration related to the OpFlex protocol
     "opflex": {
+    //  // This section controls how persistant config is treated
+    //  // during opflex startup
+    //  "startup": {
+    //      // Location of the pol.json that will be read and used on startup
+    //      // will be provided by the orchestrator
+    //      "policy-file": "/foo/bar/pol.json",
+    //      // How long to use the above file after agent connects to the leaf
+    //      // default is 0 meaning as soon as agent connects to leaf we will
+    //      // stop using the local policy for future resolves
+    //      "policy-duration": 0,
+    //      // Wait till opflex connects to leaf before using the local policy
+    //      // default 0, use in combination with policy-duration > 0
+    //      // This is useful if you want to preserve the old flows until
+    //      // the leaf connection succeeds and not overwrite them before we
+    //      // connect to the leaf using the local policy
+    //      // A related knob timers.switch-sync-delay controls after connection
+    //      // how much more longer to freeze the flow tables
+    //      "resolve-aft-conn": false
+    //  },
         // The policy domain for this agent.
         "domain": "openstack",
 

--- a/libopflex/engine/include/opflex/engine/internal/MOSerializer.h
+++ b/libopflex/engine/include/opflex/engine/internal/MOSerializer.h
@@ -393,7 +393,8 @@ public:
                      modb::mointernal::StoreClient& client,
                      bool replaceChildren,
                      /* out */
-                     modb::mointernal::StoreClient::notif_t* notifs = NULL);
+                     modb::mointernal::StoreClient::notif_t* notifs,
+                     bool skiplocal = false);
 
     /**
      * Dump the managed object database to the file specified as a
@@ -425,9 +426,11 @@ public:
      * @param file the file containing the managed objects
      * @param client the store client to use
      * @param return the number of managed objects read
+     * @param skiplocal skip local mos if true
      */
     size_t readMOs(FILE* file,
-                   modb::mointernal::StoreClient& client);
+                   modb::mointernal::StoreClient& client,
+                   bool skiplocal = false);
 
     /**
      * Update managed objects from RapidJson document into the MODB

--- a/libopflex/include/opflex/ofcore/OFFramework.h
+++ b/libopflex/include/opflex/ofcore/OFFramework.h
@@ -761,6 +761,18 @@ public:
     bool waitForPendingItems(uint32_t& wait);
 
     /**
+     * Set startup policy file
+     * @param file startup policy file name or boost::none
+     * @param model the model to use for startupdb
+     * @param duration in ms how long from new connection to use startupdb
+     * @param resolve_after_connection delay local resolves till connection
+     */
+    void setStartupPolicy(boost::optional<std::string>& file,
+                          const modb::ModelMetadata& model,
+                          uint64_t& duration,
+                          bool& resolve_after_connection);
+
+    /**
      * Start the framework.  This will start all the framework threads
      * and attempt to connect to configured OpFlex peers.
      */

--- a/libopflex/ofcore/OFFramework.cpp
+++ b/libopflex/ofcore/OFFramework.cpp
@@ -127,6 +127,14 @@ bool OFFramework::waitForPendingItems(uint32_t& wait) {
     return pimpl->processor.waitForPendingItems(wait);
 }
 
+void OFFramework::setStartupPolicy(boost::optional<std::string>& file,
+                                   const modb::ModelMetadata& model,
+                                   uint64_t& duration,
+                                   bool& resolve_after_connection) {
+    pimpl->processor.setStartupPolicy(file, model,
+                                      duration, resolve_after_connection);
+}
+
 void OFFramework::start() {
     LOG(DEBUG) << "Starting OpFlex Framework";
     pimpl->started = true;


### PR DESCRIPTION
    "opflex": {
       "startup": {
            "policy-file": "/home/mchalla/thomas/pol.json",
            "policy-duration": 0,
            "resolve-aft-conn": false
       },

- opflex.startup.policy-file contains pol.json to use at startup
- opflex.startup.policy-duration tells how long in seconds to keep resolving policy from the above pol.json
- opflex.startup.resolve-aft-conn wait till conn before using startup db use in combination with duration > 0
- opflex.startup.resolve-once placeholder for resolving only first time from startup db
- opflex.startup.full-proxy placeholder use startup db for life of opflex meaning startup db will be updated at run time to keep both in sync

If policy-file exists we create a startupdb thats used for intermediate resolves until the leaf connection succeeds based on the above startup-policy-duration

On every local resolve we lookup startupdb and recursively resolve children and put those in the running modb and generating notifications as needed.

On a connect to leaf depending on the above timer and the fact that these threads can run in parallel we will continue to resolve from startupdb while also sending all the resolves to the leaf.

Once the curtime is beyond the set duration functionality reverts to current behavior of only resolving from the leaf.

On stop we write current running policy into pol.json from the config if present.

If the file is missing functionality is same as before.

Change isOrphan to skip check when using startup db since the timing of the sync resolve is causing some valid mos to be deleted as orphans (still investigating an async approach similar to how it would work
 with a mock server or leaf)

Signed-off-by: Madhu Challa <challa@gmail.com>
(cherry picked from commit a1e4e3ca7120a663fb588c22ca64eaf16c20a29e)