### PR TITLE
Fix crash in resetAllUnconfiguredPeers by deferring close to UV loop thread

### DIFF
--- a/libopflex/engine/OpflexPool.cpp
+++ b/libopflex/engine/OpflexPool.cpp
@@ -41,6 +41,7 @@ OpflexPool::OpflexPool(HandlerFactory& factory_,
     conn_async = {};
     cleanup_async = {};
     writeq_async = {};
+    reset_async = {};
 }
 
 OpflexPool::~OpflexPool() {
@@ -191,6 +192,7 @@ void OpflexPool::on_cleanup_async(uv_async_t* handle) {
 
     uv_close((uv_handle_t*)&pool->writeq_async, NULL);
     uv_close((uv_handle_t*)&pool->conn_async, NULL);
+    uv_close((uv_handle_t*)&pool->reset_async, NULL);
     uv_close((uv_handle_t*)handle, NULL);
     yajr::finiLoop(pool->client_loop);
 }
@@ -200,6 +202,23 @@ void OpflexPool::on_writeq_async(uv_async_t* handle) {
     const std::lock_guard<std::recursive_mutex> lock(pool->conn_mutex);
     for (conn_map_t::value_type& v : pool->connections) {
         v.second.conn->processWriteQueue();
+    }
+}
+
+void OpflexPool::on_reset_async(uv_async_t* handle) {
+    OpflexPool* pool = (OpflexPool*)handle->data;
+    if (!pool->active) return;
+    std::vector<peer_name_t> to_close;
+    {
+        const std::lock_guard<std::recursive_mutex> lock(pool->conn_mutex);
+        to_close.swap(pool->peers_to_close);
+    }
+    for (const peer_name_t& peer : to_close) {
+        const std::lock_guard<std::recursive_mutex> lock(pool->conn_mutex);
+        auto it = pool->connections.find(peer);
+        if (it != pool->connections.end() && it->second.conn) {
+            it->second.conn->close();
+        }
     }
 }
 
@@ -213,9 +232,11 @@ void OpflexPool::start() {
     conn_async.data = this;
     cleanup_async.data = this;
     writeq_async.data = this;
+    reset_async.data = this;
     uv_async_init(client_loop, &conn_async, on_conn_async);
     uv_async_init(client_loop, &cleanup_async, on_cleanup_async);
     uv_async_init(client_loop, &writeq_async, on_writeq_async);
+    uv_async_init(client_loop, &reset_async, on_reset_async);
 
     threadManager.startTask("connection_pool");
 }
@@ -349,13 +370,15 @@ void OpflexPool::doRemovePeer(const string& hostname, int port) {
 }
 
 void OpflexPool::resetAllUnconfiguredPeers() {
+    if (!active) return;
     const std::lock_guard<std::recursive_mutex> lock(conn_mutex);
-    conn_map_t conns(connections);
-    for (conn_map_t::value_type& v : conns) {
+    for (const conn_map_t::value_type& v : connections) {
         if (!isConfiguredPeer(v.first.first, v.first.second)) {
-            v.second.conn->close();
+            peers_to_close.push_back(v.first);
         }
     }
+    if (!peers_to_close.empty())
+        uv_async_send(&reset_async);
 }
 
 // must be called with conn_mutex held

--- a/libopflex/engine/include/opflex/engine/internal/OpflexPool.h
+++ b/libopflex/engine/include/opflex/engine/internal/OpflexPool.h
@@ -435,6 +435,10 @@ private:
     uv_async_t conn_async;
     uv_async_t cleanup_async;
     uv_async_t writeq_async;
+    uv_async_t reset_async;
+
+    /** Peers that need to be closed, dispatched to UV loop thread */
+    std::vector<peer_name_t> peers_to_close;
 
     std::list<ofcore::PeerStatusListener*> peerStatusListeners;
     ofcore::PeerStatusListener::Health curHealth;
@@ -452,6 +456,7 @@ private:
     static void on_conn_async(uv_async_t *handle);
     static void on_cleanup_async(uv_async_t *handle);
     static void on_writeq_async(uv_async_t *handle);
+    static void on_reset_async(uv_async_t *handle);
 
     void updatePeerStatus(const std::string& hostname, int port,
                           ofcore::PeerStatusListener::PeerStatus status);


### PR DESCRIPTION
resetAllUnconfiguredPeers() is called from the Processor/modb_notif thread (via EndpointManager::configUpdated on PlatformConfig deletion), but conn->close() manipulates libuv handles (timers, TCP streams) that belong to the UV loop thread. This cross-thread access causes:
- double free or corruption (out) during doAddPeer
- Assertion !(stream->flags & UV_HANDLE_CLOSING) in uv__stream_io

Fix: Instead of calling conn->close() directly, queue the peer names into peers_to_close and signal the UV loop via uv_async_send(). The new on_reset_async() callback runs on the UV loop thread where it is safe to close connections. This follows the same pattern used by the existing conn_async and cleanup_async handles.