### PR TITLE
[mmr-6.1.1] Avoid connect timer teardown hang for passive peers

### DIFF
--- a/libopflex/comms/CommunicationPeer.cpp
+++ b/libopflex/comms/CommunicationPeer.cpp
@@ -195,7 +195,8 @@ void CommunicationPeer::destroy(bool now) {
     stopConnectTimer();
     onDisconnect();
 
-    if (!uv_is_closing((uv_handle_t*)&connectTimer_)) {
+    if (connectTimeout_ > 0 &&
+            !uv_is_closing((uv_handle_t*)&connectTimer_)) {
         // Keep the peer alive until libuv unlinks its embedded timer.
         up();
         uv_close((uv_handle_t*)&connectTimer_, on_close);

--- a/libopflex/include/opflex/yajr/internal/comms.hpp
+++ b/libopflex/include/opflex/yajr/internal/comms.hpp
@@ -517,8 +517,10 @@ class CommunicationPeer : public Peer, virtual public ::yajr::Peer {
                 req_.data = this;
                 getHandle()->loop = uvLoopSelector_(getData());
                 getLoopData()->up();
-                uv_timer_init(getHandle()->loop, &connectTimer_);
-                connectTimer_.data = this;
+                if (connectTimeout_ > 0) {
+                    uv_timer_init(getHandle()->loop, &connectTimer_);
+                    connectTimer_.data = this;
+                }
             }
 
     /**
@@ -1059,7 +1061,8 @@ class PassivePeer : public CommunicationPeer {
                     connectionHandler,
                     data,
                     uvLoopSelector,
-                    kPS_RESOLVING)
+                    kPS_RESOLVING,
+                    0)
         {
             createFail_ = 0;
         }


### PR DESCRIPTION
Passive peers never use the TCP connection watchdog, but they still registered its libuv timer. Closing that unused timer during peer destruction could leave loop teardown waiting indefinitely.

Disable the watchdog for passive peers and initialize or close connectTimer_ only when a connection timeout is configured. Active peer watchdog behavior remains unchanged.

(cherry picked from commit 54c55f59623d00d7d6a265a44ea5601a20b5022a)