### PR TITLE
Change connect timer default timeout

### DIFF
--- a/agent-ovs/lib/include/opflexagent/Agent.h
+++ b/agent-ovs/lib/include/opflexagent/Agent.h
@@ -376,7 +376,7 @@ private:
     /* keepalive timeout */
     uint32_t keepaliveTimeout = 120000;
     /* connect timeout */
-    uint32_t connectTimeout = 10; /* seconds */
+    uint32_t connectTimeout = 30; /* seconds */
     /* How long to wait before timing out old multicast cache */
     uint32_t multicast_cache_timeout = 300; /* seconds */
     /* How long to wait from platform config to switch Sync */

--- a/libopflex/engine/include/opflex/engine/Processor.h
+++ b/libopflex/engine/include/opflex/engine/Processor.h
@@ -605,7 +605,7 @@ private:
 
     uint32_t peerHandshakeTimeout = 45000;
     uint32_t keepaliveTimeout = 120000;
-    uint32_t connectTimerTimeout = 10;
+    uint32_t connectTimerTimeout = 30;
 
     /**
      *  policy refresh timer duration in msecs

--- a/libopflex/include/opflex/yajr/internal/comms.hpp
+++ b/libopflex/include/opflex/yajr/internal/comms.hpp
@@ -499,7 +499,7 @@ class CommunicationPeer : public Peer, virtual public ::yajr::Peer {
         void * data,
         ::yajr::Peer::UvLoopSelector uvLoopSelector = NULL,
         internal::Peer::PeerStatus status = kPS_UNINITIALIZED,
-        const uint32_t connectTimeout = 10)
+        const uint32_t connectTimeout = 30)
             :
                 ::yajr::Peer(),
                 internal::Peer(passive, uvLoopSelector, status),
@@ -886,7 +886,7 @@ class ActivePeer : public CommunicationPeer {
             ::yajr::Peer::StateChangeCb connectionHandler,
             void * data,
             ::yajr::Peer::UvLoopSelector uvLoopSelector = NULL,
-            const uint32_t connectTimeout = 10)
+            const uint32_t connectTimeout = 30)
         :
             CommunicationPeer(
                     false,
@@ -942,7 +942,7 @@ class ActiveTcpPeer : public ActivePeer {
             ::yajr::Peer::StateChangeCb connectionHandler,
             void * data,
             ::yajr::Peer::UvLoopSelector uvLoopSelector = NULL,
-            const uint32_t connectTimeout = 10)
+            const uint32_t connectTimeout = 30)
         :
             ActivePeer(
                     connectionHandler,

--- a/libopflex/include/opflex/yajr/yajr.hpp
+++ b/libopflex/include/opflex/yajr/yajr.hpp
@@ -125,7 +125,7 @@ class Peer {
                                      /**< [in] uv_loop selector for this Peer */
             bool nullTermination = true,
                  /**< [in] add null byte to end of every rpc message sent out */
-            const uint32_t connectTimeout = 10
+            const uint32_t connectTimeout = 30
                                 /**< [in] value for connection watchdog timer */
     );
 


### PR DESCRIPTION
The default timeout of the connect timer needed to be increased in order to support cases where the fabric is under load.

(cherry picked from commit 3b8688cceb3149073da345947e57c4f6a23bad25)