### PR TITLE
disable startuppol on error, fix switch sync delay

### DIFF
--- a/agent-ovs/lib/include/opflexagent/Agent.h
+++ b/agent-ovs/lib/include/opflexagent/Agent.h
@@ -299,6 +299,12 @@ public:
     uint32_t getSwitchSyncDelay() { return switch_sync_delay; }
 
     /**
+     * Set Switch Sync delay value, used from test code
+     * @param delay in seconds
+     */
+    void setSwitchSyncDelay(uint32_t delay) { switch_sync_delay = delay; }
+
+    /**
      * Get if switch sync set to dynamic
      */
     uint32_t getSwitchSyncDynamic() { return switch_sync_dynamic; }

--- a/agent-ovs/ovs/SwitchManager.cpp
+++ b/agent-ovs/ovs/SwitchManager.cpp
@@ -102,6 +102,10 @@ void SwitchManager::enableSync() {
             << "[" << (connection ? connection->getSwitchName() : "(none)")
             << "] Switch state synchronization enabled";
 
+        // This is not reliable when read from the constructor.
+        // The renderer policy can be read before the policy
+        // file that contains this value. so read it again.
+        connectDelayMs = agent.getSwitchSyncDelay()*1000;
         // Set a deadline for syncing of switch state. If we get
         // connected to the switch before that, then we'll wait till
         // the deadline expires before attempting to sync.
@@ -122,10 +126,6 @@ void SwitchManager::enableSync() {
 
 void SwitchManager::registerStateHandler(SwitchStateHandler* handler) {
     stateHandler = handler;
-}
-
-void SwitchManager::setSyncDelayOnConnect(long delay) {
-    connectDelayMs = delay;
 }
 
 void SwitchManager::Connected(SwitchConnection *swConn) {

--- a/agent-ovs/ovs/include/SwitchManager.h
+++ b/agent-ovs/ovs/include/SwitchManager.h
@@ -90,12 +90,6 @@ public:
      */
     void registerStateHandler(SwitchStateHandler* handler);
 
-    /**
-     * Set the delay after connection before syncing starts
-     * @param delay the delay in milliseconds
-     */
-    void setSyncDelayOnConnect(long delay);
-
     /* Interface: OnConnectListener */
     virtual void Connected(SwitchConnection *swConn);
 

--- a/agent-ovs/ovs/test/include/FlowManagerFixture.h
+++ b/agent-ovs/ovs/test/include/FlowManagerFixture.h
@@ -31,7 +31,7 @@ public:
     FlowManagerFixture(opflex_elem_t mode = opflex_elem_t::INVALID_MODE)
         : ModbFixture(mode), ctZoneManager(idGen),
         switchManager(agent, exec, reader, portmapper) {
-        switchManager.setSyncDelayOnConnect(0);
+        agent.setSwitchSyncDelay(0);
         ctZoneManager.setCtZoneRange(1, 65534);
         ctZoneManager.init("conntrack");
     }

--- a/libopflex/engine/Processor.cpp
+++ b/libopflex/engine/Processor.cpp
@@ -745,6 +745,10 @@ void Processor::start(ofcore::OFConstants::OpflexElementMode agent_mode) {
     if (startupPolicyEnabled) {
         size_t objs = readStartupPolicy();
         LOG(DEBUG) << "Read " << objs << " objects from startup policy";
+        if (objs == 0) {
+           LOG(INFO) << "Disabling startup policy due to read failure";
+           startupPolicyEnabled = false;
+        }
     }
 
     client = &store->getStoreClient("_SYSTEM_");


### PR DESCRIPTION
As an optimization turn off startup policy if the read fails for any reason or if 0 objects are read

Also switch sync delay may not be reliable if the config file that enables it is read after renderer config. Fix it by reading the value before using it (set in constructor)