### PR TITLE
[mmr-6.1.1] Fix opflex teardown crashes on host-agent restart

### DIFF
--- a/agent-ovs/ovs/IntFlowManager.cpp
+++ b/agent-ovs/ovs/IntFlowManager.cpp
@@ -234,6 +234,7 @@ void IntFlowManager::stop() {
     }
     if (multiCastIOThread) {
         LOG(DEBUG) << "Stopping multiCastIOThread";
+        multiCastIOService.stop();
         multiCastIOThread->join();
         multiCastIOThread.reset();
     }
@@ -6935,6 +6936,9 @@ void IntFlowManager::readOldMulticastGroups() {
     if (oldMcastEntries.empty()) return;
 
     /* Start a timer to clear the oldMcastEntries */
+    if (multiCastIOService.stopped()) {
+        multiCastIOService.reset();
+    }
     multiCastIOThread.reset(new std::thread([this]() {
         LOG(DEBUG) << "multiCastIOThread start with timeout "
                    << agent.getMulticastCacheTimeout() << " secs.";

--- a/libopflex/comms/CommunicationPeer.cpp
+++ b/libopflex/comms/CommunicationPeer.cpp
@@ -194,6 +194,12 @@ void CommunicationPeer::destroy(bool now) {
     destroying_ = true;
     stopConnectTimer();
     onDisconnect();
+
+    if (!uv_is_closing((uv_handle_t*)&connectTimer_)) {
+        // Keep the peer alive until libuv unlinks its embedded timer.
+        up();
+        uv_close((uv_handle_t*)&connectTimer_, on_close);
+    }
 }
 
 int CommunicationPeer::tcpInit() {


### PR DESCRIPTION
Stop the multicast timer service before joining its worker thread to avoid waiting for the multicast cache timer and tripping the shutdown watchdog.

Close connectTimer_ before deleting a communication peer so libuv cannot walk a freed timer handle.

This prevents exit 134 watchdog aborts and exit 139 use-after-free crashes.

(cherry picked from commit 77e98fdf86a96eb58f6c056dcca35c1ead88a65c)