### PR TITLE
[mmr-6.1.1] Get uplink interface in VLAN mode

### DIFF
--- a/agent-ovs/ovs/OVSRenderer.cpp
+++ b/agent-ovs/ovs/OVSRenderer.cpp
@@ -439,6 +439,7 @@ void OVSRenderer::setProperties(const ptree& properties) {
         encapType = IntFlowManager::ENCAP_VLAN;
         encapIface = vlan.get().get<std::string>(ENCAP_IFACE, "");
         uplinkNativeIface = vlan.get().get<std::string>(UPLINK_NATIVE_IFACE, "");
+        uplinkIface = vlan.get().get<std::string>(UPLINK_IFACE, "");
         count += 1;
     }
     if (vxlan) {


### PR DESCRIPTION
Commit 6a36c63 intended a fix for VLAN encap mode, by using the MAC address from the uplink interface as the MAC address for the OpFlex identity message. That patch missed population of this value on agent start.

This patch retrieves that interface value when in VLAN mode.

(cherry picked from commit 6c7fbb4f59e8d854feeb3b2a9e57054bebd2b300)