### PR TITLE
[mmr-6.1.1] Fix flow mod priority

### DIFF
--- a/agent-ovs/ovs/IntFlowManager.cpp
+++ b/agent-ovs/ovs/IntFlowManager.cpp
@@ -5451,7 +5451,7 @@ void IntFlowManager::updateEPGFlood(const URI& epgURI, uint32_t epgVnid,
              * irrespective of inventory mode for external svi BD
              */
             FlowBuilder ucast;
-            actionOutputToEPGTunnel(ucast.priority(2))
+            actionOutputToEPGTunnel(ucast.priority(1))
                 .build(grpDst);
         }
         mcast.action()

--- a/agent-ovs/ovs/test/IntFlowManager_test.cpp
+++ b/agent-ovs/ovs/test/IntFlowManager_test.cpp
@@ -4349,7 +4349,7 @@ void BaseIntFlowManagerFixture::initExpSviBD(const URI& sviBDURI,
          .reg(SEPG, fixedVnid).reg(FD, fdId).isEthDst(mmac).actions()
          .mdAct(opflexagent::flow::meta::out::FLOOD)
          .go(STAT).done());
-    ADDF(Bldr().table(BR).priority(2)
+    ADDF(Bldr().table(BR).priority(1)
          .actions().mdAct(opflexagent::flow::meta::out::TUNNEL)
          .go(STAT).done());
     if(uplink != OFPP_NONE) {


### PR DESCRIPTION
A priority for a flow mod added in commit
c26dc7abd5c10aa11961b572510d063f3fd8d6db causes input packets to be output to the input port, which are then dropped by the OVS pipeline. Other uses of the actionOutputToEPGTunnel method put the priority at 1, which would fix the above issue. This patch uses the same priority (1) as other calls to this method.

(cherry picked from commit 140725eb3b8ff7bba5d506f51ce9d76c7d6ddf80)