### PR TITLE
Add TCP connection watchdog timer

### DIFF
--- a/agent-ovs/lib/Agent.cpp
+++ b/agent-ovs/lib/Agent.cpp
@@ -191,6 +191,7 @@ void Agent::setProperties(const boost::property_tree::ptree& properties) {
     static const std::string OPFLEX_SWITCH_SYNC_DELAY("opflex.timers.switch-sync-delay");
     static const std::string OPFLEX_SWITCH_SYNC_DYNAMIC("opflex.timers.switch-sync-dynamic");
     static const std::string OPFLEX_RESET_WAIT_DELAY("opflex.timers.reset-wait-delay");
+    static const std::string OPFLEX_CONNECT_TIMEOUT("opflex.timers.connect-timeout");
     static const std::string DISABLED_FEATURES("feature.disabled");
     static const std::string BEHAVIOR_L34FLOWS_WITHOUT_SUBNET("behavior.l34flows-without-subnet");
     static const std::string OPFLEX_ASYC_JSON("opflex.asyncjson.enabled");
@@ -516,6 +517,12 @@ void Agent::setProperties(const boost::property_tree::ptree& properties) {
         LOG(INFO) << "policy retry delay timer set to " << policy_retry_delay_timer << " secs";
     }
 
+    optional<uint32_t> connectTimeoutOpt = properties.get_optional<uint32_t>(OPFLEX_CONNECT_TIMEOUT);
+    if (connectTimeoutOpt) {
+        connectTimeout = connectTimeoutOpt.get();
+        LOG(INFO) << "connect watchedog timer set to " << connectTimeout << " secs";
+    }
+
     optional<uint32_t> handshakeOpt = properties.get_optional<uint32_t>(OPFLEX_HANDSHAKE);
     if (handshakeOpt) {
         peerHandshakeTimeout = handshakeOpt.get();
@@ -654,6 +661,7 @@ void Agent::applyProperties() {
     framework.setPolicyRetryDelayTimerDuration(policy_retry_delay_timer*1000);
     framework.setHandshakeTimeout(peerHandshakeTimeout);
     framework.setKeepaliveTimeout(keepaliveTimeout);
+    framework.setConnectTimeout(connectTimeout);
     framework.setStartupPolicy(opflexPolicyFile, modelgbp::getMetadata(),
                                startupPolicyDuration, startupPolicyEnabled,
                                localResolveAftConn);

--- a/agent-ovs/lib/include/opflexagent/Agent.h
+++ b/agent-ovs/lib/include/opflexagent/Agent.h
@@ -375,6 +375,8 @@ private:
     uint32_t peerHandshakeTimeout = 45000;
     /* keepalive timeout */
     uint32_t keepaliveTimeout = 120000;
+    /* connect timeout */
+    uint32_t connectTimeout = 10; /* seconds */
     /* How long to wait before timing out old multicast cache */
     uint32_t multicast_cache_timeout = 300; /* seconds */
     /* How long to wait from platform config to switch Sync */

--- a/libopflex/engine/OpflexClientConnection.cpp
+++ b/libopflex/engine/OpflexClientConnection.cpp
@@ -85,7 +85,8 @@ void OpflexClientConnection::connect() {
     peer = yajr::Peer::create(hostname,
                               std::to_string(port),
                               on_state_change,
-                              this, loop_selector);
+                              this, loop_selector,
+                              true, getConnectTimeout());
 }
 
 void OpflexClientConnection::disconnect() {

--- a/libopflex/engine/OpflexPEHandler.cpp
+++ b/libopflex/engine/OpflexPEHandler.cpp
@@ -126,6 +126,7 @@ OpflexPEHandler::OpflexPEHandler(OpflexConnection* conn, Processor* processor_)
     : OpflexHandler(conn), processor(processor_) {
     conn->setHandshakeTimeout(processor_->getHandshakeTimeout());
     conn->setKeepaliveTimeout(processor_->getKeepaliveTimeout());
+    conn->setConnectTimeout(processor_->getConnectTimerTimeout());
 }
 
 void OpflexPEHandler::connected() {

--- a/libopflex/engine/include/opflex/engine/Processor.h
+++ b/libopflex/engine/include/opflex/engine/Processor.h
@@ -221,11 +221,25 @@ public:
     void setKeepaliveTimeout(const uint32_t timeout) {
         keepaliveTimeout = timeout;
     }
-\
+
     /**
      * Set the prr timer duration in secs
      */
     uint64_t getPrrTimerDuration() { return prrTimerDuration; }
+
+    /**
+     * Get the connect watchdog timeout
+     */
+    const uint32_t getConnectTimerTimeout() const {
+        return connectTimerTimeout;
+    }
+
+    /**
+     * Set the connect watchdog timeout
+     */
+    void setConnectTimeout(const uint32_t timeout) {
+        connectTimerTimeout = timeout;
+    }
 
     // See HandlerFactory::newHandler
     virtual
@@ -591,6 +605,7 @@ private:
 
     uint32_t peerHandshakeTimeout = 45000;
     uint32_t keepaliveTimeout = 120000;
+    uint32_t connectTimerTimeout = 10;
 
     /**
      *  policy refresh timer duration in msecs

--- a/libopflex/engine/include/opflex/engine/internal/OpflexConnection.h
+++ b/libopflex/engine/include/opflex/engine/internal/OpflexConnection.h
@@ -141,6 +141,23 @@ public:
         keepaliveTimeout = timeout;
     }
 
+    /**
+     * Get the connect watchdog timeout (in ms)
+     * @return timeout
+     */
+    uint32_t getConnectTimeout() const {
+        return connectTimeout;
+    }
+
+    /**
+     * Set the connect watchdog timeout (in ms)
+     * @param timeout timeout
+     */
+    void setConnectTimeout(uint32_t timeout) {
+        connectTimeout = timeout;
+    }
+
+
 protected:
     /**
      * The handler for the connection
@@ -150,6 +167,7 @@ protected:
 private:
     uint32_t handshakeTimeout;
     uint32_t keepaliveTimeout;
+    uint32_t connectTimeout;
 
     virtual void notifyReady();
     virtual void notifyFailed() {}

--- a/libopflex/include/opflex/ofcore/OFFramework.h
+++ b/libopflex/include/opflex/ofcore/OFFramework.h
@@ -755,6 +755,12 @@ public:
      */
     void setKeepaliveTimeout(const uint32_t timeout);
 
+    /**
+     * Set the connection watchdog timeout
+     * @param timeout keepalive timeout in milliseconds
+     */
+    void setConnectTimeout(const uint32_t timeout);
+
    /**
     * Wait for pending items
     * @param wait min wait time input and how long to wait as output

--- a/libopflex/include/opflex/yajr/yajr.hpp
+++ b/libopflex/include/opflex/yajr/yajr.hpp
@@ -123,8 +123,10 @@ class Peer {
                                                       /**< [in] callback data */
             UvLoopSelector          uvLoopSelector    = NULL,
                                      /**< [in] uv_loop selector for this Peer */
-            bool nullTermination = true
+            bool nullTermination = true,
                  /**< [in] add null byte to end of every rpc message sent out */
+            const uint32_t connectTimeout = 10
+                                /**< [in] value for connection watchdog timer */
     );
 
     /**

--- a/libopflex/ofcore/OFFramework.cpp
+++ b/libopflex/ofcore/OFFramework.cpp
@@ -123,6 +123,10 @@ void OFFramework::setKeepaliveTimeout(const uint32_t timeout) {
     pimpl->processor.setKeepaliveTimeout(timeout);
 }
 
+void OFFramework::setConnectTimeout(const uint32_t timeout) {
+    pimpl->processor.setConnectTimeout(timeout);
+}
+
 bool OFFramework::waitForPendingItems(uint32_t& wait) {
     return pimpl->processor.waitForPendingItems(wait);
 }


### PR DESCRIPTION
The agent has hit corner cases where it fails to complete the TCP connection process with the anycast address. This patch adds a watchdog timer to the Peer, ensuring that the Peer isn't left in an unconnected TCP state for more than the configured timeout value (default is value of 10 seconds, with a value of 0 to disable the feature).

(cherry picked from commit 968ebb7a21c27305291fe9378769a4ae3b6fc5b7)