### PR TITLE
Reset all peers during vmotion interval

### DIFF
--- a/agent-ovs/lib/ExtraConfigManager.cpp
+++ b/agent-ovs/lib/ExtraConfigManager.cpp
@@ -123,6 +123,7 @@ void ExtraConfigManager::outOfBandConfigUpdated(const OutOfBandConfigSpec &outOf
     mutator.commit();
     shared_ptr<OutOfBandConfigSpec> oobSptr(new OutOfBandConfigSpec(outOfBandCfg.tunnelEpAdvInterval));
     notifyOutOfBandConfigListeners(oobSptr);
+    framework.setResetAllPeers(true);
 }
 
 void ExtraConfigManager::outOfBandConfigDeleted() {
@@ -138,6 +139,7 @@ void ExtraConfigManager::outOfBandConfigDeleted() {
     mutator.commit();
     shared_ptr<OutOfBandConfigSpec> oobSptr;
     notifyOutOfBandConfigListeners(oobSptr);
+    framework.setResetAllPeers(false);
 }
 
 void ExtraConfigManager::packetDropLogConfigUpdated(PacketDropLogConfig &dropCfg) {

--- a/libopflex/engine/OpflexPool.cpp
+++ b/libopflex/engine/OpflexPool.cpp
@@ -34,6 +34,7 @@ OpflexPool::OpflexPool(HandlerFactory& factory_,
                        util::ThreadManager& threadManager_)
     : factory(factory_), threadManager(threadManager_),
       active(false),
+      reset_all_peers(false),
       client_mode(OFConstants::OpflexElementMode::STITCHED_MODE),
       transport_state(OFConstants::OpflexTransportModeState::SEEKING_PROXIES),
       ipv4_proxy(0), ipv6_proxy(0),

--- a/libopflex/engine/include/opflex/engine/internal/OpflexClientConnection.h
+++ b/libopflex/engine/include/opflex/engine/internal/OpflexClientConnection.h
@@ -131,6 +131,7 @@ protected:
                                 yajr::StateChange::To stateChange,
                                 int error);
     void connectionFailure();
+    void resetAllUnconfiguredPeers();
 
 };
 

--- a/libopflex/engine/include/opflex/engine/internal/OpflexPool.h
+++ b/libopflex/engine/include/opflex/engine/internal/OpflexPool.h
@@ -379,6 +379,14 @@ public:
         return tunnelMac;
     }
 
+    void setResetAllPeers(bool value) {
+        reset_all_peers = value;
+    }
+
+    bool getResetAllPeers() {
+        return reset_all_peers;
+    }
+
     /**
      * Retrieve OpFlex client stats for each available peer
      *
@@ -422,6 +430,7 @@ private:
     conn_map_t connections;
     role_map_t roles;
     boost::atomic<bool> active;
+    boost::atomic<bool> reset_all_peers;
 
     opflex::ofcore::OFConstants::OpflexElementMode client_mode;
     opflex::ofcore::OFConstants::OpflexTransportModeState transport_state;

--- a/libopflex/include/opflex/ofcore/OFFramework.h
+++ b/libopflex/include/opflex/ofcore/OFFramework.h
@@ -794,6 +794,20 @@ public:
     void deleteMOs(opflex::modb::mointernal::StoreClient::notif_t& notifs);
 
     /**
+     * Enable or Disable reset_all_peers bool in OpflexPool
+     * when enabled any peer disconnect will result in all non configured peers
+     * to disconnect.
+     * @param value bool current intended reset behavior
+     */
+    void setResetAllPeers(bool value);
+
+    /**
+     * return current value of reset_all_peers bool in OpflexPool
+     * @return bool current intended reset behavior
+     */
+    bool getResetAllPeers();
+
+    /**
      * Start the framework.  This will start all the framework threads
      * and attempt to connect to configured OpFlex peers.
      */

--- a/libopflex/ofcore/OFFramework.cpp
+++ b/libopflex/ofcore/OFFramework.cpp
@@ -256,6 +256,16 @@ void OFFramework::getMacProxy(boost::asio::ip::address_v4 &macProxyAddress ) {
     macProxyAddress = pool.getMacProxy();
 }
 
+void OFFramework::setResetAllPeers(bool value) {
+    engine::internal::OpflexPool& pool = pimpl->processor.getPool();
+    pool.setResetAllPeers(value);
+}
+
+bool OFFramework::getResetAllPeers() {
+    engine::internal::OpflexPool& pool = pimpl->processor.getPool();
+    return pool.getResetAllPeers();
+}
+
 void MockOFFramework::setV4Proxy(const boost::asio::ip::address_v4& v4ProxyAddress ) {
     engine::internal::OpflexPool& pool = pimpl->processor.getPool();
     pool.setV4Proxy(v4ProxyAddress);


### PR DESCRIPTION
Use outOfBandConfigUpdated and outOfBandConfigDeleted to figure out interval and during this period if a disconnect happens we will reset both peers and fallback to configured list

This avoids issues where we miss the platformConfigDelete event during vmotion. This basically does the same thing as what the reset.conf fix would do in case we miss that event.