### PR TITLE
Add LocalSecGrpClassifierCounter

### DIFF
--- a/agent-ovs/Makefile.am
+++ b/agent-ovs/Makefile.am
@@ -521,6 +521,7 @@ if RENDERER_OVS
 	ovs/test/IntFlowManager_test.cpp \
 	ovs/test/AccessFlowManager_test.cpp \
     ovs/test/AccessFlowManager_LocalSG_test.cpp \
+    ovs/test/SecGrpStatsManager_LocalSG_test.cpp \
 	ovs/test/PacketInHandler_test.cpp \
 	ovs/test/AdvertManager_test.cpp \
 	ovs/test/PortMapper_test.cpp \

--- a/agent-ovs/lib/include/opflexagent/test/ModbFixture.h
+++ b/agent-ovs/lib/include/opflexagent/test/ModbFixture.h
@@ -93,6 +93,7 @@ public:
     std::shared_ptr<modelgbp::gbpe::LocalL24Classifier> local_classifier0;
     std::shared_ptr<modelgbp::gbpe::LocalL24Classifier> local_classifier1;
     std::shared_ptr<modelgbp::gbpe::LocalL24Classifier> local_classifier2;
+    std::shared_ptr<modelgbp::gbpe::LocalL24Classifier> local_classifier3;
     std::shared_ptr<modelgbp::gbpe::LocalL24Classifier> local_classifier5;
     std::shared_ptr<modelgbp::gbpe::LocalL24Classifier> local_classifier6;
     std::shared_ptr<modelgbp::gbpe::LocalL24Classifier> local_classifier7;
@@ -314,6 +315,12 @@ protected:
         /* allow ARP from prov->cons */
         local_classifier2 = space->addGbpeLocalL24Classifier("classifier2");
         local_classifier2->setEtherT(l2::EtherTypeEnumT::CONST_ARP);
+
+        /* classifiers with port ranges */
+        local_classifier3 = space->addGbpeLocalL24Classifier("classifier3");
+        local_classifier3->setOrder(10)
+            .setEtherT(l2::EtherTypeEnumT::CONST_IPV4).setProt(6 /* TCP */)
+            .setDFromPort(80).setDToPort(85);
 
         /* allow bidirectional FCoE */
         local_classifier5 = space->addGbpeLocalL24Classifier("classifier5");

--- a/agent-ovs/ovs/PolicyStatsManager.cpp
+++ b/agent-ovs/ovs/PolicyStatsManager.cpp
@@ -78,6 +78,7 @@ void PolicyStatsManager::start(bool register_listener,
     }
     if(register_listener) {
         L24Classifier::registerListener(agent->getFramework(),this);
+        LocalL24Classifier::registerListener(agent->getFramework(),this);
     }
 }
 

--- a/agent-ovs/ovs/include/SecGrpStatsManager.h
+++ b/agent-ovs/ovs/include/SecGrpStatsManager.h
@@ -85,6 +85,7 @@ public:
 private:
     flowCounterState_t secGrpInState;
     flowCounterState_t secGrpOutState;
+    Agent *agent;
 };
 
 } /* namespace opflexagent */

--- a/agent-ovs/ovs/test/ContractStatsManager_test.cpp
+++ b/agent-ovs/ovs/test/ContractStatsManager_test.cpp
@@ -258,7 +258,7 @@ BOOST_FIXTURE_TEST_CASE(testFlowMatchStats, ContractStatsManagerFixture) {
     contractStatsManager.Handle(&integrationPortConn,
                                 OFPTYPE_FLOW_STATS_REPLY, NULL);
 
-    testOneFlow<MockContractStatsManager>(integrationPortConn,classifier3,
+    testOneFlow<MockContractStatsManager,L24Classifier>(integrationPortConn,classifier3,
                 IntFlowManager::POL_TABLE_ID,
                 1,
                 false,
@@ -314,7 +314,7 @@ BOOST_FIXTURE_TEST_CASE(testFlowRemoved, ContractStatsManagerFixture) {
 
     // Add flows in switchManager
     FlowEntryList entryList;
-    writeClassifierFlows(entryList,
+    writeClassifierFlows<L24Classifier>(entryList,
                          IntFlowManager::POL_TABLE_ID,
                          1,
                          classifier3,
@@ -353,7 +353,7 @@ BOOST_FIXTURE_TEST_CASE(testFlowRemoved, ContractStatsManagerFixture) {
     // calculate expected packet count and byte count
     // that we should have in Genie object
 
-    verifyFlowStats(classifier3,
+    verifyFlowStats<L24Classifier>(classifier3,
                     LAST_PACKET_COUNT,
                     LAST_PACKET_COUNT * PACKET_SIZE,
                     false,
@@ -371,7 +371,7 @@ BOOST_FIXTURE_TEST_CASE(testCircularBuffer, ContractStatsManagerFixture) {
     contractStatsManager.start();
     LOG(DEBUG) << "### Contract circbuffer Start";
     // Add flows in switchManager
-    testCircBuffer<MockContractStatsManager>(intPortConn,classifier3,
+    testCircBuffer<MockContractStatsManager,L24Classifier>(intPortConn,classifier3,
                    IntFlowManager::POL_TABLE_ID,2,&contractStatsManager,
                    epg1,epg2,&policyManager);
     LOG(DEBUG) << "### Contract circbuffer End";
@@ -388,7 +388,7 @@ BOOST_FIXTURE_TEST_CASE(testContractDelete, ContractStatsManagerFixture) {
     contractStatsManager.Handle(&integrationPortConn,
                                 OFPTYPE_FLOW_STATS_REPLY, NULL);
 
-    testOneFlow<MockContractStatsManager>(integrationPortConn,
+    testOneFlow<MockContractStatsManager,L24Classifier>(integrationPortConn,
                 classifier3,
                 IntFlowManager::POL_TABLE_ID,
                 1,
@@ -423,7 +423,7 @@ BOOST_FIXTURE_TEST_CASE(testSEpgDelete, ContractStatsManagerFixture) {
     contractStatsManager.start();
     LOG(DEBUG) << "### Contract SEPG Delete Start";
 
-    testOneFlow<MockContractStatsManager>(integrationPortConn,
+    testOneFlow<MockContractStatsManager,L24Classifier>(integrationPortConn,
                 classifier3,
                 IntFlowManager::POL_TABLE_ID,
                 1,
@@ -457,7 +457,7 @@ BOOST_FIXTURE_TEST_CASE(testrDSEpgDelete, ContractStatsManagerFixture) {
     contractStatsManager.start();
     LOG(DEBUG) << "### Contract DSEPG Delete Start";
 
-    testOneFlow<MockContractStatsManager>(integrationPortConn,
+    testOneFlow<MockContractStatsManager,L24Classifier>(integrationPortConn,
                 classifier3,
                 IntFlowManager::POL_TABLE_ID,
                 1,

--- a/genie/MODEL/EXTENSIONS/GBP/extensions.mdl
+++ b/genie/MODEL/EXTENSIONS/GBP/extensions.mdl
@@ -577,6 +577,16 @@ module[gbpe]
         member[txbytes; type=scalar/UInt64]
     }
 
+    class[LocalSecGrpClassifierCounter;
+          super=gbpe/SecGrpClassifierCounter;
+          concrete]
+    {
+        contained
+        {
+            parent[class=observer/PolicyStatUniverse]
+        }
+    }
+
     class[RoutingDomainDropCounter;
           super=observer/Observable;
           concrete;


### PR DESCRIPTION
- added as an extension of SecGrpClassifierCounter
- added make checks as a copy of SecGrpStatsManager_test.cpp, replacing all the classifiers with Local, and convert the called functions to use template arguments.
- The make checks cover the prometheus tests
- this would also result in pushing the LocalSecGrpClassifierCounter to the leaf, should we decide to push the local secgrps to the leaf, we can strip the Local before sending it.