### PR TITLE
Remove model-local endpoints

### DIFF
--- a/agent-ovs/opflex-agent-ovs.conf.in
+++ b/agent-ovs/opflex-agent-ovs.conf.in
@@ -201,8 +201,7 @@
     "endpoint-sources": {
         // Filesystem path to monitor for endpoint information
         // Default: no endpoint sources
-        "filesystem": ["DEFAULT_FS_ENDPOINT_DIR"],
-        "model-local": ["default"]
+        "filesystem": ["DEFAULT_FS_ENDPOINT_DIR"]
     },
 
     // Service sources provide metadata about services that can


### PR DESCRIPTION
The model-local endpoints with the namespace of "default" creates an unresolved policy on the agent. Remove this from the default template, as this feature is no longer being used.