### PR TITLE
Make inspect timeout configurable

### DIFF
--- a/libopflex/engine/InspectorClientConn.cpp
+++ b/libopflex/engine/InspectorClientConn.cpp
@@ -25,9 +25,11 @@ namespace internal {
 using yajr::Peer;
 
 InspectorClientConn::InspectorClientConn(HandlerFactory& handlerFactory,
-                                         const std::string& name_)
+                                         const std::string& name_,
+                                         long timeout)
     : OpflexConnection(handlerFactory), name(name_), peer(NULL) {
     client_loop = {};
+    query_timeout = timeout;
     timer = {};
 }
 
@@ -41,7 +43,7 @@ void InspectorClientConn::connect() {
 
     timer.data = this;
     uv_timer_init(&client_loop, &timer);
-    uv_timer_start(&timer, on_timer, 5000, 5000);
+    uv_timer_start(&timer, on_timer, query_timeout, query_timeout);
 
     peer = yajr::Peer::create(name,
                               on_state_change,

--- a/libopflex/engine/InspectorClientImpl.cpp
+++ b/libopflex/engine/InspectorClientImpl.cpp
@@ -27,8 +27,9 @@ namespace ofcore {
 
 InspectorClient*
 InspectorClient::newInstance(const std::string& name,
-                             const modb::ModelMetadata& model) {
-    return new engine::InspectorClientImpl(name, model);
+                             const modb::ModelMetadata& model,
+                             long timeout) {
+    return new engine::InspectorClientImpl(name, model, timeout);
 }
 
 }
@@ -50,8 +51,9 @@ using internal::OpflexConnection;
 using internal::OpflexMessage;
 
 InspectorClientImpl::InspectorClientImpl(const std::string& name_,
-                                         const modb::ModelMetadata& model)
-    : conn(*this, name_), db(threadManager),
+                                         const modb::ModelMetadata& model,
+                                         long timeout)
+    : conn(*this, name_, timeout), db(threadManager),
       serializer(&db, this), pendingRequests(0),
       followRefs(false), recursive(false), unresolved(false),
       excludeObservables(false) {

--- a/libopflex/engine/include/opflex/engine/InspectorClientImpl.h
+++ b/libopflex/engine/include/opflex/engine/InspectorClientImpl.h
@@ -42,9 +42,11 @@ public:
      *
      * @param name the unix socket name
      * @param model the model metadata object
+     * @param timeout the time to wait for query completion
      */
     InspectorClientImpl(const std::string& name,
-                        const modb::ModelMetadata& model);
+                        const modb::ModelMetadata& model,
+                        long timeout);
 
     /**
      * Destroy the inspector client

--- a/libopflex/engine/include/opflex/engine/internal/InspectorClientConn.h
+++ b/libopflex/engine/include/opflex/engine/internal/InspectorClientConn.h
@@ -35,9 +35,11 @@ public:
      * @param handlerFactory a factory that can allocate a handler for
      * the connection
      * @param name A path name for the unix socket
+     * @param timeout Time to wait for query completion
      */
     InspectorClientConn(HandlerFactory& handlerFactory,
-                        const std::string& name);
+                        const std::string& name,
+                        long timeout);
     virtual ~InspectorClientConn();
 
     // ****************
@@ -55,6 +57,7 @@ public:
 
 private:
     const std::string& name;
+    long query_timeout;
 
     yajr::Peer* peer;
 

--- a/libopflex/include/opflex/ofcore/InspectorClient.h
+++ b/libopflex/include/opflex/ofcore/InspectorClient.h
@@ -53,9 +53,11 @@ public:
      *
      * @param name A path name for the unix socket
      * @param model the model metadata object
+     * @param timeout time to wait for query completion
      */
     static InspectorClient* newInstance(const std::string& name,
-                                        const modb::ModelMetadata& model);
+                                        const modb::ModelMetadata& model,
+                                        long timeout);
 
     /**
      * Follow references for retrieved objects

--- a/libopflex/ofcore/test/Inspector_test.cpp
+++ b/libopflex/ofcore/test/Inspector_test.cpp
@@ -42,7 +42,7 @@ static const string SOCK_NAME("/tmp/inspector_test.sock");
 class InspectorFixture : public BaseFixture {
 public:
     InspectorFixture()
-        : BaseFixture(), inspector(&db), client(SOCK_NAME, md) {
+        : BaseFixture(), inspector(&db), client(SOCK_NAME, md, 5000) {
         inspector.setSocketName(SOCK_NAME);
         inspector.start();
     }


### PR DESCRIPTION
The gbp_inspect utility currently uses a fixed timeout of 5 seconds for queries. This patch adds a parameter that allows users to set a different timeout for the query. The -i argument is used to pass the timeout value in milliseconds.

(cherry picked from commit e0197fb9697d275b5ff24b1741a9108bd3d37472)