### PR TITLE
Add enable config option for startup section

### DIFF
--- a/agent-ovs/lib/include/opflexagent/Agent.h
+++ b/agent-ovs/lib/include/opflexagent/Agent.h
@@ -422,6 +422,7 @@ private:
     bool behaviorL34FlowsWithoutSubnet;
     LogParams logParams;
     /* Persistent policy from disk */
+    bool startupPolicyEnabled;
     boost::optional<std::string> opflexPolicyFile;
 };
 

--- a/docker/travis/launch-opflexagent.sh
+++ b/docker/travis/launch-opflexagent.sh
@@ -23,6 +23,7 @@ if [ -w ${PREFIX} ]; then
     mkdir -p ${VARDIR}/lib/opflex-agent-ovs/reboot-conf.d
     mkdir -p ${VARDIR}/lib/opflex-agent-ovs/droplog
     mkdir -p ${VARDIR}/lib/opflex-agent-ovs/faults
+    mkdir -p ${VARDIR}/lib/opflex-agent-ovs/startup
 fi
 
 if [ -d ${OPFLEXAGENT_CONF_PATH} ]; then

--- a/libopflex/engine/include/opflex/engine/Processor.h
+++ b/libopflex/engine/include/opflex/engine/Processor.h
@@ -272,10 +272,13 @@ public:
      * @param model the model for initializing startupdb
      * @param duration the amount of time in ms from new
      *  connection to continue using startupdb
+     * @param enabled if the feature is enabled
+     * @param resolve_after_connection resolve after leaf connection
      */
     void setStartupPolicy(boost::optional<std::string>& file,
                           const modb::ModelMetadata& model,
                           uint64_t& duration,
+                          bool& enabled,
                           bool& resolve_after_connection);
     /**
      * Enable/Disable reporting of observable changes to registered observers
@@ -591,6 +594,11 @@ private:
      * new connection timestamp in msecs
      */
     volatile int64_t newConnectiontime = 0;
+
+   /**
+    * is startup policy enabled
+    */
+    volatile bool startupPolicyEnabled = false;
 
     /**
      * local resolves only after a new connection till startupPolicyDuration

--- a/libopflex/include/opflex/ofcore/OFFramework.h
+++ b/libopflex/include/opflex/ofcore/OFFramework.h
@@ -765,11 +765,13 @@ public:
      * @param file startup policy file name or boost::none
      * @param model the model to use for startupdb
      * @param duration in ms how long from new connection to use startupdb
+     * @pararm enabled if the startup policy is enabled
      * @param resolve_after_connection delay local resolves till connection
      */
     void setStartupPolicy(boost::optional<std::string>& file,
                           const modb::ModelMetadata& model,
                           uint64_t& duration,
+                          bool& enabled,
                           bool& resolve_after_connection);
 
     /**

--- a/libopflex/ofcore/OFFramework.cpp
+++ b/libopflex/ofcore/OFFramework.cpp
@@ -130,9 +130,10 @@ bool OFFramework::waitForPendingItems(uint32_t& wait) {
 void OFFramework::setStartupPolicy(boost::optional<std::string>& file,
                                    const modb::ModelMetadata& model,
                                    uint64_t& duration,
+                                   bool& enabled,
                                    bool& resolve_after_connection) {
-    pimpl->processor.setStartupPolicy(file, model,
-                                      duration, resolve_after_connection);
+    pimpl->processor.setStartupPolicy(file, model, duration,
+                                      enabled, resolve_after_connection);
 }
 
 void OFFramework::start() {


### PR DESCRIPTION
    "opflex": {
       "startup": {
            "enabled": "true",

with default being false. If false none of the startup related code will be executed.

Also create a startup subdir ${VARDIR}/lib/opflex-agent-ovs/startup

Signed-off-by: Madhu Challa <challa@gmail.com>
(cherry picked from commit d66818687f2056eed9ac05c49d0210e867c2a24c)