### PR TITLE
[mmr-6.1.1] Fix opflex image build: keep UBI OpenSSL/FIPS pristine, source only missing deps from CentOS Stream

### DIFF
--- a/docker/travis/Dockerfile-opflex
+++ b/docker/travis/Dockerfile-opflex
@@ -1,13 +1,21 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
-RUN rpm -e --nodeps openssl-fips-provider-so 2>/dev/null || true
+
 RUN microdnf install -y yum yum-utils
-RUN yum update -y --nogpgcheck --disablerepo=* --repofrompath=centos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os  --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os && rm -rf /var/cache/yum
-RUN yum install -y --nogpgcheck --disablerepo=* --repofrompath=centos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os \
-  libstdc++ libuv \
-  boost-program-options boost-system boost-date-time boost-filesystem \
-  boost-iostreams libnetfilter_conntrack net-tools procps-ng ca-certificates \
-  logrotate \
-  && yum install -y vim-minimal strace \
+
+RUN yum --nogpgcheck update -y \
+      --disablerepo=* --enablerepo=ubi-9-baseos-rpms --enablerepo=ubi-9-appstream-rpms
+
+RUN yum install -y --nogpgcheck \
+      --disablerepo=* --enablerepo=ubi-9-baseos-rpms --enablerepo=ubi-9-appstream-rpms \
+    libstdc++ libuv \
+    libnetfilter_conntrack net-tools procps-ng ca-certificates \
+    logrotate vim-minimal strace
+
+RUN yum install -y --nogpgcheck \
+      --disablerepo=* --enablerepo=ubi-9-baseos-rpms --enablerepo=ubi-9-appstream-rpms \
+      --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os \
+      --repofrompath=centos-baseos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os \
+    boost-program-options boost-system boost-date-time boost-filesystem boost-iostreams \
   && yum clean all
 # Required OpenShift Labels
 LABEL name="ACI CNI Opflex" \

--- a/docker/travis/Dockerfile-opflex-build-base
+++ b/docker/travis/Dockerfile-opflex-build-base
@@ -1,21 +1,27 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 ENV ROOT=/usr/local
 ARG make_args=-j1
-RUN rpm -e --nodeps openssl-fips-provider-so 2>/dev/null || true
-RUN microdnf install -y yum yum-utils \
- && yum-config-manager --add-repo=https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os \
- && yum-config-manager --add-repo=https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os \
- && yum-config-manager --add-repo=https://mirror.stream.centos.org/9-stream/CRB/x86_64/os \
- && yum-config-manager --add-repo=https://mirror.stream.centos.org/9-stream/AppStream/x86_64/debug/tree \
- && yum --nogpgcheck -y update
+
+RUN microdnf install -y yum yum-utils
+
+RUN yum --nogpgcheck update -y \
+      --disablerepo=* \
+      --enablerepo=ubi-9-baseos-rpms --enablerepo=ubi-9-appstream-rpms \
+      --enablerepo=ubi-9-codeready-builder-rpms
 RUN yum --nogpgcheck install -y \
+      --disablerepo=* \
+      --enablerepo=ubi-9-baseos-rpms --enablerepo=ubi-9-appstream-rpms \
+      --enablerepo=ubi-9-codeready-builder-rpms \
     libtool pkgconfig autoconf automake make cmake file python3-six \
-    git gcc gcc-c++ diffutils python3-devel \
-    wget which curl-devel procps zlib-devel vi boost-devel libnfnetlink-devel libmnl-devel \
-    libnetfilter_conntrack-devel libnftnl-devel
+    openssl-devel git gcc gcc-c++ diffutils python3-devel \
+    wget which curl-devel procps zlib-devel vi libmnl-devel
 RUN yum --nogpgcheck install -y \
-    openssl-devel \
-    && yum clean all
+      --disablerepo=* \
+      --repofrompath=centos-baseos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os \
+      --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os \
+      --repofrompath=centos-crb,https://mirror.stream.centos.org/9-stream/CRB/x86_64/os \
+    boost-devel libnfnetlink-devel libnetfilter_conntrack-devel libnftnl-devel \
+  && yum clean all
 RUN git clone -b libnftnl-1.1.7 https://git.netfilter.org/libnftnl \
   && cd libnftnl \
   && ./autogen.sh \


### PR DESCRIPTION

The build broke because CentOS Stream's openssl-fips-provider pins an exact Stream openssl-libs version, and a broad `yum update` against CentOS Stream tried to pull that FIPS provider in but could not downgrade UBI's newer openssl-libs to the pinned Stream version - an unsatisfiable version conflict.

Changes: drop the `rpm -e` of the FIPS provider and the broad Stream `yum update`; add a UBI-only `yum update`; install everything UBI provides from UBI and pull only the packages UBI lacks (boost, netfilter -devel) from CentOS Stream.

(cherry picked from commit 7d12c5b0121efe9cab35db204f601bb012bbd6b3)