### PR TITLE
Lock ubi version to 9.3 to prevent conflicts

### DIFF
--- a/docker/travis/Dockerfile-opflex
+++ b/docker/travis/Dockerfile-opflex
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3
 RUN microdnf install -y yum yum-utils
 RUN yum update -y --nogpgcheck --disablerepo=* --repofrompath=centos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os  --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os && rm -rf /var/cache/yum
 RUN yum install -y --nogpgcheck --disablerepo=* --repofrompath=centos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os \

--- a/docker/travis/Dockerfile-opflex-build-base
+++ b/docker/travis/Dockerfile-opflex-build-base
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3
 ENV ROOT=/usr/local
 ARG make_args=-j1
 RUN microdnf install -y yum yum-utils \

--- a/docker/travis/Dockerfile-opflexserver
+++ b/docker/travis/Dockerfile-opflexserver
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3
 RUN microdnf install -y yum yum-utils \
  && yum-config-manager --add-repo=https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os \
  && yum-config-manager --add-repo=https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os \


### PR DESCRIPTION
ubi base image in 9.4 and latest uses openssl-libs-1:3.2.1-1.el9.x86_64 that conflicts with openssl-fips-provider-3.0.7-2.el9.x86_64 from mirror.stream.centos.org_9-stream_BaseOS_x86_64_os because the centos contains openssl-libs-3.2.1-1.el9.x86_64.rpm. we cannot remove the older version because systemd depends on it. So lock the version until its resolved in upstream

Signed-off-by: Madhu Challa <challa@gmail.com>
(cherry picked from commit 207cc749ee5d7cf9e941e56936eb27722d59fdfc)