### PR TITLE
Add drop log file rotation for container deployments

### DIFF
--- a/docker/travis/Dockerfile-opflex
+++ b/docker/travis/Dockerfile-opflex
@@ -6,6 +6,7 @@ RUN yum install -y --nogpgcheck --disablerepo=* --repofrompath=centos,https://mi
   libstdc++ libuv \
   boost-program-options boost-system boost-date-time boost-filesystem \
   boost-iostreams libnetfilter_conntrack net-tools procps-ng ca-certificates \
+  logrotate \
   && yum install -y vim-minimal strace \
   && yum clean all
 # Required OpenShift Labels

--- a/docker/travis/launch-opflexagent.sh
+++ b/docker/travis/launch-opflexagent.sh
@@ -47,6 +47,30 @@ if [ -n "$OPFLEXAGENT_DROPLOG_FILE" ]; then
     DROP_LOG_FILE_PATH="$LOG_DIR/$OPFLEXAGENT_DROPLOG_FILE"
     touch "$DROP_LOG_FILE_PATH"
     EXTRA_ARGS="--drop_log=$DROP_LOG_FILE_PATH"
+
+    # Background drop log rotation to prevent unbounded file growth.
+    DROPLOG_MAXSIZE_MB=${OPFLEXAGENT_DROPLOG_MAXSIZE:-50}
+    DROPLOG_ROTATE_COUNT=${OPFLEXAGENT_DROPLOG_ROTATE:-5}
+    LOGROTATE_CONF="/tmp/droplog-logrotate.conf"
+    LOGROTATE_STATE="/tmp/droplog-logrotate.state"
+    cat > "${LOGROTATE_CONF}" <<LREOF
+${DROP_LOG_FILE_PATH} {
+    size ${DROPLOG_MAXSIZE_MB}M
+    rotate ${DROPLOG_ROTATE_COUNT}
+    copytruncate
+    compress
+    delaycompress
+    missingok
+    notifempty
+}
+LREOF
+    /bin/sh -c "
+        while true; do
+            sleep 43200
+            logrotate -s \"${LOGROTATE_STATE}\" \"${LOGROTATE_CONF}\"
+        done
+    " &
+
 elif [ "$OPFLEXAGENT_DROPLOG_SYSLOG" = "true" ]; then
     EXTRA_ARGS="--drop_log_syslog"
 fi


### PR DESCRIPTION
When drop log redirect to a custom file is enabled via the OPFLEXAGENT_DROPLOG_FILE environment variable, the file grows unbounded as there is no rotation mechanism.

This patch adds a background logrotate-based rotation loop in the container launch script. A logrotate configuration is generated at startup and invoked every 12 hours.

The logrotate package is added to the container image in the Dockerfile.

New optional environment variables:
- OPFLEXAGENT_DROPLOG_MAXSIZE: max file size in MB (default 50)
- OPFLEXAGENT_DROPLOG_ROTATE: number of rotated backups (default 5)