### PR TITLE
Updated github workflow syntax

### DIFF
--- a/.github/workflows/push-git-tag.yaml
+++ b/.github/workflows/push-git-tag.yaml
@@ -17,7 +17,7 @@ jobs:
           TRAVIS_API_TOKEN: ${{ secrets.TRAVIS_API_TOKEN }}
         with:
           script: |
-            const timeoutInterval = 120000 # msec
+            const timeoutInterval = 120000; //msec
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const tag = context.ref.replace('refs/tags/', '');


### PR DESCRIPTION
added missing semicolon and corrected comment syntax

(cherry picked from commit ecc2c4516434885f31bf8f31cb74c25007b1eb8f)