### PR TITLE
Skip reset.conf if we processed PlatformConfig del

### DIFF
--- a/agent-ovs/cmd/opflex_agent.cpp
+++ b/agent-ovs/cmd/opflex_agent.cpp
@@ -121,9 +121,11 @@ public:
                         break;
                     }
                     if (!stopped && need_reset) {
-                        LOG(INFO) << "Disconnect from existing peers and " <<
-                            "fallback to configured list because of configuration update";
-                        framework.resetAllUnconfiguredPeers();
+                        if (agent.shouldReset()) {
+                            LOG(WARNING) << "Disconnect from existing peers and " <<
+                                "fallback to configured list because of configuration update";
+                            framework.resetAllUnconfiguredPeers();
+                        }
                         need_reset = false;
                         continue;
                     }

--- a/agent-ovs/lib/Agent.cpp
+++ b/agent-ovs/lib/Agent.cpp
@@ -189,6 +189,7 @@ void Agent::setProperties(const boost::property_tree::ptree& properties) {
     static const std::string OPFLEX_MULTICAST_CACHE_TIMEOUT("opflex.timers.mcast-cache-timeout");
     static const std::string OPFLEX_SWITCH_SYNC_DELAY("opflex.timers.switch-sync-delay");
     static const std::string OPFLEX_SWITCH_SYNC_DYNAMIC("opflex.timers.switch-sync-dynamic");
+    static const std::string OPFLEX_RESET_WAIT_DELAY("opflex.timers.reset-wait-delay");
     static const std::string DISABLED_FEATURES("feature.disabled");
     static const std::string BEHAVIOR_L34FLOWS_WITHOUT_SUBNET("behavior.l34flows-without-subnet");
     static const std::string OPFLEX_ASYC_JSON("opflex.asyncjson.enabled");
@@ -414,6 +415,14 @@ void Agent::setProperties(const boost::property_tree::ptree& properties) {
         switch_sync_dynamic = switchSyncDynamicOpt.get();
         LOG(INFO) << "Switch Sync Dynamic set to " << switch_sync_dynamic << " seconds";
     }
+
+    optional<uint32_t> resetWaitDelayOpt =
+        properties.get_optional<uint32_t>(OPFLEX_RESET_WAIT_DELAY);
+    if (resetWaitDelayOpt) {
+        reset_wait_delay = resetWaitDelayOpt.get();
+        LOG(INFO) << "Reset Wait delay set to " << reset_wait_delay << " seconds";
+    }
+    updateResetTime();
 
     optional<const ptree&> rendererPlugins =
         properties.get_child_optional(PLUGINS_RENDERER);

--- a/agent-ovs/lib/EndpointManager.cpp
+++ b/agent-ovs/lib/EndpointManager.cpp
@@ -1595,6 +1595,7 @@ void EndpointManager::configUpdated(const URI& uri) {
 
     if (!config) {
         LOG(WARNING) << "Platform config has been deleted. Disconnect from existing peers and fallback to configured list";
+        agent.updateResetTime();
         framework.resetAllUnconfiguredPeers();
     }
 }

--- a/agent-ovs/opflex-agent-ovs.conf.in
+++ b/agent-ovs/opflex-agent-ovs.conf.in
@@ -145,6 +145,12 @@
            // Max retries will be 5 so as to not wait
            // forever
            // "switch-sync-dynamic": 0
+           //
+           // skip reset.conf processing if platformConfig
+           // delete was processed within this interval.
+           // This is to avoid duplicate reset processing
+           // for the same event
+           // "reset-wait-delay": 5
        },
        // Statistics. Counters for various artifacts.
        // mode: can be either


### PR DESCRIPTION
There are 2 scenarios
1. reset.conf comes immediately after PlatformConfig delete We will skip processing it if within a certain time, 5 secs default This is so we do not trigger a disconnect twice for the same event, one via PlatformConfig delete and other via reset.conf

2. PlatformConfig delete comes after reset.conf This should not be an issue since we will not be able to get the PlatformConfig event once the connection has been reset via reset.conf processing. There is a small race here and in that worst case we may process the event twice but the window is significantly reduced.