### PR TITLE
Handle OpenSSL FIPS provider package conflict

### DIFF
--- a/docker/travis/Dockerfile-opflex
+++ b/docker/travis/Dockerfile-opflex
@@ -1,4 +1,5 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+RUN rpm -e --nodeps openssl-fips-provider-so 2>/dev/null || true
 RUN microdnf install -y yum yum-utils
 RUN yum update -y --nogpgcheck --disablerepo=* --repofrompath=centos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os  --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os && rm -rf /var/cache/yum
 RUN yum install -y --nogpgcheck --disablerepo=* --repofrompath=centos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os \

--- a/docker/travis/Dockerfile-opflex-build-base
+++ b/docker/travis/Dockerfile-opflex-build-base
@@ -1,6 +1,7 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 ENV ROOT=/usr/local
 ARG make_args=-j1
+RUN rpm -e --nodeps openssl-fips-provider-so 2>/dev/null || true
 RUN microdnf install -y yum yum-utils \
  && yum-config-manager --add-repo=https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os \
  && yum-config-manager --add-repo=https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os \

--- a/docker/travis/Dockerfile-opflexserver
+++ b/docker/travis/Dockerfile-opflexserver
@@ -1,4 +1,5 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+RUN rpm -e --nodeps openssl-fips-provider-so 2>/dev/null || true
 RUN microdnf install -y yum yum-utils \
  && yum-config-manager --add-repo=https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os \
  && yum-config-manager --add-repo=https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os \


### PR DESCRIPTION
Newer `openssl-libs` packages bundle the FIPS provider, which was previously a separate `openssl-fips-provider-so` package. This causes a file conflict during upgrades.

Work around this by removing the old FIPS provider package before upgrading to the new `openssl-libs`.