### PR TITLE
Fix incorrect conversion of prunefilter

### DIFF
--- a/agent-ovs/lib/FSPacketDropLogConfigSource.cpp
+++ b/agent-ovs/lib/FSPacketDropLogConfigSource.cpp
@@ -154,7 +154,6 @@ static int validatePrefix(int filter_idx, const std::string & arg,
         return -1;
     }
     if(!pfxLenArg.empty()) {
-        LOG(INFO) << "PrefixLen is set!";
         size_t *end = nullptr;
         uint8_t pfxLenVal;
         try {

--- a/agent-ovs/ovs/OVSRenderer.cpp
+++ b/agent-ovs/ovs/OVSRenderer.cpp
@@ -617,7 +617,8 @@ static void convertPruneFilter(std::shared_ptr<PacketDropLogPruneSpec> &sourceSp
     }
     if(sourceSpec->srcPfxLen) {
         std::stringstream strSrcPfxLen;
-        strSrcPfxLen << (uint8_t)sourceSpec->srcPfxLen.get();
+        strSrcPfxLen << (int)sourceSpec->srcPfxLen.get();
+        LOG(DEBUG) << "spfxLen " << strSrcPfxLen.str() << endl;
         filter->setField(TFLD_SPFX_LEN,strSrcPfxLen.str());
     }
     if(sourceSpec->dstIp) {
@@ -625,7 +626,8 @@ static void convertPruneFilter(std::shared_ptr<PacketDropLogPruneSpec> &sourceSp
     }
     if(sourceSpec->dstPfxLen) {
         std::stringstream strDstPfxLen;
-        strDstPfxLen << (uint8_t)sourceSpec->dstPfxLen.get();
+        strDstPfxLen << (int)sourceSpec->dstPfxLen.get();
+        LOG(DEBUG) << "dpfxLen " << strDstPfxLen.str() << endl;
         filter->setField(TFLD_DPFX_LEN,strDstPfxLen.str());
     }
     if(sourceSpec->srcMac) {


### PR DESCRIPTION
Although the value is limited to uint8.
Cast shouild be to int to convert correctly.