### PR TITLE
Excludes rpm* and python3-rpm pkgs from yum update

### DIFF
--- a/docker/travis/Dockerfile-opflex
+++ b/docker/travis/Dockerfile-opflex
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 RUN microdnf install -y yum yum-utils
-RUN yum update --exclude=openssl* -y --nogpgcheck --disablerepo=* --repofrompath=centos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os  --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os && rm -rf /var/cache/yum
+RUN yum update --exclude=openssl*,rpm*,python3-rpm -y --nogpgcheck --disablerepo=* --repofrompath=centos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os  --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os && rm -rf /var/cache/yum
 RUN yum install -y --nogpgcheck --disablerepo=* --repofrompath=centos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os \
   libstdc++ libuv \
   boost-program-options boost-system boost-date-time boost-filesystem \


### PR DESCRIPTION
while building opflex container image to avoid
openssl version dependency conflict