### PR TITLE
Change EP declare behavior.

### DIFF
--- a/agent-ovs/lib/Agent.cpp
+++ b/agent-ovs/lib/Agent.cpp
@@ -80,7 +80,8 @@ Agent::Agent(OFFramework& framework_, const LogParams& _logParams)
       behaviorL34FlowsWithoutSubnet(true),
       logParams(_logParams),
       startupPolicyEnabled(false),
-      localNetpolEnabled(false) {
+      localNetpolEnabled(false),
+      force_ep_undeclares(true) {
     std::random_device rng;
     std::mt19937 urng(rng());
     uuid = to_string(basic_random_generator<std::mt19937>(urng)());
@@ -200,6 +201,7 @@ void Agent::setProperties(const boost::property_tree::ptree& properties) {
     static const std::string OPFLEX_LOCAL_RESOLVE_AFTER_CONNECTION("opflex.startup.resolve-aft-conn");
     static const std::string OPFLEX_STARTUP_POLICY_DURATION("opflex.startup.policy-duration");
     static const std::string OPFLEX_ENABLE_LOCAL_NETPOL("opflex.enable-local-netpol");
+    static const std::string OPFLEX_FORCE_EP_UNDECLARES("opflex.force-ep-undeclares.enabled");
 
     // set feature flags to true
     clearFeatureFlags();
@@ -565,6 +567,14 @@ void Agent::setProperties(const boost::property_tree::ptree& properties) {
         LOG(INFO) << "Startup policy is enabled";
     }
 
+    /* Default true */
+    optional<bool> forceEpUndeclares =
+                properties.get_optional<bool>(OPFLEX_FORCE_EP_UNDECLARES);
+    if (forceEpUndeclares) {
+        if (forceEpUndeclares.get() == false)
+            force_ep_undeclares = false;
+    }
+
     optional<std::string> policyFile =
         properties.get_optional<std::string>(OPFLEX_POLICY_FILE);
     if (policyFile) {
@@ -656,6 +666,9 @@ void Agent::applyProperties() {
     framework.setStartupPolicy(opflexPolicyFile, modelgbp::getMetadata(),
                                startupPolicyDuration, startupPolicyEnabled,
                                localResolveAftConn);
+
+    LOG(INFO) << "Setting force_ep_undeclares to " << force_ep_undeclares;
+    framework.setForceEndpointUndeclares(force_ep_undeclares);
 }
 
 void Agent::start() {

--- a/agent-ovs/lib/include/opflexagent/Agent.h
+++ b/agent-ovs/lib/include/opflexagent/Agent.h
@@ -462,6 +462,8 @@ private:
     bool startupPolicyEnabled;
     /* Local Network Policy enable */
     bool localNetpolEnabled;
+    /* Force an EP undeclare on update resulting in redeclare */
+    bool force_ep_undeclares;
     boost::optional<std::string> opflexPolicyFile;
 };
 

--- a/libopflex/engine/include/opflex/engine/Processor.h
+++ b/libopflex/engine/include/opflex/engine/Processor.h
@@ -280,6 +280,13 @@ public:
                           uint64_t& duration,
                           bool& enabled,
                           bool& resolve_after_connection);
+
+    /**
+     * set force ep undeclares boolean
+     * @param enabled if we want to convert a redeclare to undeclare + declare
+     */
+    void setForceEndpointUndeclares(bool& enabled) { force_ep_undeclares = enabled; }
+
     /**
      * Enable/Disable reporting of observable changes to registered observers
      *
@@ -611,6 +618,11 @@ private:
      * policy to resolve Mos from startupdb.
      */
     uint64_t startupPolicyDuration;
+
+    /**
+     * If true convert EP redeclares to undeclare + declare
+     */
+    volatile bool force_ep_undeclares;
 
     /**
      * Processing thread

--- a/libopflex/include/opflex/ofcore/OFFramework.h
+++ b/libopflex/include/opflex/ofcore/OFFramework.h
@@ -775,6 +775,11 @@ public:
                           uint64_t& duration,
                           bool& enabled,
                           bool& resolve_after_connection);
+    /**
+     * set force ep undeclares boolean
+     * @param enabled if we want to convert a redeclare to undeclare + declare
+     */
+    void setForceEndpointUndeclares(bool& enabled);
 
     /**
      * update MODB from file

--- a/libopflex/ofcore/OFFramework.cpp
+++ b/libopflex/ofcore/OFFramework.cpp
@@ -136,6 +136,10 @@ void OFFramework::setStartupPolicy(boost::optional<std::string>& file,
                                       enabled, resolve_after_connection);
 }
 
+void OFFramework::setForceEndpointUndeclares(bool& enabled) {
+    pimpl->processor.setForceEndpointUndeclares(enabled);
+}
+
 void OFFramework::start() {
     LOG(DEBUG) << "Starting OpFlex Framework";
     pimpl->started = true;


### PR DESCRIPTION
When an existing EP is updated, instead of simply resending epdeclare, send a undeclare followed by declare.

The new behavior will be default unless disabled via flag.

Old (non default needs in opflex section)   "force-ep-undeclares": { "enabled" : "false" }

[2025-May-08 13:53:04.696491] [info] [lib/Agent.cpp:670:applyProperties] Setting force_ep_undeclares to 0

Update
[2025-May-08 13:53:34.708020] [debug] [Processor.cpp:433:declareObj] Declaring local endpoint /EprL3Universe/EprL3Ep/%2fPolicyUniverse%2fPolicySpace%2fcommon%2fGbpRoutingDomain%2frke-setup3-vrf%2f/10.2.0.204/ [2025-May-08 13:53:34.708752] [debug] [Processor.cpp:433:declareObj] Declaring local endpoint /EprL2Universe/EprL2Ep/%2fPolicyUniverse%2fPolicySpace%2frkesetup3%2fGbpBridgeDomain%2faci-containers-rkesetup3-pod-bd%2f/0a%3a58%3a0a%3a02%3a00%3acc/

Delete
[2025-May-08 13:53:47.748789] [debug] [Processor.cpp:631:processItem] Undeclaring /EprL2Universe/EprL2Ep/%2fPolicyUniverse%2fPolicySpace%2frkesetup3%2fGbpBridgeDomain%2faci-containers-rkesetup3-pod-bd%2f/0a%3a58%3a0a%3a02%3a00%3acc/ [2025-May-08 13:53:47.748989] [debug] [Processor.cpp:631:processItem] Undeclaring /EprL3Universe/EprL3Ep/%2fPolicyUniverse%2fPolicySpace%2fcommon%2fGbpRoutingDomain%2frke-setup3-vrf%2f/10.2.0.204/

Add
[2025-May-08 13:53:59.512911] [debug] [Processor.cpp:433:declareObj] Declaring local endpoint /EprL3Universe/EprL3Ep/%2fPolicyUniverse%2fPolicySpace%2fcommon%2fGbpRoutingDomain%2frke-setup3-vrf%2f/10.2.0.204/ [2025-May-08 13:53:59.513669] [debug] [Processor.cpp:433:declareObj] Declaring local endpoint /EprL2Universe/EprL2Ep/%2fPolicyUniverse%2fPolicySpace%2frkesetup3%2fGbpBridgeDomain%2faci-containers-rkesetup3-pod-bd%2f/0a%3a58%3a0a%3a02%3a00%3acc/

New (default)

[2025-May-08 13:57:01.248363] [info] [lib/Agent.cpp:670:applyProperties] Setting force_ep_undeclares to 1

Update
[2025-May-08 13:58:11.825316] [debug] [Processor.cpp:592:processItem] Undeclaring /EprL3Universe/EprL3Ep/%2fPolicyUniverse%2fPolicySpace%2fcommon%2fGbpRoutingDomain%2frke-setup3-vrf%2f/10.2.0.130/ [2025-May-08 13:58:11.825402] [debug] [Processor.cpp:433:declareObj] Declaring local endpoint /EprL3Universe/EprL3Ep/%2fPolicyUniverse%2fPolicySpace%2fcommon%2fGbpRoutingDomain%2frke-setup3-vrf%2f/10.2.0.130/ [2025-May-08 13:58:11.826056] [debug] [Processor.cpp:592:processItem] Undeclaring /EprL2Universe/EprL2Ep/%2fPolicyUniverse%2fPolicySpace%2frkesetup3%2fGbpBridgeDomain%2faci-containers-rkesetup3-pod-bd%2f/0a%3a58%3a0a%3a02%3a00%3a82/ [2025-May-08 13:58:11.826134] [debug] [Processor.cpp:433:declareObj] Declaring local endpoint /EprL2Universe/EprL2Ep/%2fPolicyUniverse%2fPolicySpace%2frkesetup3%2fGbpBridgeDomain%2faci-containers-rkesetup3-pod-bd%2f/0a%3a58%3a0a%3a02%3a00%3a82/

Delete
[2025-May-08 13:59:27.158017] [debug] [Processor.cpp:631:processItem] Undeclaring /EprL2Universe/EprL2Ep/%2fPolicyUniverse%2fPolicySpace%2frkesetup3%2fGbpBridgeDomain%2faci-containers-rkesetup3-pod-bd%2f/0a%3a58%3a0a%3a02%3a00%3a82/ [2025-May-08 13:59:27.158615] [debug] [Processor.cpp:631:processItem] Undeclaring /EprL3Universe/EprL3Ep/%2fPolicyUniverse%2fPolicySpace%2fcommon%2fGbpRoutingDomain%2frke-setup3-vrf%2f/10.2.0.130/

Add
[2025-May-08 13:59:37.922854] [debug] [Processor.cpp:433:declareObj] Declaring local endpoint /EprL3Universe/EprL3Ep/%2fPolicyUniverse%2fPolicySpace%2fcommon%2fGbpRoutingDomain%2frke-setup3-vrf%2f/10.2.0.130/ [2025-May-08 13:59:37.923454] [debug] [Processor.cpp:433:declareObj] Declaring local endpoint /EprL2Universe/EprL2Ep/%2fPolicyUniverse%2fPolicySpace%2frkesetup3%2fGbpBridgeDomain%2faci-containers-rkesetup3-pod-bd%2f/0a%3a58%3a0a%3a02%3a00%3a82/